### PR TITLE
Don't crash on empty designs

### DIFF
--- a/edg_core/edgir/__init__.py
+++ b/edg_core/edgir/__init__.py
@@ -358,8 +358,12 @@ def local_path_to_str(path: LocalPath) -> str:
 def _namespace(meta: Metadata) -> Iterable[str]:
   namespace_elts = [v.namespace_order
                     for k, v in meta.members.node.items() if v.HasField('namespace_order')]
-  assert len(namespace_elts) == 1
-  return namespace_elts[0].names
+  if len(namespace_elts) == 1:
+    return namespace_elts[0].names
+  elif not namespace_elts:
+    return []
+  else:
+    raise ValueError(f"multiple namespace_order entries {namespace_elts}")
 
 
 def ordered_blocks(block: HierarchyBlock) -> Iterable[Tuple[str, BlockLike]]:


### PR DESCRIPTION
Allow namespace_order to handle the empty case (for which it returns an empty list), upper layers should crash if needed (for example, if there is a length mismatch between ordering).

Longer term: maybe eliminate the (unordered) map in the proto def so we don't need a supplemental order data structure?