### PR TITLE
Add hull operator, remove min(array[range]) -> float

### DIFF
--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -96,7 +96,7 @@ class ConstProp {
       case init.ValInit.Val.Integer(_) => classOf[IntValue]
       case init.ValInit.Val.Boolean(_) => classOf[BooleanValue]
       case init.ValInit.Val.Text(_) => classOf[TextValue]
-      case init.ValInit.Val.Range(_) => classOf[RangeValue]
+      case init.ValInit.Val.Range(_) => classOf[RangeType]
       case _ => throw new NotImplementedError(s"Unknown param declaration / init $decl")
     }
     paramTypes.put(target, paramType)

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -326,7 +326,7 @@ class ConstProp {
 
     // Also get all empty range assignments
     val emptyRangeErrors = params.toMap.collect {
-      case (ExprRef.Param(targetPath), DepValue.Param(range: RangeValue)) if range.isEmpty =>
+      case (ExprRef.Param(targetPath), DepValue.Param(RangeEmpty)) =>
         paramSource.get(targetPath).map { case (root, constrName, value) =>
           CompilerError.EmptyRange(targetPath, root, constrName, value)
         }

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -201,11 +201,11 @@ object ExprEvaluate {
 
     case (expr.ReductionExpr.Op.ALL_UNIQUE, ArrayValue(vals)) => BooleanValue(vals.size == vals.toSet.size)
 
-    case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.Empty(_)) => FloatValue(Float.NegativeInfinity)  // TODO type needs to be dynamic
+    case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.Empty(_)) => FloatValue(Float.NegativeInfinity)
     case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.max)
     case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.max)
 
-    case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.Empty(_)) => FloatValue(Float.PositiveInfinity)  // TODO type needs to be dynamic
+    case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.Empty(_)) => FloatValue(Float.PositiveInfinity)
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.min)
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.min)
 
@@ -232,7 +232,8 @@ object ExprEvaluate {
         RangeValue.empty
       }
 
-    // TODO empty case for hull?
+    case (expr.ReductionExpr.Op.HULL, ArrayValue.Empty(_)) =>  // TODO empty range construct?
+      RangeValue(0, 0)  // TODO this is a nasty hack! - should return an invalid value
     case (expr.ReductionExpr.Op.HULL, ArrayValue.ExtractRange(valMins, valMaxs)) =>
       RangeValue(valMins.min, valMaxs.max)
 

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -227,6 +227,11 @@ object ExprEvaluate {
     case (expr.ReductionExpr.Op.MAXIMUM, FullRangeValue(lower, upper)) => FloatValue(upper)
     case (expr.ReductionExpr.Op.MINIMUM, FullRangeValue(lower, upper)) => FloatValue(lower)
 
+    // TODO can we have stricter semantics to avoid min(RangeEmpty) and max(RangeEmpty)?
+    // This just NaNs out so at least it propagates
+    case (expr.ReductionExpr.Op.MAXIMUM, RangeEmpty) => FloatValue(Float.NaN)
+    case (expr.ReductionExpr.Op.MINIMUM, RangeEmpty) => FloatValue(Float.NaN)
+
     // TODO this should be a user-level assertion instead of a compiler error
     case (expr.ReductionExpr.Op.SET_EXTRACT, ArrayValue.Empty(_)) =>
       throw new ExprEvaluateException(s"SetExtract with empty values from $reduce")

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -209,11 +209,6 @@ object ExprEvaluate {
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.min)
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.min)
 
-    // TODO max / min on Array[Range] is a bit of a hack (but kinda makes sense?) - perhaps should be removed
-    // TODO define a default in case of empty?
-    case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.ExtractRange(valMins, valMaxs)) => FloatValue(valMaxs.max)
-    case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractRange(valMins, valMaxs)) => FloatValue(valMins.min)
-
     // TODO this is definitely a hack in the absence of a proper range extractor
     case (expr.ReductionExpr.Op.MAXIMUM, RangeValue(lower, upper)) => FloatValue(upper)
     case (expr.ReductionExpr.Op.MINIMUM, RangeValue(lower, upper)) => FloatValue(lower)
@@ -227,7 +222,7 @@ object ExprEvaluate {
       throw new ExprEvaluateException(s"SetExtract with non-equal values $vals from $reduce")
     }
 
-    case (expr.ReductionExpr.Op.INTERSECTION, ArrayValue.Empty(_)) =>
+    case (expr.ReductionExpr.Op.INTERSECTION, ArrayValue.Empty(_)) =>  // TODO empty range construct?
       RangeValue(Float.NegativeInfinity, Float.PositiveInfinity)
     case (expr.ReductionExpr.Op.INTERSECTION, ArrayValue.ExtractRange(valMins, valMaxs)) =>
       val (minMax, maxMin) = (valMaxs.min, valMins.max)
@@ -236,6 +231,10 @@ object ExprEvaluate {
       } else {  // null set
         RangeValue.empty
       }
+
+    // TODO empty case for hull?
+    case (expr.ReductionExpr.Op.HULL, ArrayValue.ExtractRange(valMins, valMaxs)) =>
+      RangeValue(valMins.min, valMaxs.max)
 
     case _ => throw new ExprEvaluateException(s"Unknown reduce op in ${reduce.op} $vals from $reduce")
   }

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -233,7 +233,7 @@ object ExprEvaluate {
       }
 
     case (expr.ReductionExpr.Op.HULL, ArrayValue.Empty(_)) =>  // TODO empty range construct?
-      RangeValue(0, 0)  // TODO this is a nasty hack! - should return an invalid value
+      RangeEmpty
     case (expr.ReductionExpr.Op.HULL, ArrayValue.ExtractRange(valMins, valMaxs)) =>
       RangeValue(valMins.min, valMaxs.max)
 

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -29,12 +29,12 @@ object ExprEvaluate {
   def evalBinary(binary: expr.BinaryExpr, lhs: ExprValue, rhs: ExprValue): ExprValue = binary.op match {
     // Note promotion rules: range takes precedence, then float, then int
     case expr.BinaryExpr.Op.ADD => (lhs, rhs) match {
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         val all = Seq(lhsMin + rhsMin, lhsMin + rhsMax, lhsMax + rhsMin, lhsMax + rhsMax)
         RangeValue(all.min, all.max)
-      case (RangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
         RangeValue(lhsMin + rhs, lhsMax + rhs)
-      case (FloatPromotable(lhs), RangeValue(rhsMin, rhsMax)) =>
+      case (FloatPromotable(lhs), FullRangeValue(rhsMin, rhsMax)) =>
         RangeValue(lhs + rhsMin, lhs + rhsMax)
       case (FloatValue(lhs), FloatPromotable(rhs)) => FloatValue(lhs + rhs)
       case (FloatPromotable(lhs), FloatValue(rhs)) => FloatValue(lhs + rhs)
@@ -42,12 +42,12 @@ object ExprEvaluate {
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.SUB => (lhs, rhs) match {
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         val all = Seq(lhsMin - rhsMin, lhsMin - rhsMax, lhsMax - rhsMin, lhsMax - rhsMax)
         RangeValue(all.min, all.max)
-      case (RangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
         RangeValue(lhsMin - rhs, lhsMax - rhs)
-      case (FloatPromotable(lhs), RangeValue(rhsMin, rhsMax)) =>
+      case (FloatPromotable(lhs), FullRangeValue(rhsMin, rhsMax)) =>
         RangeValue(lhs - rhsMin, lhs - rhsMax)
       case (FloatValue(lhs), FloatPromotable(rhs)) => FloatValue(lhs - rhs)
       case (FloatPromotable(lhs), FloatValue(rhs)) => FloatValue(lhs - rhs)
@@ -55,12 +55,12 @@ object ExprEvaluate {
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.MULT => (lhs, rhs) match {
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         val all = Seq(lhsMin * rhsMin, lhsMin * rhsMax, lhsMax * rhsMin, lhsMax * rhsMax)
         RangeValue(all.min, all.max)
-      case (RangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
         RangeValue(lhsMin * rhs, lhsMax * rhs)
-      case (FloatPromotable(lhs), RangeValue(rhsMin, rhsMax)) =>
+      case (FloatPromotable(lhs), FullRangeValue(rhsMin, rhsMax)) =>
         RangeValue(lhs * rhsMin, lhs * rhsMax)
       case (FloatValue(lhs), FloatPromotable(rhs)) => FloatValue(lhs * rhs)
       case (FloatPromotable(lhs), FloatValue(rhs)) => FloatValue(lhs * rhs)
@@ -68,12 +68,12 @@ object ExprEvaluate {
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.DIV => (lhs, rhs) match {
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         val all = Seq(lhsMin / rhsMin, lhsMin / rhsMax, lhsMax / rhsMin, lhsMax / rhsMax)
         RangeValue(all.min, all.max)
-      case (RangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FloatPromotable(rhs)) =>
         RangeValue(lhsMin / rhs, lhsMax / rhs)
-      case (FloatPromotable(lhs), RangeValue(rhsMin, rhsMax)) =>
+      case (FloatPromotable(lhs), FullRangeValue(rhsMin, rhsMax)) =>
         RangeValue(lhs / rhsMin, lhs / rhsMax)
       case (FloatValue(lhs), FloatPromotable(rhs)) => FloatValue(lhs / rhs)
       case (FloatPromotable(lhs), FloatValue(rhs)) => FloatValue(lhs / rhs)
@@ -100,18 +100,23 @@ object ExprEvaluate {
 
     case expr.BinaryExpr.Op.EQ => (lhs, rhs) match {
       // TODO can optionally support Range <-> Float ops later if desired, it's a 'type error' now
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         BooleanValue(lhsMin == rhsMin && lhsMax == rhsMax)
+      case (RangeEmpty, RangeEmpty) => BooleanValue(true)
+      case (_: RangeValue, _: RangeValue) => BooleanValue(false)  // type mismatch by priority
       case (IntValue(lhs), IntValue(rhs)) => BooleanValue(lhs == rhs)  // prioritize int compare before promotion
       case (FloatPromotable(lhs), FloatPromotable(rhs)) => BooleanValue(lhs == rhs)
       case (BooleanValue(lhs), BooleanValue(rhs)) => BooleanValue(lhs == rhs)
       case (TextValue(lhs), TextValue(rhs)) => BooleanValue(lhs == rhs)
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
+    // TODO dedup w/ above?
     case expr.BinaryExpr.Op.NEQ => (lhs, rhs) match {
       // TODO can optionally support Range <-> Float ops later if desired, it's a 'type error' now
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         BooleanValue(lhsMin != rhsMin || lhsMax != rhsMax)
+      case (RangeEmpty, RangeEmpty) => BooleanValue(false)
+      case (_: RangeValue, _: RangeValue) => BooleanValue(true)  // type mismatch by priority
       case (IntValue(lhs), IntValue(rhs)) => BooleanValue(lhs != rhs)  // prioritize int compare before promotion
       case (FloatPromotable(lhs), FloatPromotable(rhs)) => BooleanValue(lhs != rhs)
       case (BooleanValue(lhs), BooleanValue(rhs)) => BooleanValue(lhs != rhs)
@@ -121,28 +126,28 @@ object ExprEvaluate {
 
     case expr.BinaryExpr.Op.GT => (lhs, rhs) match {
       // TODO can optionally support Range <-> Float ops later if desired, it's a 'type error' now
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMin > rhsMax)
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMin > rhsMax)
       case (IntValue(lhs), IntValue(rhs)) => BooleanValue(lhs > rhs) // prioritize int compare before promotion
       case (FloatPromotable(lhs), FloatPromotable(rhs)) => BooleanValue(lhs > rhs)
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.GTE => (lhs, rhs) match {
       // TODO can optionally support Range <-> Float ops later if desired, it's a 'type error' now
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMin >= rhsMax)
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMin >= rhsMax)
       case (IntValue(lhs), IntValue(rhs)) => BooleanValue(lhs >= rhs) // prioritize int compare before promotion
       case (FloatPromotable(lhs), FloatPromotable(rhs)) => BooleanValue(lhs >= rhs)
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.LT => (lhs, rhs) match {
       // TODO can optionally support Range <-> Float ops later if desired, it's a 'type error' now
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMax < rhsMin)
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMax < rhsMin)
       case (IntValue(lhs), IntValue(rhs)) => BooleanValue(lhs < rhs) // prioritize int compare before promotion
       case (FloatPromotable(lhs), FloatPromotable(rhs)) => BooleanValue(lhs < rhs)
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.LTE => (lhs, rhs) match {
       // TODO can optionally support Range <-> Float ops later if desired, it's a 'type error' now
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMax <= rhsMin)
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) => BooleanValue(lhsMax <= rhsMin)
       case (IntValue(lhs), IntValue(rhs)) => BooleanValue(lhs <= rhs) // prioritize int compare before promotion
       case (FloatPromotable(lhs), FloatPromotable(rhs)) => BooleanValue(lhs <= rhs)
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
@@ -160,7 +165,9 @@ object ExprEvaluate {
     }
 
     case expr.BinaryExpr.Op.INTERSECTION => (lhs, rhs) match {
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (RangeEmpty, _) => RangeEmpty  // anything intersecting with empty is empty
+      case (_, RangeEmpty) => RangeEmpty
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         val (minMax, maxMin) = (math.min(lhsMax, rhsMax), math.max(lhsMin, rhsMin))
         if (maxMin <= minMax) {
           RangeValue(maxMin, minMax)
@@ -170,9 +177,12 @@ object ExprEvaluate {
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
     case expr.BinaryExpr.Op.SUBSET => (lhs, rhs) match {  // lhs contained within rhs
-      case (RangeValue(lhsMin, lhsMax), RangeValue(rhsMin, rhsMax)) =>
+      case (RangeEmpty, _: FullRangeValue) => BooleanValue(true)  // empty contained within anything
+      case (_: FullRangeValue, RangeEmpty) => BooleanValue(false)  // empty contains nothing
+      case (FloatPromotable(_), RangeEmpty) => BooleanValue(false)  // empty contains nothing, not even single points
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
         BooleanValue(rhsMin <= lhsMin && rhsMax >= lhsMax)
-      case (FloatPromotable(lhs), RangeValue(rhsMin, rhsMax)) =>BooleanValue(rhsMin <= lhs && rhsMax >= lhs)
+      case (FloatPromotable(lhs), FullRangeValue(rhsMin, rhsMax)) => BooleanValue(rhsMin <= lhs && rhsMax >= lhs)
       case _ => throw new ExprEvaluateException(s"Unknown binary operands types in $lhs ${binary.op} $rhs from $binary")
     }
 
@@ -210,8 +220,8 @@ object ExprEvaluate {
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.min)
 
     // TODO this is definitely a hack in the absence of a proper range extractor
-    case (expr.ReductionExpr.Op.MAXIMUM, RangeValue(lower, upper)) => FloatValue(upper)
-    case (expr.ReductionExpr.Op.MINIMUM, RangeValue(lower, upper)) => FloatValue(lower)
+    case (expr.ReductionExpr.Op.MAXIMUM, FullRangeValue(lower, upper)) => FloatValue(upper)
+    case (expr.ReductionExpr.Op.MINIMUM, FullRangeValue(lower, upper)) => FloatValue(lower)
 
     // TODO this should be a user-level assertion instead of a compiler error
     case (expr.ReductionExpr.Op.SET_EXTRACT, ArrayValue.Empty(_)) =>
@@ -224,6 +234,8 @@ object ExprEvaluate {
 
     case (expr.ReductionExpr.Op.INTERSECTION, ArrayValue.Empty(_)) =>  // TODO empty range construct?
       RangeValue(Float.NegativeInfinity, Float.PositiveInfinity)
+
+    // TODO intersection if it contains an empty
     case (expr.ReductionExpr.Op.INTERSECTION, ArrayValue.ExtractRange(valMins, valMaxs)) =>
       val (minMax, maxMin) = (valMaxs.min, valMins.max)
       if (maxMin <= minMax) {
@@ -232,6 +244,7 @@ object ExprEvaluate {
         RangeValue.empty
       }
 
+    // TODO hull if it contains an empty
     case (expr.ReductionExpr.Op.HULL, ArrayValue.Empty(_)) =>  // TODO empty range construct?
       RangeEmpty
     case (expr.ReductionExpr.Op.HULL, ArrayValue.ExtractRange(valMins, valMaxs)) =>

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -223,11 +223,9 @@ object ExprEvaluate {
 
     case (expr.ReductionExpr.Op.ALL_UNIQUE, ArrayValue(vals)) => BooleanValue(vals.size == vals.toSet.size)
 
-    case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.Empty(_)) => FloatValue(Float.NegativeInfinity)
     case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.max)
     case (expr.ReductionExpr.Op.MAXIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.max)
 
-    case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.Empty(_)) => FloatValue(Float.PositiveInfinity)
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.min)
     case (expr.ReductionExpr.Op.MINIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.min)
 
@@ -255,7 +253,7 @@ object ExprEvaluate {
         val (minMax, maxMin) = (valMaxs.min, valMins.max)
         if (maxMin <= minMax) {
           RangeValue(maxMin, minMax)
-        } else {  // does not intersect, mull set
+        } else {  // does not intersect, null set
           RangeEmpty
         }
       // The implicit initial value of intersect is the full range

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -176,6 +176,14 @@ object ExprEvaluate {
         }
       case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
     }
+    case expr.BinaryExpr.Op.HULL => (lhs, rhs) match {
+      case (RangeEmpty, rhs: FullRangeValue) => rhs
+      case (lhs: FullRangeValue, RangeEmpty) => lhs
+      case (FullRangeValue(lhsMin, lhsMax), FullRangeValue(rhsMin, rhsMax)) =>
+        RangeValue(math.min(lhsMin, rhsMin), math.max(lhsMax, rhsMax))
+      case (RangeEmpty, RangeEmpty) => RangeEmpty
+      case _ => throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
+    }
     case expr.BinaryExpr.Op.SUBSET => (lhs, rhs) match {  // lhs contained within rhs
       case (RangeEmpty, _: FullRangeValue) => BooleanValue(true)  // empty contained within anything
       case (_: FullRangeValue, RangeEmpty) => BooleanValue(false)  // empty contains nothing

--- a/compiler/src/main/scala/edg/compiler/ExprToString.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprToString.scala
@@ -54,6 +54,7 @@ class ExprToString() extends ValueExprMap[String] {
         case Op.MAX | Op.MIN => None
         case Op.INTERSECTION => Some("∩")
         case Op.SUBSET => Some("⊆")
+        case Op.HULL => Some("h∪")
         case Op.RANGE => None
         case Op.UNDEFINED | Op.Unrecognized(_) => None
       }
@@ -65,7 +66,7 @@ class ExprToString() extends ValueExprMap[String] {
         case Op.GT | Op.GTE | Op.LT | Op.LTE => None
         case Op.MAX => Some("max")
         case Op.MIN => Some("min")
-        case Op.INTERSECTION | Op.SUBSET => None
+        case Op.INTERSECTION | Op.HULL | Op.SUBSET => None
         case Op.RANGE => Some("range")
         case Op.UNDEFINED | Op.Unrecognized(_) => None
       }

--- a/compiler/src/main/scala/edg/compiler/ExprToString.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprToString.scala
@@ -91,6 +91,7 @@ class ExprToString() extends ValueExprMap[String] {
       case Op.MINIMUM => Some("min")
       case Op.SET_EXTRACT => Some("setExtract")
       case Op.INTERSECTION => Some("intersection")
+      case Op.HULL => Some("hull")
       case Op.UNDEFINED | Op.Unrecognized(_) => None
     }
   }

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -51,12 +51,12 @@ case class IntValue(value: BigInt) extends FloatPromotable {
   override def toStringValue: String = value.toString
 }
 
+sealed trait RangeType extends ExprValue
+
 object RangeValue {
   def apply(lower: Double, upper: Double): RangeType =
     RangeValue(lower.toFloat, upper.toFloat)  // convenience method
 }
-
-sealed trait RangeType extends ExprValue
 
 case class RangeValue(lower: Float, upper: Float) extends RangeType {
   require(lower <= upper, s"malformed range ($lower, $upper)")
@@ -137,6 +137,7 @@ object ArrayValue {
     case class EmptyArray() extends ExtractedRange
 
     def unapply[T <: ExprValue](vals: ArrayValue[T]): Option[ExtractedRange] = seqMapOption(vals.values) {
+      // the outer option returns None if it encounters a non-Range value
       case RangeValue(eltMin, eltMax) => Some((eltMin, eltMax))
       case RangeEmpty => None
     }.map { valueOpts =>

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -125,11 +125,21 @@ object ArrayValue {
     }
   }
 
-  object ExtractRange {
-    def unapply[T <: ExprValue](vals: ArrayValue[T]): Option[(Seq[Float], Seq[Float])] = seqMapOption(vals.values) {
-      case FullRangeValue(eltMin, eltMax) => (eltMin, eltMax)
-    }.map(_.unzip)
+  // Extracts the min and maxes from an array of ranges, returning an empty array if any of the contents are empty
+  object ExtactRangePropagatingEmpty {
+
   }
+
+  // Extracts the min and maxes from an array of ranges, discarding any empty values
+  object ExtractRangeDiscardingEmpty {
+
+  }
+
+//  object ExtractRange {
+//    def unapply[T <: ExprValue](vals: ArrayValue[T]): Option[(Seq[Float], Seq[Float])] = seqMapOption(vals.values) {
+//      case FullRangeValue(eltMin, eltMax) => (eltMin, eltMax)
+//    }.map(_.unzip)
+//  }
 
   object ExtractBoolean {
     def unapply[T <: ExprValue](vals: ArrayValue[T]): Option[Seq[Boolean]] = seqMapOption(vals.values) {

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -52,23 +52,20 @@ case class IntValue(value: BigInt) extends FloatPromotable {
 }
 
 object RangeValue {
-  def apply(lower: Double, upper: Double): RangeValue =
-    FullRangeValue(lower.toFloat, upper.toFloat)  // convenience method
-
-  def empty: RangeValue = RangeEmpty
+  def apply(lower: Double, upper: Double): RangeType =
+    RangeValue(lower.toFloat, upper.toFloat)  // convenience method
 }
 
-sealed trait RangeValue extends ExprValue
+sealed trait RangeType extends ExprValue
 
-// TODO better name - basically means "not empty / null set"
-case class FullRangeValue(lower: Float, upper: Float) extends RangeValue {
+case class RangeValue(lower: Float, upper: Float) extends RangeType {
   require(lower <= upper, s"malformed range ($lower, $upper)")
 
   override def toLit: lit.ValueLit = Literal.Range(lower, upper)
   override def toStringValue: String = s"($lower, $upper)"
 }
 
-case object RangeEmpty extends RangeValue {  // an empty range, analogous to an empty set
+case object RangeEmpty extends RangeType {  // an empty range, analogous to an empty set
   override def toLit: lit.ValueLit = Literal.Range(Float.NaN, Float.NaN)
   override def toStringValue: String = s"(${Float.NaN}, ${Float.NaN})"
 }
@@ -140,7 +137,7 @@ object ArrayValue {
     case class EmptyArray() extends ExtractedRange
 
     def unapply[T <: ExprValue](vals: ArrayValue[T]): Option[ExtractedRange] = seqMapOption(vals.values) {
-      case FullRangeValue(eltMin, eltMax) => Some((eltMin, eltMax))
+      case RangeValue(eltMin, eltMax) => Some((eltMin, eltMax))
       case RangeEmpty => None
     }.map { valueOpts =>
       val containsNone = valueOpts.contains(None)

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -51,14 +51,15 @@ case class IntValue(value: BigInt) extends FloatPromotable {
 
 object RangeValue {
   def apply(lower: Double, upper: Double): RangeValue =
-    NumericRangeValue(lower.toFloat, upper.toFloat)  // convenience method
+    FullRangeValue(lower.toFloat, upper.toFloat)  // convenience method
 
   def empty: RangeValue = RangeEmpty
 }
 
 sealed trait RangeValue extends ExprValue
 
-case class NumericRangeValue(lower: Float, upper: Float) extends RangeValue {
+// TODO better name - basically means "not empty / null set"
+case class FullRangeValue(lower: Float, upper: Float) extends RangeValue {
   require(lower <= upper, s"malformed range ($lower, $upper)")
 
   override def toLit: lit.ValueLit = Literal.Range(lower, upper)
@@ -126,7 +127,7 @@ object ArrayValue {
 
   object ExtractRange {
     def unapply[T <: ExprValue](vals: ArrayValue[T]): Option[(Seq[Float], Seq[Float])] = seqMapOption(vals.values) {
-      case RangeValue(eltMin, eltMax) => (eltMin, eltMax)
+      case FullRangeValue(eltMin, eltMax) => (eltMin, eltMax)
     }.map(_.unzip)
   }
 

--- a/compiler/src/test/scala/edg/compiler/ExprEvaluateTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ExprEvaluateTest.scala
@@ -63,9 +63,9 @@ class ExprEvaluateTest extends AnyFlatSpec {
     evalTest.map(ValueExpr.BinOp(Op.INTERSECTION,
       ValueExpr.Literal(5.0, 7.0), ValueExpr.Literal(7.0, 10.0)
     )) should equal(RangeValue(7.0, 7.0))
-    assert(evalTest.map(ValueExpr.BinOp(Op.INTERSECTION,
+    evalTest.map(ValueExpr.BinOp(Op.INTERSECTION,
       ValueExpr.Literal(5.0, 7.0), ValueExpr.Literal(8.0, 10.0)
-    )).asInstanceOf[RangeValue].isEmpty)
+    )) should equal(RangeEmpty)
 
     evalTest.map(ValueExpr.BinOp(Op.SUBSET,
       ValueExpr.Literal(6.0), ValueExpr.Literal(5.0, 7.0)

--- a/compiler/src/test/scala/edg/compiler/ExprEvaluateTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ExprEvaluateTest.scala
@@ -66,6 +66,21 @@ class ExprEvaluateTest extends AnyFlatSpec {
     evalTest.map(ValueExpr.BinOp(Op.INTERSECTION,
       ValueExpr.Literal(5.0, 7.0), ValueExpr.Literal(8.0, 10.0)
     )) should equal(RangeEmpty)
+    // TODO test with empty ranges?
+
+    evalTest.map(ValueExpr.BinOp(Op.HULL,
+      ValueExpr.Literal(4.0, 6.0), ValueExpr.Literal(5.0, 7.0)
+    )) should equal(RangeValue(4.0, 7.0))
+    evalTest.map(ValueExpr.BinOp(Op.HULL,
+      ValueExpr.Literal(5.0, 7.0), ValueExpr.Literal(4.0, 6.0)
+    )) should equal(RangeValue(4.0, 7.0))
+    evalTest.map(ValueExpr.BinOp(Op.HULL,
+      ValueExpr.Literal(5.0, 7.0), ValueExpr.Literal(7.0, 10.0)
+    )) should equal(RangeValue(5.0, 10.0))
+    evalTest.map(ValueExpr.BinOp(Op.HULL,
+      ValueExpr.Literal(5.0, 7.0), ValueExpr.Literal(8.0, 10.0)
+    )) should equal(RangeValue(5.0, 10.0))
+    // TODO test with empty ranges?
 
     evalTest.map(ValueExpr.BinOp(Op.SUBSET,
       ValueExpr.Literal(6.0), ValueExpr.Literal(5.0, 7.0)

--- a/edg_core/Array.py
+++ b/edg_core/Array.py
@@ -220,14 +220,14 @@ class Vector(BaseVector, Generic[VectorType]):
 
   def min(self, selector: Callable[[VectorType], FloatExpr]) -> FloatExpr:
     param = selector(self.elt_sample)
-    if not isinstance(param, (FloatExpr, RangeExpr)):  # TODO check that returned type is child
+    if not isinstance(param, FloatExpr):  # TODO check that returned type is child
       raise TypeError(f"selector to min(...) must return Float, got {param} of type {type(param)}")
 
     return ArrayExpr(param)._bind(MapExtractBinding(self, param)).min()
 
   def max(self, selector: Callable[[VectorType], FloatExpr]) -> FloatExpr:
     param = selector(self.elt_sample)
-    if not isinstance(param, (FloatExpr, RangeExpr)):  # TODO check that returned type is child
+    if not isinstance(param, FloatExpr):  # TODO check that returned type is child
       raise TypeError(f"selector to max(...) must return Float, got {param} of type {type(param)}")
 
     return ArrayExpr(param)._bind(MapExtractBinding(self, param)).max()

--- a/edg_core/Array.py
+++ b/edg_core/Array.py
@@ -84,6 +84,9 @@ class ArrayExpr(ConstraintExpr['ArrayExpr', 'ArrayExpr', Any], Generic[ArrayType
   def intersection(self) -> ArrayType:
     return self.create_reduce_op(ReductionOp.intersection)
 
+  def hull(self) -> ArrayType:
+    return self.create_reduce_op(ReductionOp.hull)
+
   def equal_any(self) -> ArrayType:
     return self.create_reduce_op(ReductionOp.equal_any)
 
@@ -215,18 +218,17 @@ class Vector(BaseVector, Generic[VectorType]):
 
     return ArrayExpr(param)._bind(MapExtractBinding(self, param)).sum()  #type:ignore
 
-  # TODO should these work on Ranges? Return min-of-lower / max-of-upper?
-  def min(self, selector: Callable[[VectorType], Union[FloatExpr, RangeExpr]]) -> FloatExpr:
+  def min(self, selector: Callable[[VectorType], FloatExpr]) -> FloatExpr:
     param = selector(self.elt_sample)
     if not isinstance(param, (FloatExpr, RangeExpr)):  # TODO check that returned type is child
-      raise TypeError(f"selector to min(...) must return Float/RangeExpr, got {param} of type {type(param)}")
+      raise TypeError(f"selector to min(...) must return Float, got {param} of type {type(param)}")
 
     return ArrayExpr(param)._bind(MapExtractBinding(self, param)).min()
 
-  def max(self, selector: Callable[[VectorType], Union[FloatExpr, RangeExpr]]) -> FloatExpr:
+  def max(self, selector: Callable[[VectorType], FloatExpr]) -> FloatExpr:
     param = selector(self.elt_sample)
     if not isinstance(param, (FloatExpr, RangeExpr)):  # TODO check that returned type is child
-      raise TypeError(f"selector to max(...) must return Float/RangeExpr, got {param} of type {type(param)}")
+      raise TypeError(f"selector to max(...) must return Float, got {param} of type {type(param)}")
 
     return ArrayExpr(param)._bind(MapExtractBinding(self, param)).max()
 
@@ -236,3 +238,10 @@ class Vector(BaseVector, Generic[VectorType]):
       raise TypeError(f"selector to intersection(...) must return RangeExpr, got {param} of type {type(param)}")
 
     return ArrayExpr(param)._bind(MapExtractBinding(self, param)).intersection()
+
+  def hull(self, selector: Callable[[VectorType], RangeExpr]) -> RangeExpr:
+    param = selector(self.elt_sample)
+    if not isinstance(param, RangeExpr):  # TODO check that returned type is child
+      raise TypeError(f"selector to hull(...) must return RangeExpr, got {param} of type {type(param)}")
+
+    return ArrayExpr(param)._bind(MapExtractBinding(self, param)).hull()

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -258,6 +258,7 @@ class BinaryOpBinding(Binding):
       ReductionOp.min: edgir.BinaryExpr.MIN,
       ReductionOp.max: edgir.BinaryExpr.MAX,
       ReductionOp.intersection: edgir.BinaryExpr.INTERSECTION,
+      ReductionOp.hull: edgir.BinaryExpr.HULL,
     }
 
     super().__init__()
@@ -706,6 +707,9 @@ class RangeExpr(NumLikeExpr['RangeExpr', RangeLike, Tuple[float, float]]):
 
   def intersect(self, other: RangeLike) -> RangeExpr:
     return self._create_binary_op(self._to_expr_type(other), self, ReductionOp.intersection)
+
+  def hull(self, other: RangeLike) -> RangeExpr:
+    return self._create_binary_op(self._to_expr_type(other), self, ReductionOp.hull)
 
   def lower(self) -> FloatExpr:
     return self._lower

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -26,8 +26,9 @@ class ReductionOp(Enum):
   all_equal = 4
   all_unique = 5
   intersection = 6
-  op_and = 7,
-  op_or = 8,
+  hull = 7
+  op_and = 8
+  op_or = 9
 
 
 class BinaryNumOp(Enum):
@@ -214,6 +215,7 @@ class ReductionOpBinding(Binding):
       ReductionOp.all_equal: edgir.ReductionExpr.ALL_EQ,
       ReductionOp.all_unique: edgir.ReductionExpr.ALL_UNIQUE,
       ReductionOp.intersection: edgir.ReductionExpr.INTERSECTION,
+      ReductionOp.hull: edgir.ReductionExpr.HULL,
       ReductionOp.op_and: edgir.ReductionExpr.ALL_TRUE,
       ReductionOp.op_or: edgir.ReductionExpr.ANY_TRUE,
     }

--- a/edg_core/edgir/common_pb2.py
+++ b/edg_core/edgir/common_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -19,9 +18,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='common.proto',
   package='edg.common',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\x0c\x63ommon.proto\x12\nedg.common\"\x99\x04\n\x08Metadata\x12$\n\x07unknown\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12\x0f\n\x05known\x18\x02 \x01(\tH\x00\x12/\n\x07members\x18\x65 \x01(\x0b\x32\x1c.edg.common.Metadata.MembersH\x01\x12\x13\n\ttext_leaf\x18\x66 \x01(\tH\x01\x12\x12\n\x08\x62in_leaf\x18g \x01(\x0cH\x01\x12\x33\n\x0esource_locator\x18n \x01(\x0b\x32\x19.edg.common.SourceLocatorH\x01\x12\x35\n\x0fnamespace_order\x18o \x01(\x0b\x32\x1a.edg.common.NamespaceOrderH\x01\x12\"\n\x05\x65rror\x18p \x01(\x0b\x32\x11.edg.common.ErrorH\x01\x12+\n\ncopper_net\x18x \x01(\x0b\x32\x15.edg.common.CopperNetH\x01\x12*\n\tfootprint\x18y \x01(\x0b\x32\x15.edg.common.FootprintH\x01\x1a\x82\x01\n\x07Members\x12\x34\n\x04node\x18\n \x03(\x0b\x32&.edg.common.Metadata.Members.NodeEntry\x1a\x41\n\tNodeEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12#\n\x05value\x18\x02 \x01(\x0b\x32\x14.edg.common.Metadata:\x02\x38\x01\x42\x06\n\x04typeB\x06\n\x04meta\"\xc7\x01\n\rSourceLocator\x12\x14\n\x0c\x66ile_package\x18\x01 \x01(\t\x12\x13\n\x0bline_offset\x18\x02 \x01(\x05\x12\x12\n\ncol_offset\x18\x03 \x01(\x05\x12\x39\n\x0bsource_type\x18\x04 \x01(\x0e\x32$.edg.common.SourceLocator.SourceType\"<\n\nSourceType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0e\n\nDEFINITION\x10\x01\x12\x11\n\rINSTANTIATION\x10\x02\"\x1f\n\x0eNamespaceOrder\x12\r\n\x05names\x18\x01 \x03(\t\"V\n\x05\x45rror\x12\x0f\n\x07message\x18\x01 \x01(\t\x12\x11\n\ttraceback\x18\x03 \x01(\t\x12)\n\x06source\x18\x02 \x03(\x0b\x32\x19.edg.common.SourceLocator\"\x0b\n\tCopperNet\"\xd2\x01\n\tFootprint\x12\x15\n\rrefdes_prefix\x18\x01 \x01(\t\x12\x16\n\x0e\x66ootprint_name\x18\x15 \x01(\t\x12\x33\n\x07pinning\x18\x03 \x03(\x0b\x32\".edg.common.Footprint.PinningEntry\x12\x0c\n\x04part\x18\n \x01(\t\x12\x14\n\x0cmanufacturer\x18\x0b \x01(\t\x12\r\n\x05value\x18\x0c \x01(\t\x1a.\n\x0cPinningEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x07\n\x05\x45mptyb\x06proto3')
 )
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -33,19 +32,19 @@ _SOURCELOCATOR_SOURCETYPE = _descriptor.EnumDescriptor(
   values=[
     _descriptor.EnumValueDescriptor(
       name='UNKNOWN', index=0, number=0,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='DEFINITION', index=1, number=1,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='INSTANTIATION', index=2, number=2,
-      options=None,
+      serialized_options=None,
       type=None),
   ],
   containing_type=None,
-  options=None,
+  serialized_options=None,
   serialized_start=708,
   serialized_end=768,
 )
@@ -65,21 +64,21 @@ _METADATA_MEMBERS_NODEENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.common.Metadata.Members.NodeEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -102,14 +101,14 @@ _METADATA_MEMBERS = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_METADATA_MEMBERS_NODEENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -132,77 +131,77 @@ _METADATA = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='known', full_name='edg.common.Metadata.known', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='members', full_name='edg.common.Metadata.members', index=2,
       number=101, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='text_leaf', full_name='edg.common.Metadata.text_leaf', index=3,
       number=102, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='bin_leaf', full_name='edg.common.Metadata.bin_leaf', index=4,
       number=103, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='source_locator', full_name='edg.common.Metadata.source_locator', index=5,
       number=110, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='namespace_order', full_name='edg.common.Metadata.namespace_order', index=6,
       number=111, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='error', full_name='edg.common.Metadata.error', index=7,
       number=112, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='copper_net', full_name='edg.common.Metadata.copper_net', index=8,
       number=120, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='footprint', full_name='edg.common.Metadata.footprint', index=9,
       number=121, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_METADATA_MEMBERS, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -232,28 +231,28 @@ _SOURCELOCATOR = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='line_offset', full_name='edg.common.SourceLocator.line_offset', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='col_offset', full_name='edg.common.SourceLocator.col_offset', index=2,
       number=3, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='source_type', full_name='edg.common.SourceLocator.source_type', index=3,
       number=4, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -261,7 +260,7 @@ _SOURCELOCATOR = _descriptor.Descriptor(
   enum_types=[
     _SOURCELOCATOR_SOURCETYPE,
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -285,14 +284,14 @@ _NAMESPACEORDER = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -316,28 +315,28 @@ _ERROR = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='traceback', full_name='edg.common.Error.traceback', index=1,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='source', full_name='edg.common.Error.source', index=2,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -361,7 +360,7 @@ _COPPERNET = _descriptor.Descriptor(
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -385,21 +384,21 @@ _FOOTPRINT_PINNINGENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.common.Footprint.PinningEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -422,49 +421,49 @@ _FOOTPRINT = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='footprint_name', full_name='edg.common.Footprint.footprint_name', index=1,
       number=21, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='pinning', full_name='edg.common.Footprint.pinning', index=2,
       number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='part', full_name='edg.common.Footprint.part', index=3,
       number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='manufacturer', full_name='edg.common.Footprint.manufacturer', index=4,
       number=11, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.common.Footprint.value', index=5,
       number=12, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_FOOTPRINT_PINNINGENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -488,7 +487,7 @@ _EMPTY = _descriptor.Descriptor(
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -551,6 +550,7 @@ DESCRIPTOR.message_types_by_name['Error'] = _ERROR
 DESCRIPTOR.message_types_by_name['CopperNet'] = _COPPERNET
 DESCRIPTOR.message_types_by_name['Footprint'] = _FOOTPRINT
 DESCRIPTOR.message_types_by_name['Empty'] = _EMPTY
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Metadata = _reflection.GeneratedProtocolMessageType('Metadata', (_message.Message,), dict(
 
@@ -626,8 +626,6 @@ Empty = _reflection.GeneratedProtocolMessageType('Empty', (_message.Message,), d
 _sym_db.RegisterMessage(Empty)
 
 
-_METADATA_MEMBERS_NODEENTRY.has_options = True
-_METADATA_MEMBERS_NODEENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_FOOTPRINT_PINNINGENTRY.has_options = True
-_FOOTPRINT_PINNINGENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_METADATA_MEMBERS_NODEENTRY._options = None
+_FOOTPRINT_PINNINGENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/edg_core/edgir/elem_pb2.py
+++ b/edg_core/edgir/elem_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -23,10 +22,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='elem.proto',
   package='edg.elem',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\nelem.proto\x12\x08\x65\x64g.elem\x1a\x0c\x63ommon.proto\x1a\ninit.proto\x1a\nexpr.proto\x1a\tref.proto\"\xed\x02\n\x04Port\x12*\n\x06params\x18\n \x03(\x0b\x32\x1a.edg.elem.Port.ParamsEntry\x12\x34\n\x0b\x63onstraints\x18\x0b \x03(\x0b\x32\x1f.edg.elem.Port.ConstraintsEntry\x12(\n\nself_class\x18\x14 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12*\n\x0csuperclasses\x18\x15 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xe1\x03\n\x06\x42undle\x12,\n\x06params\x18\n \x03(\x0b\x32\x1c.edg.elem.Bundle.ParamsEntry\x12*\n\x05ports\x18\x0b \x03(\x0b\x32\x1b.edg.elem.Bundle.PortsEntry\x12\x36\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32!.edg.elem.Bundle.ConstraintsEntry\x12(\n\nself_class\x18\x14 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12*\n\x0csuperclasses\x18\x15 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xca\x01\n\tPortArray\x12(\n\nself_class\x18\x14 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x05ports\x18\r \x03(\x0b\x32\x1e.edg.elem.PortArray.PortsEntry\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\"\xcc\x01\n\x08PortLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12\x1e\n\x04port\x18\x03 \x01(\x0b\x32\x0e.edg.elem.PortH\x00\x12$\n\x05\x61rray\x18\x04 \x01(\x0b\x32\x13.edg.elem.PortArrayH\x00\x12\"\n\x06\x62undle\x18\x06 \x01(\x0b\x32\x10.edg.elem.BundleH\x00\x42\x04\n\x02is\"\xbb\x07\n\x0eHierarchyBlock\x12\x34\n\x06params\x18\n \x03(\x0b\x32$.edg.elem.HierarchyBlock.ParamsEntry\x12\x32\n\x05ports\x18\x0b \x03(\x0b\x32#.edg.elem.HierarchyBlock.PortsEntry\x12\x34\n\x06\x62locks\x18\x0c \x03(\x0b\x32$.edg.elem.HierarchyBlock.BlocksEntry\x12\x32\n\x05links\x18\r \x03(\x0b\x32#.edg.elem.HierarchyBlock.LinksEntry\x12>\n\x0b\x63onstraints\x18\x0e \x03(\x0b\x32).edg.elem.HierarchyBlock.ConstraintsEntry\x12(\n\nself_class\x18\x17 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12*\n\x0csuperclasses\x18\x14 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x0fprerefine_class\x18\x15 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12<\n\ngenerators\x18\x16 \x03(\x0b\x32(.edg.elem.HierarchyBlock.GeneratorsEntry\x12\x13\n\x0bis_abstract\x18\x1e \x01(\x08\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1a\x42\n\x0b\x42locksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.elem.BlockLike:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\x1a\x46\n\x0fGeneratorsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.elem.Generator:\x02\x38\x01\"\x9e\x01\n\tGenerator\x12\n\n\x02\x66n\x18\x01 \x01(\t\x12+\n\x0frequired_params\x18\x02 \x03(\x0b\x32\x12.edg.ref.LocalPath\x12*\n\x0erequired_ports\x18\x03 \x03(\x0b\x32\x12.edg.ref.LocalPath\x12,\n\x10\x63onnected_blocks\x18\x04 \x03(\x0b\x32\x12.edg.ref.LocalPath\"\x94\x01\n\tBlockLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12-\n\thierarchy\x18\x04 \x01(\x0b\x32\x18.edg.elem.HierarchyBlockH\x00\x42\x06\n\x04type\"\xc5\x04\n\x04Link\x12*\n\x06params\x18\n \x03(\x0b\x32\x1a.edg.elem.Link.ParamsEntry\x12(\n\x05ports\x18\x0b \x03(\x0b\x32\x19.edg.elem.Link.PortsEntry\x12(\n\x05links\x18\r \x03(\x0b\x32\x19.edg.elem.Link.LinksEntry\x12\x34\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32\x1f.edg.elem.Link.ConstraintsEntry\x12(\n\nself_class\x18\x14 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12*\n\x0csuperclasses\x18\x15 \x03(\x0b\x32\x14.edg.ref.LibraryPath\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\x0bParamsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.init.ValInit:\x02\x38\x01\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\xbf\x03\n\tLinkArray\x12(\n\nself_class\x18\x14 \x01(\x0b\x32\x14.edg.ref.LibraryPath\x12-\n\x05ports\x18\x0b \x03(\x0b\x32\x1e.edg.elem.LinkArray.PortsEntry\x12\x39\n\x0b\x63onstraints\x18\x0c \x03(\x0b\x32$.edg.elem.LinkArray.ConstraintsEntry\x12-\n\x05links\x18\r \x03(\x0b\x32\x1e.edg.elem.LinkArray.LinksEntry\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a@\n\nPortsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.PortLike:\x02\x38\x01\x1aG\n\x10\x43onstraintsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\x1a@\n\nLinksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12!\n\x05value\x18\x02 \x01(\x0b\x32\x12.edg.elem.LinkLike:\x02\x38\x01\"\xaa\x01\n\x08LinkLike\x12&\n\tundefined\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12(\n\x08lib_elem\x18\x02 \x01(\x0b\x32\x14.edg.ref.LibraryPathH\x00\x12\x1e\n\x04link\x18\x03 \x01(\x0b\x32\x0e.edg.elem.LinkH\x00\x12$\n\x05\x61rray\x18\x04 \x01(\x0b\x32\x13.edg.elem.LinkArrayH\x00\x42\x06\n\x04typeb\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,init__pb2.DESCRIPTOR,expr__pb2.DESCRIPTOR,ref__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -44,21 +43,21 @@ _PORT_PARAMSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Port.ParamsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -81,21 +80,21 @@ _PORT_CONSTRAINTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Port.ConstraintsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -118,42 +117,42 @@ _PORT = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='constraints', full_name='edg.elem.Port.constraints', index=1,
       number=11, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='self_class', full_name='edg.elem.Port.self_class', index=2,
       number=20, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='superclasses', full_name='edg.elem.Port.superclasses', index=3,
       number=21, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.elem.Port.meta', index=4,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_PORT_PARAMSENTRY, _PORT_CONSTRAINTSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -177,21 +176,21 @@ _BUNDLE_PARAMSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Bundle.ParamsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -214,21 +213,21 @@ _BUNDLE_PORTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Bundle.PortsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -251,21 +250,21 @@ _BUNDLE_CONSTRAINTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Bundle.ConstraintsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -288,49 +287,49 @@ _BUNDLE = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ports', full_name='edg.elem.Bundle.ports', index=1,
       number=11, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='constraints', full_name='edg.elem.Bundle.constraints', index=2,
       number=12, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='self_class', full_name='edg.elem.Bundle.self_class', index=3,
       number=20, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='superclasses', full_name='edg.elem.Bundle.superclasses', index=4,
       number=21, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.elem.Bundle.meta', index=5,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_BUNDLE_PARAMSENTRY, _BUNDLE_PORTSENTRY, _BUNDLE_CONSTRAINTSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -354,21 +353,21 @@ _PORTARRAY_PORTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.PortArray.PortsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -391,28 +390,28 @@ _PORTARRAY = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ports', full_name='edg.elem.PortArray.ports', index=1,
       number=13, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.elem.PortArray.meta', index=2,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_PORTARRAY_PORTSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -436,42 +435,42 @@ _PORTLIKE = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='lib_elem', full_name='edg.elem.PortLike.lib_elem', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='port', full_name='edg.elem.PortLike.port', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='array', full_name='edg.elem.PortLike.array', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='bundle', full_name='edg.elem.PortLike.bundle', index=4,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -498,21 +497,21 @@ _HIERARCHYBLOCK_PARAMSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.HierarchyBlock.ParamsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -535,21 +534,21 @@ _HIERARCHYBLOCK_PORTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.HierarchyBlock.PortsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -572,21 +571,21 @@ _HIERARCHYBLOCK_BLOCKSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.HierarchyBlock.BlocksEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -609,21 +608,21 @@ _HIERARCHYBLOCK_LINKSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.HierarchyBlock.LinksEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -646,21 +645,21 @@ _HIERARCHYBLOCK_CONSTRAINTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.HierarchyBlock.ConstraintsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -683,21 +682,21 @@ _HIERARCHYBLOCK_GENERATORSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.HierarchyBlock.GeneratorsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -720,84 +719,84 @@ _HIERARCHYBLOCK = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ports', full_name='edg.elem.HierarchyBlock.ports', index=1,
       number=11, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='blocks', full_name='edg.elem.HierarchyBlock.blocks', index=2,
       number=12, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='links', full_name='edg.elem.HierarchyBlock.links', index=3,
       number=13, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='constraints', full_name='edg.elem.HierarchyBlock.constraints', index=4,
       number=14, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='self_class', full_name='edg.elem.HierarchyBlock.self_class', index=5,
       number=23, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='superclasses', full_name='edg.elem.HierarchyBlock.superclasses', index=6,
       number=20, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='prerefine_class', full_name='edg.elem.HierarchyBlock.prerefine_class', index=7,
       number=21, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='generators', full_name='edg.elem.HierarchyBlock.generators', index=8,
       number=22, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='is_abstract', full_name='edg.elem.HierarchyBlock.is_abstract', index=9,
       number=30, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.elem.HierarchyBlock.meta', index=10,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_HIERARCHYBLOCK_PARAMSENTRY, _HIERARCHYBLOCK_PORTSENTRY, _HIERARCHYBLOCK_BLOCKSENTRY, _HIERARCHYBLOCK_LINKSENTRY, _HIERARCHYBLOCK_CONSTRAINTSENTRY, _HIERARCHYBLOCK_GENERATORSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -821,35 +820,35 @@ _GENERATOR = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='required_params', full_name='edg.elem.Generator.required_params', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='required_ports', full_name='edg.elem.Generator.required_ports', index=2,
       number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='connected_blocks', full_name='edg.elem.Generator.connected_blocks', index=3,
       number=4, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -873,28 +872,28 @@ _BLOCKLIKE = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='lib_elem', full_name='edg.elem.BlockLike.lib_elem', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='hierarchy', full_name='edg.elem.BlockLike.hierarchy', index=2,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -921,21 +920,21 @@ _LINK_PARAMSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Link.ParamsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -958,21 +957,21 @@ _LINK_PORTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Link.PortsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -995,21 +994,21 @@ _LINK_LINKSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Link.LinksEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1032,21 +1031,21 @@ _LINK_CONSTRAINTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.Link.ConstraintsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1069,56 +1068,56 @@ _LINK = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ports', full_name='edg.elem.Link.ports', index=1,
       number=11, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='links', full_name='edg.elem.Link.links', index=2,
       number=13, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='constraints', full_name='edg.elem.Link.constraints', index=3,
       number=12, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='self_class', full_name='edg.elem.Link.self_class', index=4,
       number=20, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='superclasses', full_name='edg.elem.Link.superclasses', index=5,
       number=21, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.elem.Link.meta', index=6,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_LINK_PARAMSENTRY, _LINK_PORTSENTRY, _LINK_LINKSENTRY, _LINK_CONSTRAINTSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1142,21 +1141,21 @@ _LINKARRAY_PORTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.LinkArray.PortsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1179,21 +1178,21 @@ _LINKARRAY_CONSTRAINTSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.LinkArray.ConstraintsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1216,21 +1215,21 @@ _LINKARRAY_LINKSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.elem.LinkArray.LinksEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1253,42 +1252,42 @@ _LINKARRAY = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ports', full_name='edg.elem.LinkArray.ports', index=1,
       number=11, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='constraints', full_name='edg.elem.LinkArray.constraints', index=2,
       number=12, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='links', full_name='edg.elem.LinkArray.links', index=3,
       number=13, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.elem.LinkArray.meta', index=4,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_LINKARRAY_PORTSENTRY, _LINKARRAY_CONSTRAINTSENTRY, _LINKARRAY_LINKSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1312,35 +1311,35 @@ _LINKLIKE = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='lib_elem', full_name='edg.elem.LinkLike.lib_elem', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='link', full_name='edg.elem.LinkLike.link', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='array', full_name='edg.elem.LinkLike.array', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -1488,6 +1487,7 @@ DESCRIPTOR.message_types_by_name['BlockLike'] = _BLOCKLIKE
 DESCRIPTOR.message_types_by_name['Link'] = _LINK
 DESCRIPTOR.message_types_by_name['LinkArray'] = _LINKARRAY
 DESCRIPTOR.message_types_by_name['LinkLike'] = _LINKLIKE
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Port = _reflection.GeneratedProtocolMessageType('Port', (_message.Message,), dict(
 
@@ -1712,42 +1712,23 @@ LinkLike = _reflection.GeneratedProtocolMessageType('LinkLike', (_message.Messag
 _sym_db.RegisterMessage(LinkLike)
 
 
-_PORT_PARAMSENTRY.has_options = True
-_PORT_PARAMSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_PORT_CONSTRAINTSENTRY.has_options = True
-_PORT_CONSTRAINTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_BUNDLE_PARAMSENTRY.has_options = True
-_BUNDLE_PARAMSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_BUNDLE_PORTSENTRY.has_options = True
-_BUNDLE_PORTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_BUNDLE_CONSTRAINTSENTRY.has_options = True
-_BUNDLE_CONSTRAINTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_PORTARRAY_PORTSENTRY.has_options = True
-_PORTARRAY_PORTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_HIERARCHYBLOCK_PARAMSENTRY.has_options = True
-_HIERARCHYBLOCK_PARAMSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_HIERARCHYBLOCK_PORTSENTRY.has_options = True
-_HIERARCHYBLOCK_PORTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_HIERARCHYBLOCK_BLOCKSENTRY.has_options = True
-_HIERARCHYBLOCK_BLOCKSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_HIERARCHYBLOCK_LINKSENTRY.has_options = True
-_HIERARCHYBLOCK_LINKSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_HIERARCHYBLOCK_CONSTRAINTSENTRY.has_options = True
-_HIERARCHYBLOCK_CONSTRAINTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_HIERARCHYBLOCK_GENERATORSENTRY.has_options = True
-_HIERARCHYBLOCK_GENERATORSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINK_PARAMSENTRY.has_options = True
-_LINK_PARAMSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINK_PORTSENTRY.has_options = True
-_LINK_PORTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINK_LINKSENTRY.has_options = True
-_LINK_LINKSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINK_CONSTRAINTSENTRY.has_options = True
-_LINK_CONSTRAINTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINKARRAY_PORTSENTRY.has_options = True
-_LINKARRAY_PORTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINKARRAY_CONSTRAINTSENTRY.has_options = True
-_LINKARRAY_CONSTRAINTSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_LINKARRAY_LINKSENTRY.has_options = True
-_LINKARRAY_LINKSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_PORT_PARAMSENTRY._options = None
+_PORT_CONSTRAINTSENTRY._options = None
+_BUNDLE_PARAMSENTRY._options = None
+_BUNDLE_PORTSENTRY._options = None
+_BUNDLE_CONSTRAINTSENTRY._options = None
+_PORTARRAY_PORTSENTRY._options = None
+_HIERARCHYBLOCK_PARAMSENTRY._options = None
+_HIERARCHYBLOCK_PORTSENTRY._options = None
+_HIERARCHYBLOCK_BLOCKSENTRY._options = None
+_HIERARCHYBLOCK_LINKSENTRY._options = None
+_HIERARCHYBLOCK_CONSTRAINTSENTRY._options = None
+_HIERARCHYBLOCK_GENERATORSENTRY._options = None
+_LINK_PARAMSENTRY._options = None
+_LINK_PORTSENTRY._options = None
+_LINK_LINKSENTRY._options = None
+_LINK_CONSTRAINTSENTRY._options = None
+_LINKARRAY_PORTSENTRY._options = None
+_LINKARRAY_CONSTRAINTSENTRY._options = None
+_LINKARRAY_LINKSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/edg_core/edgir/expr_pb2.py
+++ b/edg_core/edgir/expr_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='edg.expr',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\nexpr.proto\x12\x08\x65\x64g.expr\x1a\nname.proto\x1a\tref.proto\x1a\x0c\x63ommon.proto\x1a\tlit.proto\x1a\ntype.proto\"\xc5\x02\n\nBinaryExpr\x12#\n\x02op\x18\x01 \x01(\x0e\x32\x17.edg.expr.BinaryExpr.Op\x12 \n\x03lhs\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03rhs\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xcd\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03\x41\x44\x44\x10\n\x12\x07\n\x03SUB\x10\x0b\x12\x08\n\x04MULT\x10\x0c\x12\x07\n\x03\x44IV\x10\r\x12\x07\n\x03\x41ND\x10\x14\x12\x06\n\x02OR\x10\x15\x12\x07\n\x03XOR\x10\x16\x12\x0b\n\x07IMPLIES\x10\x17\x12\x06\n\x02\x45Q\x10\x1e\x12\x07\n\x03NEQ\x10\x1f\x12\x06\n\x02GT\x10(\x12\x07\n\x03GTE\x10)\x12\x06\n\x02LT\x10*\x12\x07\n\x03LTE\x10,\x12\x07\n\x03MAX\x10-\x12\x07\n\x03MIN\x10.\x12\x10\n\x0cINTERSECTION\x10\x33\x12\n\n\x06SUBSET\x10\x35\x12\t\n\x05RANGE\x10\x01\"\xf8\x01\n\rReductionExpr\x12&\n\x02op\x18\x01 \x01(\x0e\x32\x1a.edg.expr.ReductionExpr.Op\x12!\n\x04vals\x18\x04 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\x9b\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03SUM\x10\x01\x12\x0c\n\x08\x41LL_TRUE\x10\x02\x12\x0c\n\x08\x41NY_TRUE\x10\x03\x12\n\n\x06\x41LL_EQ\x10\x04\x12\x0e\n\nALL_UNIQUE\x10\x05\x12\x0b\n\x07MAXIMUM\x10\n\x12\x0b\n\x07MINIMUM\x10\x0b\x12\x0f\n\x0bSET_EXTRACT\x10\x0c\x12\x10\n\x0cINTERSECTION\x10\r\x12\x08\n\x04HULL\x10\x0e\"W\n\tRangeExpr\x12$\n\x07minimum\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12$\n\x07maximum\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"|\n\nStructExpr\x12,\n\x04vals\x18\x01 \x03(\x0b\x32\x1e.edg.expr.StructExpr.ValsEntry\x1a@\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\x9b\x01\n\x0eIfThenElseExpr\x12!\n\x04\x63ond\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03tru\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03\x66\x61l\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\"Y\n\x0b\x45xtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x05index\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"Z\n\x0eMapExtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x04path\x18\x02 \x01(\x0b\x32\x12.edg.ref.LocalPath\"`\n\rConnectedExpr\x12\'\n\nblock_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12&\n\tlink_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"l\n\x0c\x45xportedExpr\x12*\n\rexterior_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\x30\n\x13internal_block_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"O\n\nAssignExpr\x12\x1f\n\x03\x64st\x18\x01 \x01(\x0b\x32\x12.edg.ref.LocalPath\x12 \n\x03src\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xae\x04\n\tValueExpr\x12$\n\x07literal\x18\x01 \x01(\x0b\x32\x11.edg.lit.ValueLitH\x00\x12&\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x14.edg.expr.BinaryExprH\x00\x12)\n\x06reduce\x18\x04 \x01(\x0b\x32\x17.edg.expr.ReductionExprH\x00\x12&\n\x06struct\x18\x07 \x01(\x0b\x32\x14.edg.expr.StructExprH\x00\x12$\n\x05range\x18\x08 \x01(\x0b\x32\x13.edg.expr.RangeExprH\x00\x12.\n\nifThenElse\x18\n \x01(\x0b\x32\x18.edg.expr.IfThenElseExprH\x00\x12(\n\x07\x65xtract\x18\x0c \x01(\x0b\x32\x15.edg.expr.ExtractExprH\x00\x12/\n\x0bmap_extract\x18\x0e \x01(\x0b\x32\x18.edg.expr.MapExtractExprH\x00\x12,\n\tconnected\x18\x0f \x01(\x0b\x32\x17.edg.expr.ConnectedExprH\x00\x12*\n\x08\x65xported\x18\x10 \x01(\x0b\x32\x16.edg.expr.ExportedExprH\x00\x12&\n\x06\x61ssign\x18\x11 \x01(\x0b\x32\x14.edg.expr.AssignExprH\x00\x12!\n\x03ref\x18\x63 \x01(\x0b\x32\x12.edg.ref.LocalPathH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x06\n\x04\x65xprb\x06proto3')
+  serialized_pb=_b('\n\nexpr.proto\x12\x08\x65\x64g.expr\x1a\nname.proto\x1a\tref.proto\x1a\x0c\x63ommon.proto\x1a\tlit.proto\x1a\ntype.proto\"\xcf\x02\n\nBinaryExpr\x12#\n\x02op\x18\x01 \x01(\x0e\x32\x17.edg.expr.BinaryExpr.Op\x12 \n\x03lhs\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03rhs\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xd7\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03\x41\x44\x44\x10\n\x12\x07\n\x03SUB\x10\x0b\x12\x08\n\x04MULT\x10\x0c\x12\x07\n\x03\x44IV\x10\r\x12\x07\n\x03\x41ND\x10\x14\x12\x06\n\x02OR\x10\x15\x12\x07\n\x03XOR\x10\x16\x12\x0b\n\x07IMPLIES\x10\x17\x12\x06\n\x02\x45Q\x10\x1e\x12\x07\n\x03NEQ\x10\x1f\x12\x06\n\x02GT\x10(\x12\x07\n\x03GTE\x10)\x12\x06\n\x02LT\x10*\x12\x07\n\x03LTE\x10,\x12\x07\n\x03MAX\x10-\x12\x07\n\x03MIN\x10.\x12\x10\n\x0cINTERSECTION\x10\x33\x12\x08\n\x04HULL\x10\x36\x12\n\n\x06SUBSET\x10\x35\x12\t\n\x05RANGE\x10\x01\"\xf8\x01\n\rReductionExpr\x12&\n\x02op\x18\x01 \x01(\x0e\x32\x1a.edg.expr.ReductionExpr.Op\x12!\n\x04vals\x18\x04 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\x9b\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03SUM\x10\x01\x12\x0c\n\x08\x41LL_TRUE\x10\x02\x12\x0c\n\x08\x41NY_TRUE\x10\x03\x12\n\n\x06\x41LL_EQ\x10\x04\x12\x0e\n\nALL_UNIQUE\x10\x05\x12\x0b\n\x07MAXIMUM\x10\n\x12\x0b\n\x07MINIMUM\x10\x0b\x12\x0f\n\x0bSET_EXTRACT\x10\x0c\x12\x10\n\x0cINTERSECTION\x10\r\x12\x08\n\x04HULL\x10\x0e\"W\n\tRangeExpr\x12$\n\x07minimum\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12$\n\x07maximum\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"|\n\nStructExpr\x12,\n\x04vals\x18\x01 \x03(\x0b\x32\x1e.edg.expr.StructExpr.ValsEntry\x1a@\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\x9b\x01\n\x0eIfThenElseExpr\x12!\n\x04\x63ond\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03tru\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03\x66\x61l\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\"Y\n\x0b\x45xtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x05index\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"Z\n\x0eMapExtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x04path\x18\x02 \x01(\x0b\x32\x12.edg.ref.LocalPath\"`\n\rConnectedExpr\x12\'\n\nblock_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12&\n\tlink_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"l\n\x0c\x45xportedExpr\x12*\n\rexterior_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\x30\n\x13internal_block_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"O\n\nAssignExpr\x12\x1f\n\x03\x64st\x18\x01 \x01(\x0b\x32\x12.edg.ref.LocalPath\x12 \n\x03src\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xae\x04\n\tValueExpr\x12$\n\x07literal\x18\x01 \x01(\x0b\x32\x11.edg.lit.ValueLitH\x00\x12&\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x14.edg.expr.BinaryExprH\x00\x12)\n\x06reduce\x18\x04 \x01(\x0b\x32\x17.edg.expr.ReductionExprH\x00\x12&\n\x06struct\x18\x07 \x01(\x0b\x32\x14.edg.expr.StructExprH\x00\x12$\n\x05range\x18\x08 \x01(\x0b\x32\x13.edg.expr.RangeExprH\x00\x12.\n\nifThenElse\x18\n \x01(\x0b\x32\x18.edg.expr.IfThenElseExprH\x00\x12(\n\x07\x65xtract\x18\x0c \x01(\x0b\x32\x15.edg.expr.ExtractExprH\x00\x12/\n\x0bmap_extract\x18\x0e \x01(\x0b\x32\x18.edg.expr.MapExtractExprH\x00\x12,\n\tconnected\x18\x0f \x01(\x0b\x32\x17.edg.expr.ConnectedExprH\x00\x12*\n\x08\x65xported\x18\x10 \x01(\x0b\x32\x16.edg.expr.ExportedExprH\x00\x12&\n\x06\x61ssign\x18\x11 \x01(\x0b\x32\x14.edg.expr.AssignExprH\x00\x12!\n\x03ref\x18\x63 \x01(\x0b\x32\x12.edg.ref.LocalPathH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x06\n\x04\x65xprb\x06proto3')
   ,
   dependencies=[name__pb2.DESCRIPTOR,ref__pb2.DESCRIPTOR,common__pb2.DESCRIPTOR,lit__pb2.DESCRIPTOR,type__pb2.DESCRIPTOR,])
 
@@ -109,18 +109,22 @@ _BINARYEXPR_OP = _descriptor.EnumDescriptor(
       serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='SUBSET', index=18, number=53,
+      name='HULL', index=18, number=54,
       serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='RANGE', index=19, number=1,
+      name='SUBSET', index=19, number=53,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='RANGE', index=20, number=1,
       serialized_options=None,
       type=None),
   ],
   containing_type=None,
   serialized_options=None,
   serialized_start=205,
-  serialized_end=410,
+  serialized_end=420,
 )
 _sym_db.RegisterEnumDescriptor(_BINARYEXPR_OP)
 
@@ -177,8 +181,8 @@ _REDUCTIONEXPR_OP = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=506,
-  serialized_end=661,
+  serialized_start=516,
+  serialized_end=671,
 )
 _sym_db.RegisterEnumDescriptor(_REDUCTIONEXPR_OP)
 
@@ -225,7 +229,7 @@ _BINARYEXPR = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=85,
-  serialized_end=410,
+  serialized_end=420,
 )
 
 
@@ -263,8 +267,8 @@ _REDUCTIONEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=413,
-  serialized_end=661,
+  serialized_start=423,
+  serialized_end=671,
 )
 
 
@@ -301,8 +305,8 @@ _RANGEEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=663,
-  serialized_end=750,
+  serialized_start=673,
+  serialized_end=760,
 )
 
 
@@ -339,8 +343,8 @@ _STRUCTEXPR_VALSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=812,
-  serialized_end=876,
+  serialized_start=822,
+  serialized_end=886,
 )
 
 _STRUCTEXPR = _descriptor.Descriptor(
@@ -369,8 +373,8 @@ _STRUCTEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=752,
-  serialized_end=876,
+  serialized_start=762,
+  serialized_end=886,
 )
 
 
@@ -421,8 +425,8 @@ _IFTHENELSEEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=879,
-  serialized_end=1034,
+  serialized_start=889,
+  serialized_end=1044,
 )
 
 
@@ -459,8 +463,8 @@ _EXTRACTEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1036,
-  serialized_end=1125,
+  serialized_start=1046,
+  serialized_end=1135,
 )
 
 
@@ -497,8 +501,8 @@ _MAPEXTRACTEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1127,
-  serialized_end=1217,
+  serialized_start=1137,
+  serialized_end=1227,
 )
 
 
@@ -535,8 +539,8 @@ _CONNECTEDEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1219,
-  serialized_end=1315,
+  serialized_start=1229,
+  serialized_end=1325,
 )
 
 
@@ -573,8 +577,8 @@ _EXPORTEDEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1317,
-  serialized_end=1425,
+  serialized_start=1327,
+  serialized_end=1435,
 )
 
 
@@ -611,8 +615,8 @@ _ASSIGNEXPR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1427,
-  serialized_end=1506,
+  serialized_start=1437,
+  serialized_end=1516,
 )
 
 
@@ -729,8 +733,8 @@ _VALUEEXPR = _descriptor.Descriptor(
       name='expr', full_name='edg.expr.ValueExpr.expr',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1509,
-  serialized_end=2067,
+  serialized_start=1519,
+  serialized_end=2077,
 )
 
 _BINARYEXPR.fields_by_name['op'].enum_type = _BINARYEXPR_OP

--- a/edg_core/edgir/expr_pb2.py
+++ b/edg_core/edgir/expr_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -24,10 +23,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='expr.proto',
   package='edg.expr',
   syntax='proto3',
-  serialized_pb=_b('\n\nexpr.proto\x12\x08\x65\x64g.expr\x1a\nname.proto\x1a\tref.proto\x1a\x0c\x63ommon.proto\x1a\tlit.proto\x1a\ntype.proto\"\xc5\x02\n\nBinaryExpr\x12#\n\x02op\x18\x01 \x01(\x0e\x32\x17.edg.expr.BinaryExpr.Op\x12 \n\x03lhs\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03rhs\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xcd\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03\x41\x44\x44\x10\n\x12\x07\n\x03SUB\x10\x0b\x12\x08\n\x04MULT\x10\x0c\x12\x07\n\x03\x44IV\x10\r\x12\x07\n\x03\x41ND\x10\x14\x12\x06\n\x02OR\x10\x15\x12\x07\n\x03XOR\x10\x16\x12\x0b\n\x07IMPLIES\x10\x17\x12\x06\n\x02\x45Q\x10\x1e\x12\x07\n\x03NEQ\x10\x1f\x12\x06\n\x02GT\x10(\x12\x07\n\x03GTE\x10)\x12\x06\n\x02LT\x10*\x12\x07\n\x03LTE\x10,\x12\x07\n\x03MAX\x10-\x12\x07\n\x03MIN\x10.\x12\x10\n\x0cINTERSECTION\x10\x33\x12\n\n\x06SUBSET\x10\x35\x12\t\n\x05RANGE\x10\x01\"\xee\x01\n\rReductionExpr\x12&\n\x02op\x18\x01 \x01(\x0e\x32\x1a.edg.expr.ReductionExpr.Op\x12!\n\x04vals\x18\x04 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\x91\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03SUM\x10\x01\x12\x0c\n\x08\x41LL_TRUE\x10\x02\x12\x0c\n\x08\x41NY_TRUE\x10\x03\x12\n\n\x06\x41LL_EQ\x10\x04\x12\x0e\n\nALL_UNIQUE\x10\x05\x12\x0b\n\x07MAXIMUM\x10\n\x12\x0b\n\x07MINIMUM\x10\x0b\x12\x0f\n\x0bSET_EXTRACT\x10\x0c\x12\x10\n\x0cINTERSECTION\x10\r\"W\n\tRangeExpr\x12$\n\x07minimum\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12$\n\x07maximum\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"|\n\nStructExpr\x12,\n\x04vals\x18\x01 \x03(\x0b\x32\x1e.edg.expr.StructExpr.ValsEntry\x1a@\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\x9b\x01\n\x0eIfThenElseExpr\x12!\n\x04\x63ond\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03tru\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03\x66\x61l\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\"Y\n\x0b\x45xtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x05index\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"Z\n\x0eMapExtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x04path\x18\x02 \x01(\x0b\x32\x12.edg.ref.LocalPath\"`\n\rConnectedExpr\x12\'\n\nblock_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12&\n\tlink_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"l\n\x0c\x45xportedExpr\x12*\n\rexterior_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\x30\n\x13internal_block_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"O\n\nAssignExpr\x12\x1f\n\x03\x64st\x18\x01 \x01(\x0b\x32\x12.edg.ref.LocalPath\x12 \n\x03src\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xae\x04\n\tValueExpr\x12$\n\x07literal\x18\x01 \x01(\x0b\x32\x11.edg.lit.ValueLitH\x00\x12&\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x14.edg.expr.BinaryExprH\x00\x12)\n\x06reduce\x18\x04 \x01(\x0b\x32\x17.edg.expr.ReductionExprH\x00\x12&\n\x06struct\x18\x07 \x01(\x0b\x32\x14.edg.expr.StructExprH\x00\x12$\n\x05range\x18\x08 \x01(\x0b\x32\x13.edg.expr.RangeExprH\x00\x12.\n\nifThenElse\x18\n \x01(\x0b\x32\x18.edg.expr.IfThenElseExprH\x00\x12(\n\x07\x65xtract\x18\x0c \x01(\x0b\x32\x15.edg.expr.ExtractExprH\x00\x12/\n\x0bmap_extract\x18\x0e \x01(\x0b\x32\x18.edg.expr.MapExtractExprH\x00\x12,\n\tconnected\x18\x0f \x01(\x0b\x32\x17.edg.expr.ConnectedExprH\x00\x12*\n\x08\x65xported\x18\x10 \x01(\x0b\x32\x16.edg.expr.ExportedExprH\x00\x12&\n\x06\x61ssign\x18\x11 \x01(\x0b\x32\x14.edg.expr.AssignExprH\x00\x12!\n\x03ref\x18\x63 \x01(\x0b\x32\x12.edg.ref.LocalPathH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x06\n\x04\x65xprb\x06proto3')
+  serialized_options=None,
+  serialized_pb=_b('\n\nexpr.proto\x12\x08\x65\x64g.expr\x1a\nname.proto\x1a\tref.proto\x1a\x0c\x63ommon.proto\x1a\tlit.proto\x1a\ntype.proto\"\xc5\x02\n\nBinaryExpr\x12#\n\x02op\x18\x01 \x01(\x0e\x32\x17.edg.expr.BinaryExpr.Op\x12 \n\x03lhs\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03rhs\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xcd\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03\x41\x44\x44\x10\n\x12\x07\n\x03SUB\x10\x0b\x12\x08\n\x04MULT\x10\x0c\x12\x07\n\x03\x44IV\x10\r\x12\x07\n\x03\x41ND\x10\x14\x12\x06\n\x02OR\x10\x15\x12\x07\n\x03XOR\x10\x16\x12\x0b\n\x07IMPLIES\x10\x17\x12\x06\n\x02\x45Q\x10\x1e\x12\x07\n\x03NEQ\x10\x1f\x12\x06\n\x02GT\x10(\x12\x07\n\x03GTE\x10)\x12\x06\n\x02LT\x10*\x12\x07\n\x03LTE\x10,\x12\x07\n\x03MAX\x10-\x12\x07\n\x03MIN\x10.\x12\x10\n\x0cINTERSECTION\x10\x33\x12\n\n\x06SUBSET\x10\x35\x12\t\n\x05RANGE\x10\x01\"\xf8\x01\n\rReductionExpr\x12&\n\x02op\x18\x01 \x01(\x0e\x32\x1a.edg.expr.ReductionExpr.Op\x12!\n\x04vals\x18\x04 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\x9b\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03SUM\x10\x01\x12\x0c\n\x08\x41LL_TRUE\x10\x02\x12\x0c\n\x08\x41NY_TRUE\x10\x03\x12\n\n\x06\x41LL_EQ\x10\x04\x12\x0e\n\nALL_UNIQUE\x10\x05\x12\x0b\n\x07MAXIMUM\x10\n\x12\x0b\n\x07MINIMUM\x10\x0b\x12\x0f\n\x0bSET_EXTRACT\x10\x0c\x12\x10\n\x0cINTERSECTION\x10\r\x12\x08\n\x04HULL\x10\x0e\"W\n\tRangeExpr\x12$\n\x07minimum\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12$\n\x07maximum\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"|\n\nStructExpr\x12,\n\x04vals\x18\x01 \x03(\x0b\x32\x1e.edg.expr.StructExpr.ValsEntry\x1a@\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr:\x02\x38\x01\"\x9b\x01\n\x0eIfThenElseExpr\x12!\n\x04\x63ond\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03tru\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x03\x66\x61l\x18\x03 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\"Y\n\x0b\x45xtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\"\n\x05index\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"Z\n\x0eMapExtractExpr\x12&\n\tcontainer\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12 \n\x04path\x18\x02 \x01(\x0b\x32\x12.edg.ref.LocalPath\"`\n\rConnectedExpr\x12\'\n\nblock_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12&\n\tlink_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"l\n\x0c\x45xportedExpr\x12*\n\rexterior_port\x18\x01 \x01(\x0b\x32\x13.edg.expr.ValueExpr\x12\x30\n\x13internal_block_port\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"O\n\nAssignExpr\x12\x1f\n\x03\x64st\x18\x01 \x01(\x0b\x32\x12.edg.ref.LocalPath\x12 \n\x03src\x18\x02 \x01(\x0b\x32\x13.edg.expr.ValueExpr\"\xae\x04\n\tValueExpr\x12$\n\x07literal\x18\x01 \x01(\x0b\x32\x11.edg.lit.ValueLitH\x00\x12&\n\x06\x62inary\x18\x02 \x01(\x0b\x32\x14.edg.expr.BinaryExprH\x00\x12)\n\x06reduce\x18\x04 \x01(\x0b\x32\x17.edg.expr.ReductionExprH\x00\x12&\n\x06struct\x18\x07 \x01(\x0b\x32\x14.edg.expr.StructExprH\x00\x12$\n\x05range\x18\x08 \x01(\x0b\x32\x13.edg.expr.RangeExprH\x00\x12.\n\nifThenElse\x18\n \x01(\x0b\x32\x18.edg.expr.IfThenElseExprH\x00\x12(\n\x07\x65xtract\x18\x0c \x01(\x0b\x32\x15.edg.expr.ExtractExprH\x00\x12/\n\x0bmap_extract\x18\x0e \x01(\x0b\x32\x18.edg.expr.MapExtractExprH\x00\x12,\n\tconnected\x18\x0f \x01(\x0b\x32\x17.edg.expr.ConnectedExprH\x00\x12*\n\x08\x65xported\x18\x10 \x01(\x0b\x32\x16.edg.expr.ExportedExprH\x00\x12&\n\x06\x61ssign\x18\x11 \x01(\x0b\x32\x14.edg.expr.AssignExprH\x00\x12!\n\x03ref\x18\x63 \x01(\x0b\x32\x12.edg.ref.LocalPathH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x06\n\x04\x65xprb\x06proto3')
   ,
   dependencies=[name__pb2.DESCRIPTOR,ref__pb2.DESCRIPTOR,common__pb2.DESCRIPTOR,lit__pb2.DESCRIPTOR,type__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -39,87 +38,87 @@ _BINARYEXPR_OP = _descriptor.EnumDescriptor(
   values=[
     _descriptor.EnumValueDescriptor(
       name='UNDEFINED', index=0, number=0,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ADD', index=1, number=10,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='SUB', index=2, number=11,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MULT', index=3, number=12,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='DIV', index=4, number=13,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='AND', index=5, number=20,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='OR', index=6, number=21,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='XOR', index=7, number=22,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='IMPLIES', index=8, number=23,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='EQ', index=9, number=30,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='NEQ', index=10, number=31,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='GT', index=11, number=40,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='GTE', index=12, number=41,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='LT', index=13, number=42,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='LTE', index=14, number=44,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MAX', index=15, number=45,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MIN', index=16, number=46,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='INTERSECTION', index=17, number=51,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='SUBSET', index=18, number=53,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='RANGE', index=19, number=1,
-      options=None,
+      serialized_options=None,
       type=None),
   ],
   containing_type=None,
-  options=None,
+  serialized_options=None,
   serialized_start=205,
   serialized_end=410,
 )
@@ -133,49 +132,53 @@ _REDUCTIONEXPR_OP = _descriptor.EnumDescriptor(
   values=[
     _descriptor.EnumValueDescriptor(
       name='UNDEFINED', index=0, number=0,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='SUM', index=1, number=1,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ALL_TRUE', index=2, number=2,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ANY_TRUE', index=3, number=3,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ALL_EQ', index=4, number=4,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ALL_UNIQUE', index=5, number=5,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MAXIMUM', index=6, number=10,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='MINIMUM', index=7, number=11,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='SET_EXTRACT', index=8, number=12,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='INTERSECTION', index=9, number=13,
-      options=None,
+      serialized_options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='HULL', index=10, number=14,
+      serialized_options=None,
       type=None),
   ],
   containing_type=None,
-  options=None,
+  serialized_options=None,
   serialized_start=506,
-  serialized_end=651,
+  serialized_end=661,
 )
 _sym_db.RegisterEnumDescriptor(_REDUCTIONEXPR_OP)
 
@@ -193,21 +196,21 @@ _BINARYEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='lhs', full_name='edg.expr.BinaryExpr.lhs', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='rhs', full_name='edg.expr.BinaryExpr.rhs', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -215,7 +218,7 @@ _BINARYEXPR = _descriptor.Descriptor(
   enum_types=[
     _BINARYEXPR_OP,
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -239,14 +242,14 @@ _REDUCTIONEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='vals', full_name='edg.expr.ReductionExpr.vals', index=1,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -254,14 +257,14 @@ _REDUCTIONEXPR = _descriptor.Descriptor(
   enum_types=[
     _REDUCTIONEXPR_OP,
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
   serialized_start=413,
-  serialized_end=651,
+  serialized_end=661,
 )
 
 
@@ -278,28 +281,28 @@ _RANGEEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='maximum', full_name='edg.expr.RangeExpr.maximum', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=653,
-  serialized_end=740,
+  serialized_start=663,
+  serialized_end=750,
 )
 
 
@@ -316,28 +319,28 @@ _STRUCTEXPR_VALSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.expr.StructExpr.ValsEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=802,
-  serialized_end=866,
+  serialized_start=812,
+  serialized_end=876,
 )
 
 _STRUCTEXPR = _descriptor.Descriptor(
@@ -353,21 +356,21 @@ _STRUCTEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_STRUCTEXPR_VALSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=742,
-  serialized_end=866,
+  serialized_start=752,
+  serialized_end=876,
 )
 
 
@@ -384,42 +387,42 @@ _IFTHENELSEEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='tru', full_name='edg.expr.IfThenElseExpr.tru', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='fal', full_name='edg.expr.IfThenElseExpr.fal', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.expr.IfThenElseExpr.meta', index=3,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=869,
-  serialized_end=1024,
+  serialized_start=879,
+  serialized_end=1034,
 )
 
 
@@ -436,28 +439,28 @@ _EXTRACTEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='index', full_name='edg.expr.ExtractExpr.index', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1026,
-  serialized_end=1115,
+  serialized_start=1036,
+  serialized_end=1125,
 )
 
 
@@ -474,28 +477,28 @@ _MAPEXTRACTEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='path', full_name='edg.expr.MapExtractExpr.path', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1117,
-  serialized_end=1207,
+  serialized_start=1127,
+  serialized_end=1217,
 )
 
 
@@ -512,28 +515,28 @@ _CONNECTEDEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='link_port', full_name='edg.expr.ConnectedExpr.link_port', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1209,
-  serialized_end=1305,
+  serialized_start=1219,
+  serialized_end=1315,
 )
 
 
@@ -550,28 +553,28 @@ _EXPORTEDEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='internal_block_port', full_name='edg.expr.ExportedExpr.internal_block_port', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1307,
-  serialized_end=1415,
+  serialized_start=1317,
+  serialized_end=1425,
 )
 
 
@@ -588,28 +591,28 @@ _ASSIGNEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='src', full_name='edg.expr.AssignExpr.src', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1417,
-  serialized_end=1496,
+  serialized_start=1427,
+  serialized_end=1506,
 )
 
 
@@ -626,98 +629,98 @@ _VALUEEXPR = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='binary', full_name='edg.expr.ValueExpr.binary', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='reduce', full_name='edg.expr.ValueExpr.reduce', index=2,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='struct', full_name='edg.expr.ValueExpr.struct', index=3,
       number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='range', full_name='edg.expr.ValueExpr.range', index=4,
       number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ifThenElse', full_name='edg.expr.ValueExpr.ifThenElse', index=5,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='extract', full_name='edg.expr.ValueExpr.extract', index=6,
       number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='map_extract', full_name='edg.expr.ValueExpr.map_extract', index=7,
       number=14, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='connected', full_name='edg.expr.ValueExpr.connected', index=8,
       number=15, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='exported', full_name='edg.expr.ValueExpr.exported', index=9,
       number=16, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='assign', full_name='edg.expr.ValueExpr.assign', index=10,
       number=17, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='ref', full_name='edg.expr.ValueExpr.ref', index=11,
       number=99, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.expr.ValueExpr.meta', index=12,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -726,8 +729,8 @@ _VALUEEXPR = _descriptor.Descriptor(
       name='expr', full_name='edg.expr.ValueExpr.expr',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1499,
-  serialized_end=2057,
+  serialized_start=1509,
+  serialized_end=2067,
 )
 
 _BINARYEXPR.fields_by_name['op'].enum_type = _BINARYEXPR_OP
@@ -816,6 +819,7 @@ DESCRIPTOR.message_types_by_name['ConnectedExpr'] = _CONNECTEDEXPR
 DESCRIPTOR.message_types_by_name['ExportedExpr'] = _EXPORTEDEXPR
 DESCRIPTOR.message_types_by_name['AssignExpr'] = _ASSIGNEXPR
 DESCRIPTOR.message_types_by_name['ValueExpr'] = _VALUEEXPR
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 BinaryExpr = _reflection.GeneratedProtocolMessageType('BinaryExpr', (_message.Message,), dict(
   DESCRIPTOR = _BINARYEXPR,
@@ -903,6 +907,5 @@ ValueExpr = _reflection.GeneratedProtocolMessageType('ValueExpr', (_message.Mess
 _sym_db.RegisterMessage(ValueExpr)
 
 
-_STRUCTEXPR_VALSENTRY.has_options = True
-_STRUCTEXPR_VALSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_STRUCTEXPR_VALSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/edg_core/edgir/expr_pb2.pyi
+++ b/edg_core/edgir/expr_pb2.pyi
@@ -73,6 +73,7 @@ class BinaryExpr(google___protobuf___message___Message):
         MAX = typing___cast(BinaryExpr.OpValue, 45)
         MIN = typing___cast(BinaryExpr.OpValue, 46)
         INTERSECTION = typing___cast(BinaryExpr.OpValue, 51)
+        HULL = typing___cast(BinaryExpr.OpValue, 54)
         SUBSET = typing___cast(BinaryExpr.OpValue, 53)
         RANGE = typing___cast(BinaryExpr.OpValue, 1)
     UNDEFINED = typing___cast(BinaryExpr.OpValue, 0)
@@ -93,6 +94,7 @@ class BinaryExpr(google___protobuf___message___Message):
     MAX = typing___cast(BinaryExpr.OpValue, 45)
     MIN = typing___cast(BinaryExpr.OpValue, 46)
     INTERSECTION = typing___cast(BinaryExpr.OpValue, 51)
+    HULL = typing___cast(BinaryExpr.OpValue, 54)
     SUBSET = typing___cast(BinaryExpr.OpValue, 53)
     RANGE = typing___cast(BinaryExpr.OpValue, 1)
     type___Op = Op

--- a/edg_core/edgir/expr_pb2.pyi
+++ b/edg_core/edgir/expr_pb2.pyi
@@ -132,6 +132,7 @@ class ReductionExpr(google___protobuf___message___Message):
         MINIMUM = typing___cast(ReductionExpr.OpValue, 11)
         SET_EXTRACT = typing___cast(ReductionExpr.OpValue, 12)
         INTERSECTION = typing___cast(ReductionExpr.OpValue, 13)
+        HULL = typing___cast(ReductionExpr.OpValue, 14)
     UNDEFINED = typing___cast(ReductionExpr.OpValue, 0)
     SUM = typing___cast(ReductionExpr.OpValue, 1)
     ALL_TRUE = typing___cast(ReductionExpr.OpValue, 2)
@@ -142,6 +143,7 @@ class ReductionExpr(google___protobuf___message___Message):
     MINIMUM = typing___cast(ReductionExpr.OpValue, 11)
     SET_EXTRACT = typing___cast(ReductionExpr.OpValue, 12)
     INTERSECTION = typing___cast(ReductionExpr.OpValue, 13)
+    HULL = typing___cast(ReductionExpr.OpValue, 14)
     type___Op = Op
 
     op: type___ReductionExpr.OpValue = ...

--- a/edg_core/edgir/impl_pb2.py
+++ b/edg_core/edgir/impl_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -20,10 +19,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='impl.proto',
   package='edg.impl',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\nimpl.proto\x12\x08\x65\x64g.impl\x1a\x0c\x63ommon.proto\"/\n\tBlockImpl\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\".\n\x08PortImpl\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\".\n\x08LinkImpl\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\"5\n\x0f\x45nvironmentImpl\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadatab\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -41,14 +40,14 @@ _BLOCKIMPL = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -72,14 +71,14 @@ _PORTIMPL = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -103,14 +102,14 @@ _LINKIMPL = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -134,14 +133,14 @@ _ENVIRONMENTIMPL = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -159,6 +158,7 @@ DESCRIPTOR.message_types_by_name['BlockImpl'] = _BLOCKIMPL
 DESCRIPTOR.message_types_by_name['PortImpl'] = _PORTIMPL
 DESCRIPTOR.message_types_by_name['LinkImpl'] = _LINKIMPL
 DESCRIPTOR.message_types_by_name['EnvironmentImpl'] = _ENVIRONMENTIMPL
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 BlockImpl = _reflection.GeneratedProtocolMessageType('BlockImpl', (_message.Message,), dict(
   DESCRIPTOR = _BLOCKIMPL,

--- a/edg_core/edgir/init_pb2.py
+++ b/edg_core/edgir/init_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -25,10 +24,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='init.proto',
   package='edg.init',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\ninit.proto\x12\x08\x65\x64g.init\x1a\nexpr.proto\x1a\nname.proto\x1a\tref.proto\x1a\x0c\x63ommon.proto\x1a\tlit.proto\x1a\ntype.proto\"\xb5\x02\n\x07ValInit\x12%\n\x08\x66loating\x18\x01 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12$\n\x07integer\x18\x02 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12$\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12!\n\x04text\x18\x04 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12 \n\x03set\x18\x08 \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12#\n\x06struct\x18\t \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12\"\n\x05range\x18\n \x01(\x0b\x32\x11.edg.common.EmptyH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x05\n\x03valb\x06proto3')
   ,
   dependencies=[expr__pb2.DESCRIPTOR,name__pb2.DESCRIPTOR,ref__pb2.DESCRIPTOR,common__pb2.DESCRIPTOR,lit__pb2.DESCRIPTOR,type__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -46,63 +45,63 @@ _VALINIT = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='integer', full_name='edg.init.ValInit.integer', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='boolean', full_name='edg.init.ValInit.boolean', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='text', full_name='edg.init.ValInit.text', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='set', full_name='edg.init.ValInit.set', index=4,
       number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='struct', full_name='edg.init.ValInit.struct', index=5,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='range', full_name='edg.init.ValInit.range', index=6,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.init.ValInit.meta', index=7,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -145,6 +144,7 @@ _VALINIT.oneofs_by_name['val'].fields.append(
   _VALINIT.fields_by_name['range'])
 _VALINIT.fields_by_name['range'].containing_oneof = _VALINIT.oneofs_by_name['val']
 DESCRIPTOR.message_types_by_name['ValInit'] = _VALINIT
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 ValInit = _reflection.GeneratedProtocolMessageType('ValInit', (_message.Message,), dict(
   DESCRIPTOR = _VALINIT,

--- a/edg_core/edgir/lit_pb2.py
+++ b/edg_core/edgir/lit_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -21,10 +20,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='lit.proto',
   package='edg.lit',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\tlit.proto\x12\x07\x65\x64g.lit\x1a\x0c\x63ommon.proto\x1a\nname.proto\"\x17\n\x08\x46loatLit\x12\x0b\n\x03val\x18\x01 \x01(\x01\"\x15\n\x06IntLit\x12\x0b\n\x03val\x18\x01 \x01(\x12\"\x16\n\x07\x42oolLit\x12\x0b\n\x03val\x18\x01 \x01(\x08\"\x16\n\x07TextLit\x12\x0b\n\x03val\x18\x01 \x01(\t\"R\n\x08RangeLit\x12\"\n\x07minimum\x18\x01 \x01(\x0b\x32\x11.edg.lit.ValueLit\x12\"\n\x07maximum\x18\x02 \x01(\x0b\x32\x11.edg.lit.ValueLit\"\x80\x01\n\tStructLit\x12\x30\n\x07members\x18\x01 \x03(\x0b\x32\x1f.edg.lit.StructLit.MembersEntry\x1a\x41\n\x0cMembersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.edg.lit.ValueLit:\x02\x38\x01\"\x92\x02\n\x08ValueLit\x12%\n\x08\x66loating\x18\x01 \x01(\x0b\x32\x11.edg.lit.FloatLitH\x00\x12\"\n\x07integer\x18\x02 \x01(\x0b\x32\x0f.edg.lit.IntLitH\x00\x12#\n\x07\x62oolean\x18\x03 \x01(\x0b\x32\x10.edg.lit.BoolLitH\x00\x12 \n\x04text\x18\x04 \x01(\x0b\x32\x10.edg.lit.TextLitH\x00\x12$\n\x06struct\x18\t \x01(\x0b\x32\x12.edg.lit.StructLitH\x00\x12\"\n\x05range\x18\n \x01(\x0b\x32\x11.edg.lit.RangeLitH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x06\n\x04typeb\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,name__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -42,14 +41,14 @@ _FLOATLIT = _descriptor.Descriptor(
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -73,14 +72,14 @@ _INTLIT = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -104,14 +103,14 @@ _BOOLLIT = _descriptor.Descriptor(
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -135,14 +134,14 @@ _TEXTLIT = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -166,21 +165,21 @@ _RANGELIT = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='maximum', full_name='edg.lit.RangeLit.maximum', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -204,21 +203,21 @@ _STRUCTLIT_MEMBERSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.lit.StructLit.MembersEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -241,14 +240,14 @@ _STRUCTLIT = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_STRUCTLIT_MEMBERSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -272,56 +271,56 @@ _VALUELIT = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='integer', full_name='edg.lit.ValueLit.integer', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='boolean', full_name='edg.lit.ValueLit.boolean', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='text', full_name='edg.lit.ValueLit.text', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='struct', full_name='edg.lit.ValueLit.struct', index=4,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='range', full_name='edg.lit.ValueLit.range', index=5,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.lit.ValueLit.meta', index=6,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -371,6 +370,7 @@ DESCRIPTOR.message_types_by_name['TextLit'] = _TEXTLIT
 DESCRIPTOR.message_types_by_name['RangeLit'] = _RANGELIT
 DESCRIPTOR.message_types_by_name['StructLit'] = _STRUCTLIT
 DESCRIPTOR.message_types_by_name['ValueLit'] = _VALUELIT
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 FloatLit = _reflection.GeneratedProtocolMessageType('FloatLit', (_message.Message,), dict(
   DESCRIPTOR = _FLOATLIT,
@@ -430,6 +430,5 @@ ValueLit = _reflection.GeneratedProtocolMessageType('ValueLit', (_message.Messag
 _sym_db.RegisterMessage(ValueLit)
 
 
-_STRUCTLIT_MEMBERSENTRY.has_options = True
-_STRUCTLIT_MEMBERSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_STRUCTLIT_MEMBERSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/edg_core/edgir/name_pb2.py
+++ b/edg_core/edgir/name_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -20,10 +19,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='name.proto',
   package='edg.name',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\nname.proto\x12\x08\x65\x64g.name\x1a\x0c\x63ommon.proto\"M\n\tNamespace\x12\x0f\n\x05\x62\x61sic\x18\x01 \x01(\tH\x00\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.MetadataB\x0b\n\tnamespace\"?\n\x0bLibraryName\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadatab\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -41,21 +40,21 @@ _NAMESPACE = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.name.Namespace.meta', index=1,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -82,21 +81,21 @@ _LIBRARYNAME = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.name.LibraryName.meta', index=1,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -113,6 +112,7 @@ _NAMESPACE.fields_by_name['basic'].containing_oneof = _NAMESPACE.oneofs_by_name[
 _LIBRARYNAME.fields_by_name['meta'].message_type = common__pb2._METADATA
 DESCRIPTOR.message_types_by_name['Namespace'] = _NAMESPACE
 DESCRIPTOR.message_types_by_name['LibraryName'] = _LIBRARYNAME
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Namespace = _reflection.GeneratedProtocolMessageType('Namespace', (_message.Message,), dict(
   DESCRIPTOR = _NAMESPACE,

--- a/edg_core/edgir/ref_pb2.py
+++ b/edg_core/edgir/ref_pb2.py
@@ -8,7 +8,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -22,10 +21,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ref.proto',
   package='edg.ref',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\tref.proto\x12\x07\x65\x64g.ref\x1a\x0c\x63ommon.proto\x1a\nname.proto\"P\n\tLocalStep\x12+\n\x0ereserved_param\x18\x01 \x01(\x0e\x32\x11.edg.ref.ReservedH\x00\x12\x0e\n\x04name\x18\x03 \x01(\tH\x00\x42\x06\n\x04step\"S\n\tLocalPath\x12!\n\x05steps\x18\x01 \x03(\x0b\x32\x12.edg.ref.LocalStep\x12#\n\x04meta\x18\xff\x01 \x01(\x0b\x32\x14.edg.common.Metadata\"\xa0\x01\n\x0bLibraryPath\x12$\n\x05start\x18\x01 \x01(\x0b\x32\x15.edg.name.LibraryName\x12\"\n\x05steps\x18\x02 \x03(\x0b\x32\x13.edg.name.Namespace\x12\"\n\x06target\x18\x03 \x01(\x0b\x32\x12.edg.ref.LocalStep\x12#\n\x04meta\x18\xff\x01 \x01(\x0b\x32\x14.edg.common.Metadata*c\n\x08Reserved\x12\r\n\tUNDEFINED\x10\x00\x12\x12\n\x0e\x43ONNECTED_LINK\x10\x01\x12\x10\n\x0cIS_CONNECTED\x10(\x12\n\n\x06LENGTH\x10*\x12\x0c\n\x08\x41LLOCATE\x10+\x12\x08\n\x04NAME\x10,b\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,name__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 _RESERVED = _descriptor.EnumDescriptor(
   name='Reserved',
@@ -35,31 +34,31 @@ _RESERVED = _descriptor.EnumDescriptor(
   values=[
     _descriptor.EnumValueDescriptor(
       name='UNDEFINED', index=0, number=0,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='CONNECTED_LINK', index=1, number=1,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='IS_CONNECTED', index=2, number=40,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='LENGTH', index=3, number=42,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='ALLOCATE', index=4, number=43,
-      options=None,
+      serialized_options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
       name='NAME', index=5, number=44,
-      options=None,
+      serialized_options=None,
       type=None),
   ],
   containing_type=None,
-  options=None,
+  serialized_options=None,
   serialized_start=378,
   serialized_end=477,
 )
@@ -88,21 +87,21 @@ _LOCALSTEP = _descriptor.Descriptor(
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='name', full_name='edg.ref.LocalStep.name', index=1,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -129,21 +128,21 @@ _LOCALPATH = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.ref.LocalPath.meta', index=1,
       number=255, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -167,35 +166,35 @@ _LIBRARYPATH = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='steps', full_name='edg.ref.LibraryPath.steps', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='target', full_name='edg.ref.LibraryPath.target', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.ref.LibraryPath.meta', index=3,
       number=255, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -222,6 +221,7 @@ DESCRIPTOR.message_types_by_name['LocalStep'] = _LOCALSTEP
 DESCRIPTOR.message_types_by_name['LocalPath'] = _LOCALPATH
 DESCRIPTOR.message_types_by_name['LibraryPath'] = _LIBRARYPATH
 DESCRIPTOR.enum_types_by_name['Reserved'] = _RESERVED
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 LocalStep = _reflection.GeneratedProtocolMessageType('LocalStep', (_message.Message,), dict(
   DESCRIPTOR = _LOCALSTEP,

--- a/edg_core/edgir/schema_pb2.py
+++ b/edg_core/edgir/schema_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -21,10 +20,10 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='schema.proto',
   package='edg.schema',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\x0cschema.proto\x12\nedg.schema\x1a\x0c\x63ommon.proto\x1a\nelem.proto\"\x87\x04\n\x07Library\x12(\n\x02id\x18\x01 \x01(\x0b\x32\x1c.edg.schema.Library.LibIdent\x12\x0f\n\x07imports\x18\x02 \x03(\t\x12$\n\x04root\x18\n \x01(\x0b\x32\x16.edg.schema.Library.NS\x12\"\n\x04meta\x18\x7f \x01(\x0b\x32\x14.edg.common.Metadata\x1a\xdc\x02\n\x02NS\x12\x34\n\x07members\x18\x01 \x03(\x0b\x32#.edg.schema.Library.NS.MembersEntry\x1a\xd3\x01\n\x03Val\x12\x1e\n\x04port\x18\n \x01(\x0b\x32\x0e.edg.elem.PortH\x00\x12\"\n\x06\x62undle\x18\x0b \x01(\x0b\x32\x10.edg.elem.BundleH\x00\x12\x33\n\x0fhierarchy_block\x18\r \x01(\x0b\x32\x18.edg.elem.HierarchyBlockH\x00\x12\x1e\n\x04link\x18\x0e \x01(\x0b\x32\x0e.edg.elem.LinkH\x00\x12+\n\tnamespace\x18\x14 \x01(\x0b\x32\x16.edg.schema.Library.NSH\x00\x42\x06\n\x04type\x1aJ\n\x0cMembersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.edg.schema.Library.NS.Val:\x02\x38\x01\x1a\x18\n\x08LibIdent\x12\x0c\n\x04name\x18\x01 \x01(\t\"4\n\x06\x44\x65sign\x12*\n\x08\x63ontents\x18\x02 \x01(\x0b\x32\x18.edg.elem.HierarchyBlockb\x06proto3')
   ,
   dependencies=[common__pb2.DESCRIPTOR,elem__pb2.DESCRIPTOR,])
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
 
@@ -42,42 +41,42 @@ _LIBRARY_NS_VAL = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='bundle', full_name='edg.schema.Library.NS.Val.bundle', index=1,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='hierarchy_block', full_name='edg.schema.Library.NS.Val.hierarchy_block', index=2,
       number=13, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='link', full_name='edg.schema.Library.NS.Val.link', index=3,
       number=14, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='namespace', full_name='edg.schema.Library.NS.Val.namespace', index=4,
       number=20, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -103,21 +102,21 @@ _LIBRARY_NS_MEMBERSENTRY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='edg.schema.Library.NS.MembersEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=_descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001')),
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -140,14 +139,14 @@ _LIBRARY_NS = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_LIBRARY_NS_VAL, _LIBRARY_NS_MEMBERSENTRY, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -170,14 +169,14 @@ _LIBRARY_LIBIDENT = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -200,35 +199,35 @@ _LIBRARY = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='imports', full_name='edg.schema.Library.imports', index=1,
       number=2, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='root', full_name='edg.schema.Library.root', index=2,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='meta', full_name='edg.schema.Library.meta', index=3,
       number=127, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[_LIBRARY_NS, _LIBRARY_LIBIDENT, ],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -252,14 +251,14 @@ _DESIGN = _descriptor.Descriptor(
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
@@ -301,6 +300,7 @@ _LIBRARY.fields_by_name['meta'].message_type = common__pb2._METADATA
 _DESIGN.fields_by_name['contents'].message_type = elem__pb2._HIERARCHYBLOCK
 DESCRIPTOR.message_types_by_name['Library'] = _LIBRARY
 DESCRIPTOR.message_types_by_name['Design'] = _DESIGN
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 Library = _reflection.GeneratedProtocolMessageType('Library', (_message.Message,), dict(
 
@@ -349,6 +349,5 @@ Design = _reflection.GeneratedProtocolMessageType('Design', (_message.Message,),
 _sym_db.RegisterMessage(Design)
 
 
-_LIBRARY_NS_MEMBERSENTRY.has_options = True
-_LIBRARY_NS_MEMBERSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_LIBRARY_NS_MEMBERSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/edg_core/edgir/type_pb2.py
+++ b/edg_core/edgir/type_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -19,12 +18,13 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='type.proto',
   package='',
   syntax='proto3',
+  serialized_options=None,
   serialized_pb=_b('\n\ntype.protob\x06proto3')
 )
+
+
+
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
-
-
 
 
 # @@protoc_insertion_point(module_scope)

--- a/edgir/expr.proto
+++ b/edgir/expr.proto
@@ -113,7 +113,7 @@ message BinaryExpr {
     INTERSECTION = 51;
 
     /** hull :: (Range a) => (lhs :: a, rhs :: a) -> Set a
-      Given two input ranges, return the hull (union with all the inner missing bits filled in)
+      Given two input ranges, returns the convex hull (union with all the inner missing bits filled in)
     */
     HULL = 54;
 
@@ -209,7 +209,7 @@ message ReductionExpr {
     INTERSECTION = 13;
 
     /** Hull :: (Set_like s) => s Range -> Range
-        Like a union operator, but produces one range that */
+        Returns the convex hull (union with all the inner missing bits filled in) */
     HULL = 14;
   }
   Op op = 1;

--- a/edgir/expr.proto
+++ b/edgir/expr.proto
@@ -202,6 +202,10 @@ message ReductionExpr {
     /** Intersection :: (Set_like s) => s Range -> Range
         May produce an empty range */
     INTERSECTION = 13;
+
+    /** Hull :: (Set_like s) => s Range -> Range
+        Like a union operator, but produces one range that */
+    HULL = 14;
   }
   Op op = 1;
   ValueExpr vals = 4;

--- a/edgir/expr.proto
+++ b/edgir/expr.proto
@@ -112,6 +112,11 @@ message BinaryExpr {
       May produce an empty range */
     INTERSECTION = 51;
 
+    /** hull :: (Range a) => (lhs :: a, rhs :: a) -> Set a
+      Given two input ranges, return the hull (union with all the inner missing bits filled in)
+    */
+    HULL = 54;
+
     /** intersects :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Bool */
 //    INTERSECTS = 52;
 

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -38,18 +38,9 @@ class DigitalLink(CircuitLink):  # can't subclass VoltageLink because the constr
     self.require(self.source.is_connected() | (self.single_sources.length() > 0) | (self.bidirs.length() > 0),
                  "DigitalLink must have some kind of source")
 
-    # TODO RangeBuilder initializer for voltage
-    # TODO this and below should be x.voltage_out.min (etc) instead of relying on min over Array[Range]
-    bidirs_voltage_min = self.bidirs.hull(lambda x: x.voltage_out).lower()
-    bidirs_voltage_max = self.bidirs.hull(lambda x: x.voltage_out).upper()
-    single_voltage_min = self.single_sources.hull(lambda x: x.voltage_out).lower()
-    single_voltage_max = self.single_sources.hull(lambda x: x.voltage_out).upper()
-    self.assign(self.voltage, self.source.is_connected().then_else(  # TODO: really clean up
-      # TODO get rid of _to_expr_type?
-      RangeExpr._to_expr_type((self.source.voltage_out.lower().min(bidirs_voltage_min.min(single_voltage_min)),
-                               self.source.voltage_out.upper().max(bidirs_voltage_max.max(single_voltage_max)))),
-      RangeExpr._to_expr_type((bidirs_voltage_min.min(single_voltage_min),
-                               bidirs_voltage_max.max(single_voltage_max)))
+    self.assign(self.voltage, self.source.is_connected().then_else(
+      self.bidirs.hull(lambda x: x.voltage_out).hull(self.source.voltage_out),
+      self.bidirs.hull(lambda x: x.voltage_out).hull(self.single_sources.hull(lambda x: x.voltage_out))
     ))
 
     self.assign(self.voltage_limits,
@@ -78,10 +69,9 @@ class DigitalLink(CircuitLink):  # can't subclass VoltageLink because the constr
                   bidirs_output_thresholds.intersect(
                     single_output_thresholds)))
 
-    self.assign(self.input_thresholds, (  # TODO: clean up
-      self.sinks.hull(lambda x: x.input_thresholds).lower().min(self.bidirs.hull(lambda x: x.input_thresholds).lower()),
-      self.sinks.hull(lambda x: x.input_thresholds).upper().max(self.bidirs.hull(lambda x: x.input_thresholds).upper())
-    ))
+    self.assign(self.input_thresholds,
+      self.sinks.hull(lambda x: x.input_thresholds).hull(self.bidirs.hull(lambda x: x.input_thresholds)),
+    )
     self.require(self.output_thresholds.contains(self.input_thresholds), "incompatible digital thresholds")
 
     self.assign(self.pullup_capable,

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -40,10 +40,10 @@ class DigitalLink(CircuitLink):  # can't subclass VoltageLink because the constr
 
     # TODO RangeBuilder initializer for voltage
     # TODO this and below should be x.voltage_out.min (etc) instead of relying on min over Array[Range]
-    bidirs_voltage_min = self.bidirs.min(lambda x: x.voltage_out)
-    bidirs_voltage_max = self.bidirs.max(lambda x: x.voltage_out)
-    single_voltage_min = self.single_sources.min(lambda x: x.voltage_out)
-    single_voltage_max = self.single_sources.max(lambda x: x.voltage_out)
+    bidirs_voltage_min = self.bidirs.hull(lambda x: x.voltage_out).lower()
+    bidirs_voltage_max = self.bidirs.hull(lambda x: x.voltage_out).upper()
+    single_voltage_min = self.single_sources.hull(lambda x: x.voltage_out).lower()
+    single_voltage_max = self.single_sources.hull(lambda x: x.voltage_out).upper()
     self.assign(self.voltage, self.source.is_connected().then_else(  # TODO: really clean up
       # TODO get rid of _to_expr_type?
       RangeExpr._to_expr_type((self.source.voltage_out.lower().min(bidirs_voltage_min.min(single_voltage_min)),
@@ -79,8 +79,8 @@ class DigitalLink(CircuitLink):  # can't subclass VoltageLink because the constr
                     single_output_thresholds)))
 
     self.assign(self.input_thresholds, (  # TODO: clean up
-      self.sinks.min(lambda x: x.input_thresholds).min(self.bidirs.min(lambda x: x.input_thresholds)),
-      self.sinks.max(lambda x: x.input_thresholds).max(self.bidirs.max(lambda x: x.input_thresholds))
+      self.sinks.hull(lambda x: x.input_thresholds).lower().min(self.bidirs.hull(lambda x: x.input_thresholds).lower()),
+      self.sinks.hull(lambda x: x.input_thresholds).upper().max(self.bidirs.hull(lambda x: x.input_thresholds).upper())
     ))
     self.require(self.output_thresholds.contains(self.input_thresholds), "incompatible digital thresholds")
 


### PR DESCRIPTION
- Add the hull reduction operator as the proper replacement for removing the min reduction operator on arrays of ranges, for calculating the superset link voltage given a set of bidirectional ports (and the optional source or sink port)
- Undefine (should error out) the min / max reduction on arrays of ranges - no longer used
- Undefine the min / max on empty array - no longer used
- Adds a hull binary operator (primarily because we don't have an array construction primitive - perhaps another refactor for another day)
- Add a proper concept of empty ranges (empty set equivalent for intervals) internal to the compiler
  - Split RangeValue into RangeType, RangeValue(min, max) and RangeEmpty
  - Hulling an empty array returns the empty range
  - Intersecting an empty array returns the full set - with the rationale being that the implicit initial value to intersect is the full set
  - @rohit507 is the overall behavior (primarily in ExprEvaluate.scala) consistent with formal definitions of empty intervals?
- Should not create any new test failures (but tests are currently failing from #31, unconnected ports causing missing values in assertions).
