### PR TITLE
Add not-connected port support, fix (most) red tests

### DIFF
--- a/compiler/src/main/scala/edg/wir/DesignPath.scala
+++ b/compiler/src/main/scala/edg/wir/DesignPath.scala
@@ -96,7 +96,6 @@ object IndirectDesignPath {
 
 /**
   * Absolute path (from the design root) to some element.
-  * TODO: should exclude link ports, since the block side port is treated as authoritative.
   */
 case class DesignPath(steps: Seq[String]) {
   // Separates into (prefix, last) where last is the last element, and prefix is a DesignPath of all but the last

--- a/edg_core/NotConnectablePort.py
+++ b/edg_core/NotConnectablePort.py
@@ -23,7 +23,7 @@ class NotConnectablePort(Port):
     # TODO should this be a more general infrastructural function?
     # TODO dedup w/ Port._convert
     block_parent = cast(Block, self._block_parent())
-    if block_parent is None or block_parent.parent is None:
+    if block_parent is None:
       raise UnconnectableError(f"{self} must be bound to mark not-connected")
     if block_parent is not builder.get_curr_block():
       raise UnconnectableError(f"can only mark not-connected on ports of the current block")

--- a/edg_core/NotConnectablePort.py
+++ b/edg_core/NotConnectablePort.py
@@ -1,0 +1,36 @@
+from typing import cast
+from .Ports import Port
+from .HierarchyBlock import Block
+from .Builder import builder
+from .Exception import *
+
+
+class NotConnectableBlock(Block):
+  def __init__(self):
+    super().__init__()
+    self.port: Port
+
+
+class NotConnectablePort(Port):
+  """Port that additionally supports not-connected() which instantiates a dummy block with a nop port
+  and connects this port to it."""
+  def __init__(self) -> None:
+    super().__init__()
+    self.not_connected_type: Type[NotConnectableBlock]
+
+  def not_connected(self) -> Block:
+    """Marks this edge port as not connected, can be called on a boundary port only."""
+    # TODO should this be a more general infrastructural function?
+    # TODO dedup w/ Port._convert
+    block_parent = cast(Block, self._block_parent())
+    if block_parent is None or block_parent.parent is None:
+      raise UnconnectableError(f"{self} must be bound to mark not-connected")
+    if block_parent is not builder.get_curr_block():
+      raise UnconnectableError(f"can only mark not-connected on ports of the current block")
+
+    nc_block = block_parent.Block(self.not_connected_type())
+    block_parent.manager.add_element(
+      f"(not_connected){block_parent._name_of(self)}",
+      nc_block)
+    block_parent.connect(self, nc_block.port)  # we don't name it to avoid explicit name conflicts
+    return nc_block

--- a/edg_core/NotConnectablePort.py
+++ b/edg_core/NotConnectablePort.py
@@ -1,14 +1,15 @@
-from typing import cast
+from typing import cast, Generic
 from .Ports import Port
 from .HierarchyBlock import Block
 from .Builder import builder
 from .Exception import *
 
 
-class NotConnectableBlock(Block):
+NotConnectablePortType = TypeVar('NotConnectablePortType', bound=Port, covariant=True)
+class NotConnectableBlock(Block, Generic[NotConnectablePortType]):
   def __init__(self):
     super().__init__()
-    self.port: Port
+    self.port: NotConnectablePortType
 
 
 class NotConnectablePort(Port):
@@ -16,7 +17,7 @@ class NotConnectablePort(Port):
   and connects this port to it."""
   def __init__(self) -> None:
     super().__init__()
-    self.not_connected_type: Type[NotConnectableBlock]
+    self.not_connected_type: Type[NotConnectableBlock[Port]]  # TODO type check this!
 
   def not_connected(self) -> Block:
     """Marks this edge port as not connected, can be called on a boundary port only."""

--- a/edg_core/__init__.py
+++ b/edg_core/__init__.py
@@ -4,6 +4,7 @@ from .ConstraintExpr import RangeLit as RangeVal
 from .ConstraintExpr import RangeSubset, RangeSuperset
 from .ConstraintExpr import Default
 from .Ports import Port, Bundle
+from .NotConnectablePort import NotConnectableBlock, NotConnectablePort
 from .Blocks import Link
 from .DesignTop import DesignTop
 from .HierarchyBlock import Block, GeneratorBlock, ImplicitConnect, init_in_parent, abstract_block

--- a/electronics_lib/Lcd_Qt096t_if09.py
+++ b/electronics_lib/Lcd_Qt096t_if09.py
@@ -81,3 +81,6 @@ class Qt096t_if09(Lcd, Block):
     self.vdd_cap = self.Block(DecouplingCapacitor(capacitance=1*uFarad(tol=0.1)))
     self.connect(self.vdd_cap.pwr, self.pwr)
     self.connect(self.vdd_cap.gnd, self.gnd)
+
+    self.miso_nc = self.Block(self.spi.miso.not_connected())
+    self.connect(self.spi.miso, self.miso_nc.port)

--- a/electronics_lib/Lcd_Qt096t_if09.py
+++ b/electronics_lib/Lcd_Qt096t_if09.py
@@ -82,5 +82,4 @@ class Qt096t_if09(Lcd, Block):
     self.connect(self.vdd_cap.pwr, self.pwr)
     self.connect(self.vdd_cap.gnd, self.gnd)
 
-    self.miso_nc = self.Block(self.spi.miso.not_connected())
-    self.connect(self.spi.miso, self.miso_nc.port)
+    self.spi.miso.not_connected()

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -449,7 +449,7 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
     #
     # Pin Assignment Block
     #
-    assigned_pins = PinAssignmentUtil(
+    assigned_pins, not_connected = PinAssignmentUtil(
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSink)],
                    self.ic.ADC0_PINS + self.ic.ADC1_PINS),
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSource)],
@@ -465,7 +465,6 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
     #
     # TODO models should be in the _Device block, but need to figure how to handle Analog/Digital capable pins first
     # TODO dedup w/ models in the _Device block
-
     for pin_num, self_port in assigned_pins.items():
       if isinstance(self_port, (DigitalSource, DigitalSink, DigitalBidir)):
         self.connect(self_port, self.ic.io_pins[str(pin_num)].as_digital_bidir(

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -449,7 +449,7 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
     #
     # Pin Assignment Block
     #
-    assigned_pins, not_connected = PinAssignmentUtil(
+    assigned_pins = PinAssignmentUtil(
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSink)],
                    self.ic.ADC0_PINS + self.ic.ADC1_PINS),
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSource)],
@@ -465,7 +465,7 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
     #
     # TODO models should be in the _Device block, but need to figure how to handle Analog/Digital capable pins first
     # TODO dedup w/ models in the _Device block
-    for pin_num, self_port in assigned_pins.items():
+    for pin_num, self_port in assigned_pins.assigned_pins.items():
       if isinstance(self_port, (DigitalSource, DigitalSink, DigitalBidir)):
         self.connect(self_port, self.ic.io_pins[str(pin_num)].as_digital_bidir(
           voltage_limits=(0, 5) * Volt,
@@ -491,6 +491,10 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
         ))
       else:
         raise ValueError(f"unknown pin type {self_port}")
+
+    for self_port in assigned_pins.not_connected:
+      assert isinstance(self_port, NotConnectablePort), f"non-NotConnectablePort {self_port.name()} marked NC"
+      self_port.not_connected()
 
 
 class Lpc1549_48(Lpc1549Base):

--- a/electronics_lib/Microcontroller_Nucleo32.py
+++ b/electronics_lib/Microcontroller_Nucleo32.py
@@ -95,7 +95,7 @@ class Nucleo_F303k8(Microcontroller, FootprintBlock, AssignablePinBlock):  # TOD
       17: self.gnd,
     }
 
-    assigned_pins = PinAssignmentUtil(
+    assigned_pins, not_connected = PinAssignmentUtil(
       # TODO assign fixed-pin digital peripherals here
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSource)],
                    [22, 23, 24]),  # TODO account for only two DACs

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -215,7 +215,7 @@ class Stm32f103_48(Microcontroller, AssignablePinBlock, GeneratorBlock):
     #
     # Pin assignment block
     #
-    assigned_pins, not_connected = PinAssignmentUtil(
+    assigned_pins = PinAssignmentUtil(
       # TODO assign fixed-pin digital peripherals here
       # TODO
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSink)],
@@ -237,8 +237,12 @@ class Stm32f103_48(Microcontroller, AssignablePinBlock, GeneratorBlock):
       [port for port in self._all_assignable_ios if self.get(port.is_connected())],
       self._get_suggested_pin_maps(pin_assigns_str))
 
-    for pin_num, self_port in assigned_pins.items():
+    for pin_num, self_port in assigned_pins.assigned_pins.items():
       self.connect(self_port, self.ic.io_pins[str(pin_num)])
+
+    for self_port in assigned_pins.not_connected:
+      assert isinstance(self_port, NotConnectablePort), f"non-NotConnectablePort {self_port.name()} marked NC"
+      self_port.not_connected()
 
     if self.get(self.usb_0.is_connected()):
       self.usb_pull = self.Block(PullupResistor(resistance=1.5*kOhm(tol=0.01)))  # required by datasheet Table 44  # TODO proper tolerancing?

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -215,7 +215,7 @@ class Stm32f103_48(Microcontroller, AssignablePinBlock, GeneratorBlock):
     #
     # Pin assignment block
     #
-    assigned_pins = PinAssignmentUtil(
+    assigned_pins, not_connected = PinAssignmentUtil(
       # TODO assign fixed-pin digital peripherals here
       # TODO
       AnyPinAssign([port for port in self._all_assignable_ios if isinstance(port, AnalogSink)],

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -230,18 +230,13 @@ class DigitalSource(DigitalBase):
     return self._convert(DigitalSourceAdapterVoltageSource())
 
 
-class DigitalBidirNotConnected(Block):
+class DigitalBidirNotConnected(NotConnectableBlock):
   """Not-connected dummy block for Digital bidir ports"""
   def __init__(self) -> None:
     super().__init__()
     self.port = self.Port(DigitalBidir())
 
-class DigitalBidir(DigitalBase):
-  def not_connected(self) -> DigitalBidirNotConnected:
-    """Marks this port as not connected, can be called on a boundary port only."""
-    # TODO should this be a more general infrastructural function?
-    return DigitalBidirNotConnected()
-
+class DigitalBidir(DigitalBase, NotConnectablePort):
   @staticmethod
   def from_supply(neg: VoltageSink, pos: VoltageSink,
                   voltage_limit_tolerance: RangeLike = (0, 0)*Volt,
@@ -302,6 +297,7 @@ class DigitalBidir(DigitalBase):
                pulldown_capable: BoolLike = Default(False)) -> None:
     super().__init__()
     self.bridge_type = DigitalBidirBridge
+    self.not_connected_type = DigitalBidirNotConnected
 
     if model is not None:
       # TODO check that both model and individual parameters aren't overdefined

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -230,11 +230,12 @@ class DigitalSource(DigitalBase):
     return self._convert(DigitalSourceAdapterVoltageSource())
 
 
-class DigitalBidirNotConnected(NotConnectableBlock):
+class DigitalBidirNotConnected(NotConnectableBlock['DigitalBidir']):
   """Not-connected dummy block for Digital bidir ports"""
   def __init__(self) -> None:
     super().__init__()
     self.port = self.Port(DigitalBidir())
+
 
 class DigitalBidir(DigitalBase, NotConnectablePort):
   @staticmethod

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -230,7 +230,18 @@ class DigitalSource(DigitalBase):
     return self._convert(DigitalSourceAdapterVoltageSource())
 
 
+class DigitalBidirNotConnected(Block):
+  """Not-connected dummy block for Digital bidir ports"""
+  def __init__(self) -> None:
+    super().__init__()
+    self.port = self.Port(DigitalBidir())
+
 class DigitalBidir(DigitalBase):
+  def not_connected(self) -> DigitalBidirNotConnected:
+    """Marks this port as not connected, can be called on a boundary port only."""
+    # TODO should this be a more general infrastructural function?
+    return DigitalBidirNotConnected()
+
   @staticmethod
   def from_supply(neg: VoltageSink, pos: VoltageSink,
                   voltage_limit_tolerance: RangeLike = (0, 0)*Volt,

--- a/electronics_model/PinAssignmentUtil.py
+++ b/electronics_model/PinAssignmentUtil.py
@@ -27,6 +27,11 @@ PinName = Union[str, int, SpecialPin]
 ConcretePinName = str
 
 
+class AssignedPins(NamedTuple):
+  assigned_pins: Dict[ConcretePinName, CircuitPort]  # map of internal pin name -> edge leaf port
+  not_connected: List[CircuitPort]  # list of edge leaf ports that are marked as NC
+
+
 class AssignablePinGroup():
   """Base class for assignable pin definitions"""
   @abstractmethod
@@ -58,7 +63,7 @@ class AnyPinAssign(AssignablePinGroup):
         if isinstance(preassign_pin, str):  # shouldn't have ints based on how params propagated
           assert preassign_pin in self.pins, f"preassign for {preassign_pin}={port} not in pin set {self.pins} for {self}"
           assignments[preassign_pin] = leaf_port
-        elif preassign_pin == NotConnectedPin:
+        elif preassign_pin is NotConnectedPin:
           pass
         else:
           raise ValueError(f"bad preassign value {preassign_pin}")


### PR DESCRIPTION
DO NOT MERGE - DEPENDS ON #40, #43

Resolves #31, the two failing tests with the LCDs are now green. (Simon is still failing)

- Adds a `NotConnectablePort` mixin for `Port`, which adds the `not_connected()` function. This generates a dummy block (defined with the mixin) that defines a nop port for the port type, and connects the port there.
  - This is mainly (only?) intended to be used where there are unused bundle components - here, MISO is not used for the LCD
  - `not_connected()` is used to mark an edge port as disconnected, from the inside.
  - This differs from schematic capture, which marks pins not-connected from the outside. That functionality is handled by the required port infrastructure, and there is no way to NC a port from the outside. However, schematics have no concept of Bundles, where a sub-port is not-connected.
- Refactor the MCU pin assignment util to handle NC'd ports, which are `.not_connected()` at the top-level.
  - Architecturally this isn't the best, but should be cleaned by a separate refactor for #23

To some degree this is a bit of a hack, where the proper solution is better defined port types that don't include extraneous types. But defining those subset port types would be a much larger refactor job (including to-be-defined semantics), and this is probably a reasonable stopgap solution.