### PR TITLE
Define message structs for currently used metadata defs

### DIFF
--- a/edg_core/edgir/common_pb2.py
+++ b/edg_core/edgir/common_pb2.py
@@ -19,11 +19,37 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='common.proto',
   package='edg.common',
   syntax='proto3',
-  serialized_pb=_b('\n\x0c\x63ommon.proto\x12\nedg.common\"\xb0\x02\n\x08Metadata\x12$\n\x07unknown\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12\x0f\n\x05known\x18\x02 \x01(\tH\x00\x12/\n\x07members\x18\x65 \x01(\x0b\x32\x1c.edg.common.Metadata.MembersH\x01\x12\x13\n\ttext_leaf\x18\x66 \x01(\tH\x01\x12\x12\n\x08\x62in_leaf\x18g \x01(\x0cH\x01\x1a\x82\x01\n\x07Members\x12\x34\n\x04node\x18\n \x03(\x0b\x32&.edg.common.Metadata.Members.NodeEntry\x1a\x41\n\tNodeEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.edg.common.Metadata:\x02\x38\x01\x42\x06\n\x04typeB\x06\n\x04meta\"\x07\n\x05\x45mptyb\x06proto3')
+  serialized_pb=_b('\n\x0c\x63ommon.proto\x12\nedg.common\"\x99\x04\n\x08Metadata\x12$\n\x07unknown\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12\x0f\n\x05known\x18\x02 \x01(\tH\x00\x12/\n\x07members\x18\x65 \x01(\x0b\x32\x1c.edg.common.Metadata.MembersH\x01\x12\x13\n\ttext_leaf\x18\x66 \x01(\tH\x01\x12\x12\n\x08\x62in_leaf\x18g \x01(\x0cH\x01\x12\x33\n\x0esource_locator\x18n \x01(\x0b\x32\x19.edg.common.SourceLocatorH\x01\x12\x35\n\x0fnamespace_order\x18o \x01(\x0b\x32\x1a.edg.common.NamespaceOrderH\x01\x12\"\n\x05\x65rror\x18p \x01(\x0b\x32\x11.edg.common.ErrorH\x01\x12+\n\ncopper_net\x18x \x01(\x0b\x32\x15.edg.common.CopperNetH\x01\x12*\n\tfootprint\x18y \x01(\x0b\x32\x15.edg.common.FootprintH\x01\x1a\x82\x01\n\x07Members\x12\x34\n\x04node\x18\n \x03(\x0b\x32&.edg.common.Metadata.Members.NodeEntry\x1a\x41\n\tNodeEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.edg.common.Metadata:\x02\x38\x01\x42\x06\n\x04typeB\x06\n\x04meta\"\xc7\x01\n\rSourceLocator\x12\x14\n\x0c\x66ile_package\x18\x01 \x01(\t\x12\x13\n\x0bline_offset\x18\x02 \x01(\x05\x12\x12\n\ncol_offset\x18\x03 \x01(\x05\x12\x39\n\x0bsource_type\x18\x04 \x01(\x0e\x32$.edg.common.SourceLocator.SourceType\"<\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0e\n\nDEFINITION\x10\x01\x12\x11\n\rINSTANTIATION\x10\x02\"\x1f\n\x0eNamespaceOrder\x12\r\n\x05names\x18\x01 \x03(\t\"C\n\x05\x45rror\x12\x0f\n\x07message\x18\x01 \x01(\t\x12)\n\x06source\x18\x02 \x03(\x0b\x32\x19.edg.common.SourceLocator\"\x0b\n\tCopperNet\"\xd2\x01\n\tFootprint\x12\x15\n\rrefdes_prefix\x18\x01 \x01(\t\x12\x16\n\x0e\x66ootprint_name\x18\x15 \x01(\t\x12\x33\n\x07pinning\x18\x03 \x03(\x0b\x32\".edg.common.Footprint.PinningEntry\x12\x0c\n\x04part\x18\n \x01(\t\x12\x14\n\x0cmanufacturer\x18\x0b \x01(\t\x12\r\n\x05value\x18\x0c \x01(\t\x1a.\n\x0cPinningEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x07\n\x05\x45mptyb\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
+
+_SOURCELOCATOR_SOURCETYPE = _descriptor.EnumDescriptor(
+  name='SourceType',
+  full_name='edg.common.SourceLocator.SourceType',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='UNKNOWN', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='DEFINITION', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='INSTANTIATION', index=2, number=2,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=708,
+  serialized_end=768,
+)
+_sym_db.RegisterEnumDescriptor(_SOURCELOCATOR_SOURCETYPE)
 
 
 _METADATA_MEMBERS_NODEENTRY = _descriptor.Descriptor(
@@ -59,8 +85,8 @@ _METADATA_MEMBERS_NODEENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=252,
-  serialized_end=317,
+  serialized_start=485,
+  serialized_end=550,
 )
 
 _METADATA_MEMBERS = _descriptor.Descriptor(
@@ -89,8 +115,8 @@ _METADATA_MEMBERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=187,
-  serialized_end=317,
+  serialized_start=420,
+  serialized_end=550,
 )
 
 _METADATA = _descriptor.Descriptor(
@@ -135,6 +161,41 @@ _METADATA = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='source_locator', full_name='edg.common.Metadata.source_locator', index=5,
+      number=110, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='namespace_order', full_name='edg.common.Metadata.namespace_order', index=6,
+      number=111, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='error', full_name='edg.common.Metadata.error', index=7,
+      number=112, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='copper_net', full_name='edg.common.Metadata.copper_net', index=8,
+      number=120, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='footprint', full_name='edg.common.Metadata.footprint', index=9,
+      number=121, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -154,7 +215,256 @@ _METADATA = _descriptor.Descriptor(
       index=1, containing_type=None, fields=[]),
   ],
   serialized_start=29,
-  serialized_end=333,
+  serialized_end=566,
+)
+
+
+_SOURCELOCATOR = _descriptor.Descriptor(
+  name='SourceLocator',
+  full_name='edg.common.SourceLocator',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='file_package', full_name='edg.common.SourceLocator.file_package', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='line_offset', full_name='edg.common.SourceLocator.line_offset', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='col_offset', full_name='edg.common.SourceLocator.col_offset', index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='source_type', full_name='edg.common.SourceLocator.source_type', index=3,
+      number=4, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _SOURCELOCATOR_SOURCETYPE,
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=569,
+  serialized_end=768,
+)
+
+
+_NAMESPACEORDER = _descriptor.Descriptor(
+  name='NamespaceOrder',
+  full_name='edg.common.NamespaceOrder',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='names', full_name='edg.common.NamespaceOrder.names', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=770,
+  serialized_end=801,
+)
+
+
+_ERROR = _descriptor.Descriptor(
+  name='Error',
+  full_name='edg.common.Error',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='message', full_name='edg.common.Error.message', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='source', full_name='edg.common.Error.source', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=803,
+  serialized_end=870,
+)
+
+
+_COPPERNET = _descriptor.Descriptor(
+  name='CopperNet',
+  full_name='edg.common.CopperNet',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=872,
+  serialized_end=883,
+)
+
+
+_FOOTPRINT_PINNINGENTRY = _descriptor.Descriptor(
+  name='PinningEntry',
+  full_name='edg.common.Footprint.PinningEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='edg.common.Footprint.PinningEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='edg.common.Footprint.PinningEntry.value', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1050,
+  serialized_end=1096,
+)
+
+_FOOTPRINT = _descriptor.Descriptor(
+  name='Footprint',
+  full_name='edg.common.Footprint',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='refdes_prefix', full_name='edg.common.Footprint.refdes_prefix', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='footprint_name', full_name='edg.common.Footprint.footprint_name', index=1,
+      number=21, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='pinning', full_name='edg.common.Footprint.pinning', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='part', full_name='edg.common.Footprint.part', index=3,
+      number=10, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='manufacturer', full_name='edg.common.Footprint.manufacturer', index=4,
+      number=11, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='edg.common.Footprint.value', index=5,
+      number=12, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[_FOOTPRINT_PINNINGENTRY, ],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=886,
+  serialized_end=1096,
 )
 
 
@@ -177,8 +487,8 @@ _EMPTY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=335,
-  serialized_end=342,
+  serialized_start=1098,
+  serialized_end=1105,
 )
 
 _METADATA_MEMBERS_NODEENTRY.fields_by_name['value'].message_type = _METADATA
@@ -187,6 +497,11 @@ _METADATA_MEMBERS.fields_by_name['node'].message_type = _METADATA_MEMBERS_NODEEN
 _METADATA_MEMBERS.containing_type = _METADATA
 _METADATA.fields_by_name['unknown'].message_type = _EMPTY
 _METADATA.fields_by_name['members'].message_type = _METADATA_MEMBERS
+_METADATA.fields_by_name['source_locator'].message_type = _SOURCELOCATOR
+_METADATA.fields_by_name['namespace_order'].message_type = _NAMESPACEORDER
+_METADATA.fields_by_name['error'].message_type = _ERROR
+_METADATA.fields_by_name['copper_net'].message_type = _COPPERNET
+_METADATA.fields_by_name['footprint'].message_type = _FOOTPRINT
 _METADATA.oneofs_by_name['type'].fields.append(
   _METADATA.fields_by_name['unknown'])
 _METADATA.fields_by_name['unknown'].containing_oneof = _METADATA.oneofs_by_name['type']
@@ -202,7 +517,32 @@ _METADATA.fields_by_name['text_leaf'].containing_oneof = _METADATA.oneofs_by_nam
 _METADATA.oneofs_by_name['meta'].fields.append(
   _METADATA.fields_by_name['bin_leaf'])
 _METADATA.fields_by_name['bin_leaf'].containing_oneof = _METADATA.oneofs_by_name['meta']
+_METADATA.oneofs_by_name['meta'].fields.append(
+  _METADATA.fields_by_name['source_locator'])
+_METADATA.fields_by_name['source_locator'].containing_oneof = _METADATA.oneofs_by_name['meta']
+_METADATA.oneofs_by_name['meta'].fields.append(
+  _METADATA.fields_by_name['namespace_order'])
+_METADATA.fields_by_name['namespace_order'].containing_oneof = _METADATA.oneofs_by_name['meta']
+_METADATA.oneofs_by_name['meta'].fields.append(
+  _METADATA.fields_by_name['error'])
+_METADATA.fields_by_name['error'].containing_oneof = _METADATA.oneofs_by_name['meta']
+_METADATA.oneofs_by_name['meta'].fields.append(
+  _METADATA.fields_by_name['copper_net'])
+_METADATA.fields_by_name['copper_net'].containing_oneof = _METADATA.oneofs_by_name['meta']
+_METADATA.oneofs_by_name['meta'].fields.append(
+  _METADATA.fields_by_name['footprint'])
+_METADATA.fields_by_name['footprint'].containing_oneof = _METADATA.oneofs_by_name['meta']
+_SOURCELOCATOR.fields_by_name['source_type'].enum_type = _SOURCELOCATOR_SOURCETYPE
+_SOURCELOCATOR_SOURCETYPE.containing_type = _SOURCELOCATOR
+_ERROR.fields_by_name['source'].message_type = _SOURCELOCATOR
+_FOOTPRINT_PINNINGENTRY.containing_type = _FOOTPRINT
+_FOOTPRINT.fields_by_name['pinning'].message_type = _FOOTPRINT_PINNINGENTRY
 DESCRIPTOR.message_types_by_name['Metadata'] = _METADATA
+DESCRIPTOR.message_types_by_name['SourceLocator'] = _SOURCELOCATOR
+DESCRIPTOR.message_types_by_name['NamespaceOrder'] = _NAMESPACEORDER
+DESCRIPTOR.message_types_by_name['Error'] = _ERROR
+DESCRIPTOR.message_types_by_name['CopperNet'] = _COPPERNET
+DESCRIPTOR.message_types_by_name['Footprint'] = _FOOTPRINT
 DESCRIPTOR.message_types_by_name['Empty'] = _EMPTY
 
 Metadata = _reflection.GeneratedProtocolMessageType('Metadata', (_message.Message,), dict(
@@ -228,6 +568,49 @@ _sym_db.RegisterMessage(Metadata)
 _sym_db.RegisterMessage(Metadata.Members)
 _sym_db.RegisterMessage(Metadata.Members.NodeEntry)
 
+SourceLocator = _reflection.GeneratedProtocolMessageType('SourceLocator', (_message.Message,), dict(
+  DESCRIPTOR = _SOURCELOCATOR,
+  __module__ = 'common_pb2'
+  # @@protoc_insertion_point(class_scope:edg.common.SourceLocator)
+  ))
+_sym_db.RegisterMessage(SourceLocator)
+
+NamespaceOrder = _reflection.GeneratedProtocolMessageType('NamespaceOrder', (_message.Message,), dict(
+  DESCRIPTOR = _NAMESPACEORDER,
+  __module__ = 'common_pb2'
+  # @@protoc_insertion_point(class_scope:edg.common.NamespaceOrder)
+  ))
+_sym_db.RegisterMessage(NamespaceOrder)
+
+Error = _reflection.GeneratedProtocolMessageType('Error', (_message.Message,), dict(
+  DESCRIPTOR = _ERROR,
+  __module__ = 'common_pb2'
+  # @@protoc_insertion_point(class_scope:edg.common.Error)
+  ))
+_sym_db.RegisterMessage(Error)
+
+CopperNet = _reflection.GeneratedProtocolMessageType('CopperNet', (_message.Message,), dict(
+  DESCRIPTOR = _COPPERNET,
+  __module__ = 'common_pb2'
+  # @@protoc_insertion_point(class_scope:edg.common.CopperNet)
+  ))
+_sym_db.RegisterMessage(CopperNet)
+
+Footprint = _reflection.GeneratedProtocolMessageType('Footprint', (_message.Message,), dict(
+
+  PinningEntry = _reflection.GeneratedProtocolMessageType('PinningEntry', (_message.Message,), dict(
+    DESCRIPTOR = _FOOTPRINT_PINNINGENTRY,
+    __module__ = 'common_pb2'
+    # @@protoc_insertion_point(class_scope:edg.common.Footprint.PinningEntry)
+    ))
+  ,
+  DESCRIPTOR = _FOOTPRINT,
+  __module__ = 'common_pb2'
+  # @@protoc_insertion_point(class_scope:edg.common.Footprint)
+  ))
+_sym_db.RegisterMessage(Footprint)
+_sym_db.RegisterMessage(Footprint.PinningEntry)
+
 Empty = _reflection.GeneratedProtocolMessageType('Empty', (_message.Message,), dict(
   DESCRIPTOR = _EMPTY,
   __module__ = 'common_pb2'
@@ -238,4 +621,6 @@ _sym_db.RegisterMessage(Empty)
 
 _METADATA_MEMBERS_NODEENTRY.has_options = True
 _METADATA_MEMBERS_NODEENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_FOOTPRINT_PINNINGENTRY.has_options = True
+_FOOTPRINT_PINNINGENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 # @@protoc_insertion_point(module_scope)

--- a/edg_core/edgir/common_pb2.pyi
+++ b/edg_core/edgir/common_pb2.pyi
@@ -2,7 +2,17 @@
 import sys
 from google.protobuf.descriptor import (
     Descriptor as google___protobuf___descriptor___Descriptor,
+    EnumDescriptor as google___protobuf___descriptor___EnumDescriptor,
     FileDescriptor as google___protobuf___descriptor___FileDescriptor,
+)
+
+from google.protobuf.internal.containers import (
+    RepeatedCompositeFieldContainer as google___protobuf___internal___containers___RepeatedCompositeFieldContainer,
+    RepeatedScalarFieldContainer as google___protobuf___internal___containers___RepeatedScalarFieldContainer,
+)
+
+from google.protobuf.internal.enum_type_wrapper import (
+    _EnumTypeWrapper as google___protobuf___internal___enum_type_wrapper____EnumTypeWrapper,
 )
 
 from google.protobuf.message import (
@@ -10,10 +20,13 @@ from google.protobuf.message import (
 )
 
 from typing import (
+    Iterable as typing___Iterable,
     Mapping as typing___Mapping,
     MutableMapping as typing___MutableMapping,
+    NewType as typing___NewType,
     Optional as typing___Optional,
     Text as typing___Text,
+    cast as typing___cast,
     overload as typing___overload,
 )
 
@@ -71,6 +84,21 @@ class Metadata(google___protobuf___message___Message):
     @property
     def members(self) -> type___Metadata.Members: ...
 
+    @property
+    def source_locator(self) -> type___SourceLocator: ...
+
+    @property
+    def namespace_order(self) -> type___NamespaceOrder: ...
+
+    @property
+    def error(self) -> type___Error: ...
+
+    @property
+    def copper_net(self) -> type___CopperNet: ...
+
+    @property
+    def footprint(self) -> type___Footprint: ...
+
     def __init__(self,
         *,
         unknown : typing___Optional[type___Empty] = None,
@@ -78,14 +106,118 @@ class Metadata(google___protobuf___message___Message):
         members : typing___Optional[type___Metadata.Members] = None,
         text_leaf : typing___Optional[typing___Text] = None,
         bin_leaf : typing___Optional[builtin___bytes] = None,
+        source_locator : typing___Optional[type___SourceLocator] = None,
+        namespace_order : typing___Optional[type___NamespaceOrder] = None,
+        error : typing___Optional[type___Error] = None,
+        copper_net : typing___Optional[type___CopperNet] = None,
+        footprint : typing___Optional[type___Footprint] = None,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions___Literal[u"bin_leaf",b"bin_leaf",u"known",b"known",u"members",b"members",u"meta",b"meta",u"text_leaf",b"text_leaf",u"type",b"type",u"unknown",b"unknown"]) -> builtin___bool: ...
-    def ClearField(self, field_name: typing_extensions___Literal[u"bin_leaf",b"bin_leaf",u"known",b"known",u"members",b"members",u"meta",b"meta",u"text_leaf",b"text_leaf",u"type",b"type",u"unknown",b"unknown"]) -> None: ...
+    def HasField(self, field_name: typing_extensions___Literal[u"bin_leaf",b"bin_leaf",u"copper_net",b"copper_net",u"error",b"error",u"footprint",b"footprint",u"known",b"known",u"members",b"members",u"meta",b"meta",u"namespace_order",b"namespace_order",u"source_locator",b"source_locator",u"text_leaf",b"text_leaf",u"type",b"type",u"unknown",b"unknown"]) -> builtin___bool: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"bin_leaf",b"bin_leaf",u"copper_net",b"copper_net",u"error",b"error",u"footprint",b"footprint",u"known",b"known",u"members",b"members",u"meta",b"meta",u"namespace_order",b"namespace_order",u"source_locator",b"source_locator",u"text_leaf",b"text_leaf",u"type",b"type",u"unknown",b"unknown"]) -> None: ...
     @typing___overload
-    def WhichOneof(self, oneof_group: typing_extensions___Literal[u"meta",b"meta"]) -> typing_extensions___Literal["members","text_leaf","bin_leaf"]: ...
+    def WhichOneof(self, oneof_group: typing_extensions___Literal[u"meta",b"meta"]) -> typing_extensions___Literal["members","text_leaf","bin_leaf","source_locator","namespace_order","error","copper_net","footprint"]: ...
     @typing___overload
     def WhichOneof(self, oneof_group: typing_extensions___Literal[u"type",b"type"]) -> typing_extensions___Literal["unknown","known"]: ...
 type___Metadata = Metadata
+
+class SourceLocator(google___protobuf___message___Message):
+    DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    SourceTypeValue = typing___NewType('SourceTypeValue', builtin___int)
+    type___SourceTypeValue = SourceTypeValue
+    SourceType: _SourceType
+    class _SourceType(google___protobuf___internal___enum_type_wrapper____EnumTypeWrapper[SourceLocator.SourceTypeValue]):
+        DESCRIPTOR: google___protobuf___descriptor___EnumDescriptor = ...
+        UNKNOWN = typing___cast(SourceLocator.SourceTypeValue, 0)
+        DEFINITION = typing___cast(SourceLocator.SourceTypeValue, 1)
+        INSTANTIATION = typing___cast(SourceLocator.SourceTypeValue, 2)
+    UNKNOWN = typing___cast(SourceLocator.SourceTypeValue, 0)
+    DEFINITION = typing___cast(SourceLocator.SourceTypeValue, 1)
+    INSTANTIATION = typing___cast(SourceLocator.SourceTypeValue, 2)
+    type___SourceType = SourceType
+
+    file_package: typing___Text = ...
+    line_offset: builtin___int = ...
+    col_offset: builtin___int = ...
+    source_type: type___SourceLocator.SourceTypeValue = ...
+
+    def __init__(self,
+        *,
+        file_package : typing___Optional[typing___Text] = None,
+        line_offset : typing___Optional[builtin___int] = None,
+        col_offset : typing___Optional[builtin___int] = None,
+        source_type : typing___Optional[type___SourceLocator.SourceTypeValue] = None,
+        ) -> None: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"col_offset",b"col_offset",u"file_package",b"file_package",u"line_offset",b"line_offset",u"source_type",b"source_type"]) -> None: ...
+type___SourceLocator = SourceLocator
+
+class NamespaceOrder(google___protobuf___message___Message):
+    DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    names: google___protobuf___internal___containers___RepeatedScalarFieldContainer[typing___Text] = ...
+
+    def __init__(self,
+        *,
+        names : typing___Optional[typing___Iterable[typing___Text]] = None,
+        ) -> None: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"names",b"names"]) -> None: ...
+type___NamespaceOrder = NamespaceOrder
+
+class Error(google___protobuf___message___Message):
+    DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    message: typing___Text = ...
+
+    @property
+    def source(self) -> google___protobuf___internal___containers___RepeatedCompositeFieldContainer[type___SourceLocator]: ...
+
+    def __init__(self,
+        *,
+        message : typing___Optional[typing___Text] = None,
+        source : typing___Optional[typing___Iterable[type___SourceLocator]] = None,
+        ) -> None: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"message",b"message",u"source",b"source"]) -> None: ...
+type___Error = Error
+
+class CopperNet(google___protobuf___message___Message):
+    DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+
+    def __init__(self,
+        ) -> None: ...
+type___CopperNet = CopperNet
+
+class Footprint(google___protobuf___message___Message):
+    DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    class PinningEntry(google___protobuf___message___Message):
+        DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+        key: typing___Text = ...
+        value: typing___Text = ...
+
+        def __init__(self,
+            *,
+            key : typing___Optional[typing___Text] = None,
+            value : typing___Optional[typing___Text] = None,
+            ) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"key",b"key",u"value",b"value"]) -> None: ...
+    type___PinningEntry = PinningEntry
+
+    refdes_prefix: typing___Text = ...
+    footprint_name: typing___Text = ...
+    part: typing___Text = ...
+    manufacturer: typing___Text = ...
+    value: typing___Text = ...
+
+    @property
+    def pinning(self) -> typing___MutableMapping[typing___Text, typing___Text]: ...
+
+    def __init__(self,
+        *,
+        refdes_prefix : typing___Optional[typing___Text] = None,
+        footprint_name : typing___Optional[typing___Text] = None,
+        pinning : typing___Optional[typing___Mapping[typing___Text, typing___Text]] = None,
+        part : typing___Optional[typing___Text] = None,
+        manufacturer : typing___Optional[typing___Text] = None,
+        value : typing___Optional[typing___Text] = None,
+        ) -> None: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"footprint_name",b"footprint_name",u"manufacturer",b"manufacturer",u"part",b"part",u"pinning",b"pinning",u"refdes_prefix",b"refdes_prefix",u"value",b"value"]) -> None: ...
+type___Footprint = Footprint
 
 class Empty(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...

--- a/edg_core/edgir/elem_pb2.py
+++ b/edg_core/edgir/elem_pb2.py
@@ -23,7 +23,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='elem.proto',
   package='edg.elem',
   syntax='proto3',
-  serialized_pb=_b('\n\nelem.proto\x12\x08\x65\x64g.elem\x1a\x0c\x63ommon.proto\x1a\ninit.proto\x1a\nexpr.proto\x1a\tref.proto\"\xc3\x02\n\x04Port\x12*\n\x06params\x18\n \x03(\x0b\x32\x1a.edg.elem.Port.ParamsEntry\x12\x34\n\x0b\x63onstraints\x18\x0b \x03(\x0b\x32\x1f.edg.elem.Port.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xb7\x03\n\x06\x42undle\x12,\n\x06params\x18\n \x03(\x0b\x32\x1c.edg.elem.Bundle.ParamsEntry\x12*\n\x05ports\x18\x0b \x03(\x0b\x32\x1b.edg.elem.Bundle.PortsEntry\x12\x36\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32!.edg.elem.Bundle.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xcc\x01\n\tPortArray\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x05ports\x18\r \x03(\x0b\x32\x1e.edg.elem.PortArray.PortsEntry\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\"\xcc\x01\n\x08PortLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12\x1e\n\x04port\x18\x03 \x01(\x0b\x32\x0e.edg.elem.PortH\x00\x12$\n\x05\x61rray\x18\x04 \x01(\x0b\x32\x13.edg.elem.PortArrayH\x00\x12\"\n\x06\x62undle\x18\x06 \x01(\x0b\x32\x10.edg.elem.BundleH\x00\x42\x04\n\x02is\"\xc7\x05\n\x0eHierarchyBlock\x12\x34\n\x06params\x18\n \x03(\x0b\x32$.edg.elem.HierarchyBlock.ParamsEntry\x12\x32\n\x05ports\x18\x0b \x03(\x0b\x32#.edg.elem.HierarchyBlock.PortsEntry\x12\x34\n\x06\x62locks\x18\x0c \x03(\x0b\x32$.edg.elem.HierarchyBlock.BlocksEntry\x12\x32\n\x05links\x18\r \x03(\x0b\x32#.edg.elem.HierarchyBlock.LinksEntry\x12>\n\x0b\x63onstraints\x18\x0e \x03(\x0b\x32).edg.elem.HierarchyBlock.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1a\x42\n\x0b\x42locksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.elem.BlockLike:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\x94\x01\n\tBlockLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12-\n\thierarchy\x18\x04 \x01(\x0b\x32\x18.edg.elem.HierarchyBlockH\x00\x42\x06\n\x04type\"\x9b\x04\n\x04Link\x12*\n\x06params\x18\n \x03(\x0b\x32\x1a.edg.elem.Link.ParamsEntry\x12(\n\x05ports\x18\x0b \x03(\x0b\x32\x19.edg.elem.Link.PortsEntry\x12(\n\x05links\x18\r \x03(\x0b\x32\x19.edg.elem.Link.LinksEntry\x12\x34\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32\x1f.edg.elem.Link.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xc1\x03\n\tLinkArray\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x05ports\x18\x0b \x03(\x0b\x32\x1e.edg.elem.LinkArray.PortsEntry\x12\x39\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32$.edg.elem.LinkArray.ConstraintsEntry\x12-\n\x05links\x18\r \x03(\x0b\x32\x1e.edg.elem.LinkArray.LinksEntry\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\"\xaa\x01\n\x08LinkLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12\x1e\n\x04link\x18\x03 \x01(\x0b\x32\x0e.edg.elem.LinkH\x00\x12$\n\x05\x61rray\x18\x04 \x01(\x0b\x32\x13.edg.elem.LinkArrayH\x00\x42\x06\n\x04typeb\x06proto3')
+  serialized_pb=_b('\n\nelem.proto\x12\x08\x65\x64g.elem\x1a\x0c\x63ommon.proto\x1a\ninit.proto\x1a\nexpr.proto\x1a\tref.proto\"\xc3\x02\n\x04Port\x12*\n\x06params\x18\n \x03(\x0b\x32\x1a.edg.elem.Port.ParamsEntry\x12\x34\n\x0b\x63onstraints\x18\x0b \x03(\x0b\x32\x1f.edg.elem.Port.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xb7\x03\n\x06\x42undle\x12,\n\x06params\x18\n \x03(\x0b\x32\x1c.edg.elem.Bundle.ParamsEntry\x12*\n\x05ports\x18\x0b \x03(\x0b\x32\x1b.edg.elem.Bundle.PortsEntry\x12\x36\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32!.edg.elem.Bundle.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xcc\x01\n\tPortArray\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x05ports\x18\r \x03(\x0b\x32\x1e.edg.elem.PortArray.PortsEntry\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\"\xcc\x01\n\x08PortLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12\x1e\n\x04port\x18\x03 \x01(\x0b\x32\x0e.edg.elem.PortH\x00\x12$\n\x05\x61rray\x18\x04 \x01(\x0b\x32\x13.edg.elem.PortArrayH\x00\x12\"\n\x06\x62undle\x18\x06 \x01(\x0b\x32\x10.edg.elem.BundleH\x00\x42\x04\n\x02is\"\xb3\x06\n\x0eHierarchyBlock\x12\x34\n\x06params\x18\n \x03(\x0b\x32$.edg.elem.HierarchyBlock.ParamsEntry\x12\x32\n\x05ports\x18\x0b \x03(\x0b\x32#.edg.elem.HierarchyBlock.PortsEntry\x12\x34\n\x06\x62locks\x18\x0c \x03(\x0b\x32$.edg.elem.HierarchyBlock.BlocksEntry\x12\x32\n\x05links\x18\r \x03(\x0b\x32#.edg.elem.HierarchyBlock.LinksEntry\x12>\n\x0b\x63onstraints\x18\x0e \x03(\x0b\x32).edg.elem.HierarchyBlock.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x0fprerefine_class\x18\x15 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12&\n\tgenerator\x18\x16 \x01(\x0b\x32\x13.edg.elem.Generator\x12\x13\n\x0bis_abstract\x18\x1e \x01(\x08\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1a\x42\n\x0b\x42locksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.elem.BlockLike:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xa1\x01\n\tGenerator\x12\x0e\n\x06module\x18\x01 \x01(\t\x12\r\n\x05\x63lass\x18\x02 \x01(\t\x12:\n\nconditions\x18\x03 \x03(\x0b\x32&.edg.elem.Generator.GeneratorCondition\x1a\x39\n\x12GeneratorCondition\x12#\n\x07prereqs\x18\x01 \x03(\x0b\x32\x12.edg.ref.LocalPath\"\x94\x01\n\tBlockLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12-\n\thierarchy\x18\x04 \x01(\x0b\x32\x18.edg.elem.HierarchyBlockH\x00\x42\x06\n\x04type\"\x9b\x04\n\x04Link\x12*\n\x06params\x18\n \x03(\x0b\x32\x1a.edg.elem.Link.ParamsEntry\x12(\n\x05ports\x18\x0b \x03(\x0b\x32\x19.edg.elem.Link.PortsEntry\x12(\n\x05links\x18\r \x03(\x0b\x32\x19.edg.elem.Link.LinksEntry\x12\x34\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32\x1f.edg.elem.Link.ConstraintsEntry\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xc1\x03\n\tLinkArray\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x05ports\x18\x0b \x03(\x0b\x32\x1e.edg.elem.LinkArray.PortsEntry\x12\x39\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32$.edg.elem.LinkArray.ConstraintsEntry\x12-\n\x05links\x18\r \x03(\x0b\x32\x1e.edg.elem.LinkArray.LinksEntry\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\"\xaa\x01\n\x08LinkLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12\x1e\n\x04link\x18\x03 \x01(\x0b\x32\x0e.edg.elem.LinkH\x00\x12$\n\x05\x61rray\x18\x04 \x01(\x0b\x32\x13.edg.elem.LinkArrayH\x00\x42\x06\n\x04typeb\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,init__pb2.DESCRIPTOR,expr__pb2.DESCRIPTOR,ref__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -578,8 +578,8 @@ _HIERARCHYBLOCK_BLOCKSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1762,
-  serialized_end=1828,
+  serialized_start=1870,
+  serialized_end=1936,
 )
 
 _HIERARCHYBLOCK_LINKSENTRY = _descriptor.Descriptor(
@@ -615,8 +615,8 @@ _HIERARCHYBLOCK_LINKSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1830,
-  serialized_end=1894,
+  serialized_start=1938,
+  serialized_end=2002,
 )
 
 _HIERARCHYBLOCK_CONSTRAINTSENTRY = _descriptor.Descriptor(
@@ -706,7 +706,28 @@ _HIERARCHYBLOCK = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='meta', full_name='edg.elem.HierarchyBlock.meta', index=6,
+      name='prerefine_class', full_name='edg.elem.HierarchyBlock.prerefine_class', index=6,
+      number=21, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='generator', full_name='edg.elem.HierarchyBlock.generator', index=7,
+      number=22, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='is_abstract', full_name='edg.elem.HierarchyBlock.is_abstract', index=8,
+      number=30, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='meta', full_name='edg.elem.HierarchyBlock.meta', index=9,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -725,7 +746,82 @@ _HIERARCHYBLOCK = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1256,
-  serialized_end=1967,
+  serialized_end=2075,
+)
+
+
+_GENERATOR_GENERATORCONDITION = _descriptor.Descriptor(
+  name='GeneratorCondition',
+  full_name='edg.elem.Generator.GeneratorCondition',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='prereqs', full_name='edg.elem.Generator.GeneratorCondition.prereqs', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2182,
+  serialized_end=2239,
+)
+
+_GENERATOR = _descriptor.Descriptor(
+  name='Generator',
+  full_name='edg.elem.Generator',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='module', full_name='edg.elem.Generator.module', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='class', full_name='edg.elem.Generator.class', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='conditions', full_name='edg.elem.Generator.conditions', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[_GENERATOR_GENERATORCONDITION, ],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2078,
+  serialized_end=2239,
 )
 
 
@@ -772,8 +868,8 @@ _BLOCKLIKE = _descriptor.Descriptor(
       name='type', full_name='edg.elem.BlockLike.type',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1970,
-  serialized_end=2118,
+  serialized_start=2242,
+  serialized_end=2390,
 )
 
 
@@ -884,8 +980,8 @@ _LINK_LINKSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1830,
-  serialized_end=1894,
+  serialized_start=1938,
+  serialized_end=2002,
 )
 
 _LINK_CONSTRAINTSENTRY = _descriptor.Descriptor(
@@ -986,8 +1082,8 @@ _LINK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2121,
-  serialized_end=2660,
+  serialized_start=2393,
+  serialized_end=2932,
 )
 
 
@@ -1098,8 +1194,8 @@ _LINKARRAY_LINKSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1830,
-  serialized_end=1894,
+  serialized_start=1938,
+  serialized_end=2002,
 )
 
 _LINKARRAY = _descriptor.Descriptor(
@@ -1156,8 +1252,8 @@ _LINKARRAY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2663,
-  serialized_end=3112,
+  serialized_start=2935,
+  serialized_end=3384,
 )
 
 
@@ -1211,8 +1307,8 @@ _LINKLIKE = _descriptor.Descriptor(
       name='type', full_name='edg.elem.LinkLike.type',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3115,
-  serialized_end=3285,
+  serialized_start=3387,
+  serialized_end=3557,
 )
 
 _PORT_PARAMSENTRY.fields_by_name['value'].message_type = init__pb2._VALINIT
@@ -1275,7 +1371,12 @@ _HIERARCHYBLOCK.fields_by_name['blocks'].message_type = _HIERARCHYBLOCK_BLOCKSEN
 _HIERARCHYBLOCK.fields_by_name['links'].message_type = _HIERARCHYBLOCK_LINKSENTRY
 _HIERARCHYBLOCK.fields_by_name['constraints'].message_type = _HIERARCHYBLOCK_CONSTRAINTSENTRY
 _HIERARCHYBLOCK.fields_by_name['superclasses'].message_type = ref__pb2._LIBRARYPATH
+_HIERARCHYBLOCK.fields_by_name['prerefine_class'].message_type = ref__pb2._LIBRARYPATH
+_HIERARCHYBLOCK.fields_by_name['generator'].message_type = _GENERATOR
 _HIERARCHYBLOCK.fields_by_name['meta'].message_type = common__pb2._METADATA
+_GENERATOR_GENERATORCONDITION.fields_by_name['prereqs'].message_type = ref__pb2._LOCALPATH
+_GENERATOR_GENERATORCONDITION.containing_type = _GENERATOR
+_GENERATOR.fields_by_name['conditions'].message_type = _GENERATOR_GENERATORCONDITION
 _BLOCKLIKE.fields_by_name['undefined'].message_type = common__pb2._EMPTY
 _BLOCKLIKE.fields_by_name['lib_elem'].message_type = ref__pb2._LIBRARYPATH
 _BLOCKLIKE.fields_by_name['hierarchy'].message_type = _HIERARCHYBLOCK
@@ -1334,6 +1435,7 @@ DESCRIPTOR.message_types_by_name['Bundle'] = _BUNDLE
 DESCRIPTOR.message_types_by_name['PortArray'] = _PORTARRAY
 DESCRIPTOR.message_types_by_name['PortLike'] = _PORTLIKE
 DESCRIPTOR.message_types_by_name['HierarchyBlock'] = _HIERARCHYBLOCK
+DESCRIPTOR.message_types_by_name['Generator'] = _GENERATOR
 DESCRIPTOR.message_types_by_name['BlockLike'] = _BLOCKLIKE
 DESCRIPTOR.message_types_by_name['Link'] = _LINK
 DESCRIPTOR.message_types_by_name['LinkArray'] = _LINKARRAY
@@ -1461,6 +1563,21 @@ _sym_db.RegisterMessage(HierarchyBlock.PortsEntry)
 _sym_db.RegisterMessage(HierarchyBlock.BlocksEntry)
 _sym_db.RegisterMessage(HierarchyBlock.LinksEntry)
 _sym_db.RegisterMessage(HierarchyBlock.ConstraintsEntry)
+
+Generator = _reflection.GeneratedProtocolMessageType('Generator', (_message.Message,), dict(
+
+  GeneratorCondition = _reflection.GeneratedProtocolMessageType('GeneratorCondition', (_message.Message,), dict(
+    DESCRIPTOR = _GENERATOR_GENERATORCONDITION,
+    __module__ = 'elem_pb2'
+    # @@protoc_insertion_point(class_scope:edg.elem.Generator.GeneratorCondition)
+    ))
+  ,
+  DESCRIPTOR = _GENERATOR,
+  __module__ = 'elem_pb2'
+  # @@protoc_insertion_point(class_scope:edg.elem.Generator)
+  ))
+_sym_db.RegisterMessage(Generator)
+_sym_db.RegisterMessage(Generator.GeneratorCondition)
 
 BlockLike = _reflection.GeneratedProtocolMessageType('BlockLike', (_message.Message,), dict(
   DESCRIPTOR = _BLOCKLIKE,

--- a/edg_core/edgir/elem_pb2.pyi
+++ b/edg_core/edgir/elem_pb2.pyi
@@ -28,6 +28,7 @@ from .init_pb2 import (
 
 from .ref_pb2 import (
     LibraryPath as ref_pb2___LibraryPath,
+    LocalPath as ref_pb2___LocalPath,
 )
 
 from typing import (
@@ -338,6 +339,7 @@ class HierarchyBlock(google___protobuf___message___Message):
         def ClearField(self, field_name: typing_extensions___Literal[u"key",b"key",u"value",b"value"]) -> None: ...
     type___ConstraintsEntry = ConstraintsEntry
 
+    is_abstract: builtin___bool = ...
 
     @property
     def params(self) -> typing___MutableMapping[typing___Text, init_pb2___ValInit]: ...
@@ -358,6 +360,12 @@ class HierarchyBlock(google___protobuf___message___Message):
     def superclasses(self) -> google___protobuf___internal___containers___RepeatedCompositeFieldContainer[ref_pb2___LibraryPath]: ...
 
     @property
+    def prerefine_class(self) -> ref_pb2___LibraryPath: ...
+
+    @property
+    def generator(self) -> type___Generator: ...
+
+    @property
     def meta(self) -> common_pb2___Metadata: ...
 
     def __init__(self,
@@ -368,11 +376,42 @@ class HierarchyBlock(google___protobuf___message___Message):
         links : typing___Optional[typing___Mapping[typing___Text, type___LinkLike]] = None,
         constraints : typing___Optional[typing___Mapping[typing___Text, expr_pb2___ValueExpr]] = None,
         superclasses : typing___Optional[typing___Iterable[ref_pb2___LibraryPath]] = None,
+        prerefine_class : typing___Optional[ref_pb2___LibraryPath] = None,
+        generator : typing___Optional[type___Generator] = None,
+        is_abstract : typing___Optional[builtin___bool] = None,
         meta : typing___Optional[common_pb2___Metadata] = None,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions___Literal[u"meta",b"meta"]) -> builtin___bool: ...
-    def ClearField(self, field_name: typing_extensions___Literal[u"blocks",b"blocks",u"constraints",b"constraints",u"links",b"links",u"meta",b"meta",u"params",b"params",u"ports",b"ports",u"superclasses",b"superclasses"]) -> None: ...
+    def HasField(self, field_name: typing_extensions___Literal[u"generator",b"generator",u"meta",b"meta",u"prerefine_class",b"prerefine_class"]) -> builtin___bool: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"blocks",b"blocks",u"constraints",b"constraints",u"generator",b"generator",u"is_abstract",b"is_abstract",u"links",b"links",u"meta",b"meta",u"params",b"params",u"ports",b"ports",u"prerefine_class",b"prerefine_class",u"superclasses",b"superclasses"]) -> None: ...
 type___HierarchyBlock = HierarchyBlock
+
+class Generator(google___protobuf___message___Message):
+    DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+    class GeneratorCondition(google___protobuf___message___Message):
+        DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...
+
+        @property
+        def prereqs(self) -> google___protobuf___internal___containers___RepeatedCompositeFieldContainer[ref_pb2___LocalPath]: ...
+
+        def __init__(self,
+            *,
+            prereqs : typing___Optional[typing___Iterable[ref_pb2___LocalPath]] = None,
+            ) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"prereqs",b"prereqs"]) -> None: ...
+    type___GeneratorCondition = GeneratorCondition
+
+    module: typing___Text = ...
+
+    @property
+    def conditions(self) -> google___protobuf___internal___containers___RepeatedCompositeFieldContainer[type___Generator.GeneratorCondition]: ...
+
+    def __init__(self,
+        *,
+        module : typing___Optional[typing___Text] = None,
+        conditions : typing___Optional[typing___Iterable[type___Generator.GeneratorCondition]] = None,
+        ) -> None: ...
+    def ClearField(self, field_name: typing_extensions___Literal[u"class",b"class",u"conditions",b"conditions",u"module",b"module"]) -> None: ...
+type___Generator = Generator
 
 class BlockLike(google___protobuf___message___Message):
     DESCRIPTOR: google___protobuf___descriptor___Descriptor = ...

--- a/edgir/common.proto
+++ b/edgir/common.proto
@@ -9,8 +9,6 @@ package edg.common;
 
 /** Arbitrary metadata stored in tree form. */
 message Metadata {
-
-
   message Members {
      map<string, Metadata> node = 10;
   }
@@ -40,8 +38,67 @@ message Metadata {
         Mixing up binary and textual formats is just a recipe
         for trouble. */
     bytes bin_leaf = 103;
+
+    // Defined formats
+    // Note: key not defined (but should be sane and consistent), so parsing should match on type of value.
+    SourceLocator source_locator = 110;
+    NamespaceOrder namespace_order = 111;
+
+    // Electronics-specific formats
+    CopperNet copper_net = 120;
+    Footprint footprint = 121;
   }
 }
+
+
+/** Definitions for structured metadata formats */
+
+/** For locating source data */
+message SourceLocator {
+  string file_package = 1;  // package name (portable, not tied to an absolute path) that locates the file
+  int32 line_offset = 2;  // line number
+  int32 col_offset = 3;  // character offset within the line
+
+  enum SourceType {
+    UNKNOWN = 0;
+    DEFINITION = 1;  // source defining this class, would be present in library
+    INSTANTIATION = 2;  // source of instantiation, would not be present in library
+  }
+  SourceType source_type = 4;
+}
+
+/** Supplemental data structure for anything containing a namespace (eg, Block, Link) that
+ defines the original lexical ordering (since proto maps are not order-preserving) */
+message NamespaceOrder {
+  repeated string names = 1;  // names in order, lowest index is first
+}
+
+/** Used to communicate results of analysis / checking passes.
+ Limited to Block and Link objects. */
+message Error {
+  string message = 1;  // free-form error message
+  repeated SourceLocator source = 2;  // source locator, eg line of failing constraint
+  // TODO: should there be a structured stack trace? currently would just be part of message
+}
+
+/** Indicates a copper connection between ports */
+message CopperNet {
+  // Currently empty (all-to-all copper connection implied)
+  // TODO: future feature: define specific ports connected?
+}
+
+/** Defines a footprint with copper mapping between pins and own ports */
+message Footprint {
+  string footprint_name = 1;  // footprint name in KiCad format, including library
+  string manufacturer = 2;
+  string part = 3;  // part number
+  string value = 4;  // only for informational purposes when inspecting components in layout
+  string refdes_prefix = 5;  // eg, 'U' for chips, 'R' for resistors
+
+  map<string, string> pinning = 6;  // footprint pin -> port name (which can use dots to indicate path sub-components)
+  // TODO: use Ref.LocalPath? but importing ref creates a circular import dependency
+}
+
 
 /** Placeholder until I figure out how to import properly */
 message Empty {}

--- a/edgir/common.proto
+++ b/edgir/common.proto
@@ -40,9 +40,11 @@ message Metadata {
     bytes bin_leaf = 103;
 
     // Defined formats
-    // Note: key not defined (but should be sane and consistent), so parsing should match on type of value.
+    // Note: key should be the message definition name (eg, SourceLocator)
+    // TODO: how to handle multiple metadata of a given type?
     SourceLocator source_locator = 110;
     NamespaceOrder namespace_order = 111;
+    Error error = 112;
 
     // Electronics-specific formats
     CopperNet copper_net = 120;
@@ -62,7 +64,7 @@ message SourceLocator {
   enum SourceType {
     UNKNOWN = 0;
     DEFINITION = 1;  // source defining this class, would be present in library
-    INSTANTIATION = 2;  // source of instantiation, would not be present in library
+    INSTANTIATION = 2;  // source of instantiation, would be present in design
   }
   SourceType source_type = 4;
 }
@@ -89,14 +91,14 @@ message CopperNet {
 
 /** Defines a footprint with copper mapping between pins and own ports */
 message Footprint {
-  string footprint_name = 1;  // footprint name in KiCad format, including library
-  string manufacturer = 2;
-  string part = 3;  // part number
-  string value = 4;  // only for informational purposes when inspecting components in layout
-  string refdes_prefix = 5;  // eg, 'U' for chips, 'R' for resistors
-
-  map<string, string> pinning = 6;  // footprint pin -> port name (which can use dots to indicate path sub-components)
+  string refdes_prefix = 1;  // eg, 'U' for chips, 'R' for resistors
+  string footprint_name =21;  // footprint name in KiCad format, including library
+  map<string, string> pinning = 3;  // footprint pin -> port name (which can use dots to indicate path sub-components)
   // TODO: use Ref.LocalPath? but importing ref creates a circular import dependency
+
+  string part = 10;  // part number
+  string manufacturer = 11;
+  string value = 12;  // only for informational purposes when inspecting components in layout
 }
 
 

--- a/edgir/elem.proto
+++ b/edgir/elem.proto
@@ -117,9 +117,25 @@ message HierarchyBlock {
       Connections between internal; block and edge (of this block) ports are represented by exported constraints. */
   map<string, edg.expr.ValueExpr> constraints = 14;
 
-  repeated edg.ref.LibraryPath superclasses = 20;
+  repeated edg.ref.LibraryPath superclasses = 20;  // in library: superclasses; in design: reference to library class
+  edg.ref.LibraryPath prerefine_class = 21;  // if refined: the class pre-refinement; otherwise empty
+  Generator generator = 22;  // optional, and removed upon invocation
+
+  bool is_abstract = 30;  // true if abstract superclass, and should error
 
   edg.common.Metadata meta = 127;
+}
+
+message Generator {
+  string module = 1;  // Python module containing the class of the generator
+  string class = 2;  // Python class name for the generator
+
+  message GeneratorCondition {
+    repeated ref.LocalPath prereqs = 1;  // list of parameters that must be defined for the generator to fire
+    // these are also the only parameters that may be accessed from the generator
+  }
+  repeated GeneratorCondition conditions = 3;  // ANY of these conditions being satisfied will fire this generator
+  // overall, this defines conditions as an OR of any of several AND clauses of parameters being defined
 }
 
 message BlockLike {
@@ -166,7 +182,9 @@ message LinkArray {
 message LinkLike {
   oneof type {
     edg.common.Empty undefined = 1;
+
     edg.ref.LibraryPath lib_elem = 2;
+
     /** not allowed w/in the library */
     Link link = 3;
     LinkArray array = 4;


### PR DESCRIPTION
Will re-generate the Python bindings before merging.

Partial fix (definitions only, implementation to come later) for #9