### PR TITLE
Range type

### DIFF
--- a/edg_core/Binding.py
+++ b/edg_core/Binding.py
@@ -8,6 +8,7 @@ from typing import *
 from . import edgir
 from .Core import Refable
 from .IdentityDict import IdentityDict
+from .Range import Range
 
 if TYPE_CHECKING:
   from .Ports import BasePort, Port
@@ -153,16 +154,15 @@ class FloatLiteralBinding(LiteralBinding):
 
 class RangeLiteralBinding(LiteralBinding):
   def __repr__(self) -> str:
-    return f"Lit({self.lower, self.upper})"
+    return f"Lit({self.value})"
 
-  def __init__(self, value: Tuple[Union[float, int], Union[float, int]]):
-    self.lower = value[0]
-    self.upper = value[1]
+  def __init__(self, value: Range):
+    self.value = value
 
   def expr_to_proto(self, expr: ConstraintExpr, ref_map: IdentityDict[Refable, edgir.LocalPath]) -> edgir.ValueExpr:
     pb = edgir.ValueExpr()
-    pb.literal.range.minimum.floating.val = self.lower
-    pb.literal.range.maximum.floating.val = self.upper
+    pb.literal.range.minimum.floating.val = self.value.lower
+    pb.literal.range.maximum.floating.val = self.value.upper
     return pb
 
 

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -320,9 +320,9 @@ class RangeExpr(NumLikeExpr[Tuple[float, float], RangeLike]):
       return RangeExpr()._bind(RangeBuilderBinding(expr, expr))
     elif isinstance(input, tuple) and isinstance(input[0], (int, float)) and isinstance(input[1], (int, float)):
       assert len(input) == 2
-      return RangeExpr()._bind(RangeLiteralBinding((input[0], input[1])))
+      return RangeExpr()._bind(RangeLiteralBinding(Range(input[0], input[1])))
     elif isinstance(input, Range):
-      return RangeExpr()._bind(RangeLiteralBinding((input.lower, input.upper)))
+      return RangeExpr()._bind(RangeLiteralBinding(input))
     elif isinstance(input, tuple):
       assert len(input) == 2
       return RangeExpr()._bind(RangeBuilderBinding(

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -291,7 +291,7 @@ RangeLit = Tuple[FloatLit, FloatLit]
 # A RangeLike type excluding the float-to-range implicit conversion
 RangeLikeNonFloat = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike]]
 RangeLike = Union[RangeLikeNonFloat, FloatLike]
-class RangeExpr(NumLikeExpr[Tuple[float, float], RangeLike]):
+class RangeExpr(NumLikeExpr[Range, RangeLike]):
   # Some range literals for defaults
   POSITIVE: RangeLikeNonFloat = Range.from_lower(0.0)
   NEGATIVE: RangeLikeNonFloat = Range.from_upper(0.0)

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -13,6 +13,7 @@ from .Binding import ReductionOp, BinaryNumOp, BinaryBoolOp
 from .Builder import builder
 from .Core import Refable
 from .IdentityDict import IdentityDict
+from .Range import Range
 
 if TYPE_CHECKING:
   from .Ports import BasePort
@@ -287,7 +288,7 @@ class FloatExpr(NumLikeExpr[float, FloatLike]):
 
 
 RangeLit = Tuple[FloatLit, FloatLit]
-RangeLike = Union['RangeExpr', Tuple[FloatLike, FloatLike], FloatLike]
+RangeLike = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike], FloatLike]
 class RangeExpr(NumLikeExpr[Tuple[float, float], RangeLike]):
   # Some range literals for defaults
   POSITIVE = (0.0, float('inf'))
@@ -325,6 +326,11 @@ class RangeExpr(NumLikeExpr[Tuple[float, float], RangeLike]):
         FloatExpr._to_expr_type(input[0]),
         FloatExpr._to_expr_type(input[1])
         ))
+    elif isinstance(input, Range):
+      return RangeExpr()._bind(RangeBuilderBinding(
+        FloatExpr._to_expr_type(input.lower),
+        FloatExpr._to_expr_type(input.upper)
+      ))
     else:
       raise TypeError(f"op arg to RangeExpr must be FloatLike, got {input} of type {type(input)}")
 
@@ -345,7 +351,7 @@ class RangeExpr(NumLikeExpr[Tuple[float, float], RangeLike]):
     return self._create_bool_op(self, RangeExpr._to_expr_type(item), BinaryBoolOp.subset)
 
   def contains(self, item: Union[RangeLike, FloatLike]) -> BoolExpr:
-    if isinstance(item, (RangeExpr, tuple)):
+    if isinstance(item, (RangeExpr, tuple, Range)):
       return RangeExpr._to_expr_type(item).within(self)
     elif isinstance(item, (int, float, FloatExpr)):
       return self._create_bool_op(FloatExpr._to_expr_type(item), self, BinaryBoolOp.subset)

--- a/edg_core/HdlInterfaceServer.py
+++ b/edg_core/HdlInterfaceServer.py
@@ -103,8 +103,9 @@ class HdlInterface():  # type: ignore
         if issubclass(cls, DesignTop):  # TODO don't create another instance, perhaps refinements should be static?
           cls().refinements().populate_proto(response.refinements)
     except BaseException as e:
-      # TODO - include traceback in error message? traceback.print_exc()
-      response.error = str(e)
+      import traceback
+      # exception formatting from https://stackoverflow.com/questions/4564559/get-exception-description-and-stack-trace-which-caused-an-exception-all-as-a-st
+      response.error = "".join(traceback.TracebackException.from_exception(e).format())
     return response
 
   def ElaborateGenerator(self, request: edgrpc.GeneratorRequest) -> edgrpc.GeneratorResponse:

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -22,7 +22,7 @@ def init_in_parent(fn: InitType) -> InitType:
   import inspect
   from .Builder import builder
 
-  param_types = (bool, float, int, tuple, str, Range, ConstraintExpr)
+  param_types = (bool, float, int, Range, tuple, str, ConstraintExpr)
   float_like_types = (float, int, FloatExpr)
 
   def wrapped(self: Block, *args_tup, **kwargs) -> Any:
@@ -58,7 +58,7 @@ def init_in_parent(fn: InitType) -> InitType:
               param_model: ConstraintExpr = BoolExpr(arg_val)
             elif isinstance(arg_default, (float, int, FloatExpr)):
               param_model = FloatExpr(arg_val)
-            elif isinstance(arg_default, (RangeExpr, Range)) or (isinstance(arg_default, tuple) and
+            elif isinstance(arg_default, (Range, RangeExpr)) or (isinstance(arg_default, tuple) and
                 isinstance(arg_default[0], float_like_types) and isinstance(arg_default[0], float_like_types)):
               param_model = RangeExpr(arg_val)
             elif isinstance(arg_default, (str, StringExpr)):

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -551,7 +551,7 @@ class GeneratorBlock(Block):
     if isinstance(param, FloatExpr):
       assert isinstance(value, Number), f"get({self._name_of(param)}) expected float, got {value}"
     elif isinstance(param, RangeExpr):
-      assert isinstance(value[0], Number) and isinstance(value[1], Number), f"get({self._name_of(param)}) expected range, got {value}"
+      assert isinstance(value, Range), f"get({self._name_of(param)}) expected range, got {value}"
     elif isinstance(param, BoolExpr):
       assert isinstance(value, bool), f"get({self._name_of(param)}) expected bool, got {value}"
     elif isinstance(param, StringExpr):

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -10,6 +10,7 @@ from .Blocks import BaseBlock, BlockElaborationState, ConnectedPorts
 from .Binding import ParamBinding, AssignBinding
 from .ConstraintExpr import ConstraintExpr, BoolExpr, FloatExpr, RangeExpr, StringExpr
 from .Core import Refable, non_library
+from .Range import Range
 from .Exception import *
 from .IdentityDict import IdentityDict
 from .IdentitySet import IdentitySet
@@ -21,7 +22,7 @@ def init_in_parent(fn: InitType) -> InitType:
   import inspect
   from .Builder import builder
 
-  param_types = (bool, float, int, tuple, str, ConstraintExpr)
+  param_types = (bool, float, int, tuple, str, Range, ConstraintExpr)
   float_like_types = (float, int, FloatExpr)
 
   def wrapped(self: Block, *args_tup, **kwargs) -> Any:
@@ -57,7 +58,7 @@ def init_in_parent(fn: InitType) -> InitType:
               param_model: ConstraintExpr = BoolExpr(arg_val)
             elif isinstance(arg_default, (float, int, FloatExpr)):
               param_model = FloatExpr(arg_val)
-            elif isinstance(arg_default, RangeExpr) or (isinstance(arg_default, tuple) and
+            elif isinstance(arg_default, (RangeExpr, Range)) or (isinstance(arg_default, tuple) and
                 isinstance(arg_default[0], float_like_types) and isinstance(arg_default[0], float_like_types)):
               param_model = RangeExpr(arg_val)
             elif isinstance(arg_default, (str, StringExpr)):

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -1,0 +1,43 @@
+from typing import Tuple, Union
+
+
+class Range:
+  @staticmethod
+  def from_tolerance(center: float, tolerance: Union[float, Tuple[float, float]]) -> 'Range':
+    """Creates a Range given a center value and normalized tolerance percentage.
+    If a single tolerance is given, it is treated as bidirectional (+/- value).
+    If a tuple of two values is given, it is treated as negative, then positive tolerance."""
+    if isinstance(tolerance, tuple):
+      assert tolerance[0] <= tolerance[1], f"invalid tolerance {tolerance}"
+      return Range(center * (1 + tolerance[0]), center * (1 + tolerance[1]))
+    elif isinstance(tolerance, (float, int)):
+      assert tolerance >= 0, f"bidirectional tolerance {tolerance} must be positive"
+      return Range(center * (1 - tolerance), center * (1 + tolerance))
+    else:
+      raise ValueError(f"unknown tolerance format {tolerance}")
+
+  @staticmethod
+  def from_lower(lower: float) -> 'Range':
+    """Creates a Range from lower to positive infinity"""
+    return Range(lower, float('inf'))
+
+  @staticmethod
+  def from_upper(upper: float) -> 'Range':
+    """Creates a Range from upper to negative infinity"""
+    return Range(float('-inf'), upper)
+
+  """A range type that indicates a range of values and provides utility functions
+   Ends are treated as inclusive (closed)."""
+  def __init__(self, lower: float, upper: float):
+    assert lower <= upper, f"invalid range with lower {lower} > upper {upper}"
+    self.lower = lower
+    self.upper = upper
+
+  def contains(self, other: Union['Range', float]) -> bool:
+    """Return whether other range or float is contained (a subset of) this range."""
+    if isinstance(other, (float, int)):
+      return self.lower <= other <= self.upper
+    elif isinstance(other, Range):
+      return self.lower <= other.lower and other.upper <= self.upper
+    else:
+      raise ValueError(f"unknown other {other}")

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -2,6 +2,10 @@ from typing import Tuple, Union
 
 
 class Range:
+  """A range type that indicates a range of values and provides utility functions. Immutable.
+   Ends are treated as inclusive (closed).
+   """
+
   @staticmethod
   def from_tolerance(center: float, tolerance: Union[float, Tuple[float, float]]) -> 'Range':
     """Creates a Range given a center value and normalized tolerance percentage.
@@ -26,8 +30,11 @@ class Range:
     """Creates a Range from upper to negative infinity"""
     return Range(float('-inf'), upper)
 
-  """A range type that indicates a range of values and provides utility functions
-   Ends are treated as inclusive (closed)."""
+  @staticmethod
+  def all() -> 'Range':
+    """Creates a Range that is a superset of every range"""
+    return Range(float('-inf'), float('inf'))
+
   def __init__(self, lower: float, upper: float):
     assert lower <= upper, f"invalid range with lower {lower} > upper {upper}"
     self.lower = lower
@@ -41,3 +48,15 @@ class Range:
       return self.lower <= item.lower and item.upper <= self.upper
     else:
       raise ValueError(f"unknown other {item}")
+
+  def __mul__(self, other: float) -> 'Range':
+    assert isinstance(other, (float, int))
+    if other >= 0:
+      return Range(self.lower * other, self.upper * other)
+    else:
+      return Range(self.upper * other, self.lower * other)
+
+  def __eq__(self, other) -> bool:
+    if not isinstance(other, Range):
+      return False
+    return self.lower == other.lower and self.upper == other.upper

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -103,7 +103,7 @@ class Range:
     elif isinstance(item, Range):
       return self.lower <= item.lower and item.upper <= self.upper
     else:
-      raise ValueError(f"unknown other {item}")
+      return NotImplemented
 
   def intersects(self, other: 'Range') -> bool:
     return (self.upper >= other.lower) and (self.lower <= other.upper)
@@ -148,8 +148,7 @@ class Range:
 
   def __truediv__(self, other: Union['Range', float]) -> 'Range':
     if isinstance(other, Range):
-      assert (self.lower >= 0 and self.upper >= 0) or (self.lower <= 0 and self.upper <= 0), \
-        "TODO invert with range crossing zero not supported"
+      assert other.lower >= 0 or other.upper <= 0, "TODO invert with range crossing zero not supported"
       corners = [self.lower / other.lower,
                  self.lower / other.upper,
                  self.upper / other.lower,
@@ -164,8 +163,7 @@ class Range:
       return NotImplemented
 
   def __rtruediv__(self, other: float) -> 'Range':
-    assert (self.lower >= 0 and self.upper >= 0) or (self.lower <= 0 and self.upper <= 0), \
-      "TODO invert with range crossing zero not supported"
+    assert self.lower >= 0 or self.upper <= 0, "TODO invert with range crossing zero not supported"
     if isinstance(other, (float, int)):
       return Range(other / self.upper, other / self.lower)
     else:
@@ -176,3 +174,23 @@ class Range:
       return Range(self.lower, new_upper)
     else:
       return self
+
+  def bound_to(self, bounds: 'Range') -> 'Range':
+    """Adjusts this range to be within the input bounds.
+    If the ranges intersect, returns the intersection.
+    If the ranges do not intersect, returns the point at the closer edge of the bounds."""
+    if self.lower < bounds.lower:
+      new_lower = bounds.lower
+    elif self.lower > bounds.upper:
+      new_lower = bounds.upper
+    else:
+      new_lower = self.lower
+
+    if self.upper < bounds.lower:
+      new_upper = bounds.lower
+    elif self.upper > bounds.upper:
+      new_upper = bounds.upper
+    else:
+      new_upper = self.upper
+
+    return Range(new_lower, new_upper)

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -90,6 +90,9 @@ class Range:
       return False
     return self.lower == other.lower and self.upper == other.upper
 
+  def center(self) -> float:
+    return self.lower + self.upper / 2
+
   def __contains__(self, item: Union['Range', float]) -> bool:
     """Return whether other range or float is contained (a subset of) this range."""
     if isinstance(item, (float, int)):
@@ -98,6 +101,17 @@ class Range:
       return self.lower <= item.lower and item.upper <= self.upper
     else:
       raise ValueError(f"unknown other {item}")
+
+  def intersects(self, other: 'Range') -> bool:
+    return (self.upper >= other.lower) and (self.lower <= other.upper)
+
+  def __add__(self, other: Union['Range', float]) -> 'Range':
+    if isinstance(other, Range):
+      return Range(self.lower + other.lower, self.upper + other.upper)
+    elif isinstance(other, (float, int)):
+      return Range(self.lower + other, self.upper + other)
+    else:
+      return NotImplemented
 
   def __mul__(self, other: Union['Range', float]) -> 'Range':
     if isinstance(other, Range):

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -82,8 +82,8 @@ class Range:
 
   def __init__(self, lower: float, upper: float):
     assert lower <= upper, f"invalid range with lower {lower} > upper {upper}"
-    self.lower = lower
-    self.upper = upper
+    self.lower = float(lower)
+    self.upper = float(upper)
 
   def __eq__(self, other) -> bool:
     if not isinstance(other, Range):

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -94,7 +94,7 @@ class Range:
     return self.lower == other.lower and self.upper == other.upper
 
   def center(self) -> float:
-    return self.lower + self.upper / 2
+    return (self.lower + self.upper) / 2
 
   def __contains__(self, item: Union['Range', float]) -> bool:
     """Return whether other range or float is contained (a subset of) this range."""

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -33,11 +33,11 @@ class Range:
     self.lower = lower
     self.upper = upper
 
-  def contains(self, other: Union['Range', float]) -> bool:
+  def __contains__(self, item: Union['Range', float]) -> bool:
     """Return whether other range or float is contained (a subset of) this range."""
-    if isinstance(other, (float, int)):
-      return self.lower <= other <= self.upper
-    elif isinstance(other, Range):
-      return self.lower <= other.lower and other.upper <= self.upper
+    if isinstance(item, (float, int)):
+      return self.lower <= item <= self.upper
+    elif isinstance(item, Range):
+      return self.lower <= item.lower and item.upper <= self.upper
     else:
-      raise ValueError(f"unknown other {other}")
+      raise ValueError(f"unknown other {item}")

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -113,6 +113,12 @@ class Range:
     else:
       return NotImplemented
 
+  def __rsub__(self, other: float) -> 'Range':
+    if isinstance(other, (float, int)):
+      return Range(other - self.upper, other - self.lower)
+    else:
+      return NotImplemented
+
   def __mul__(self, other: Union['Range', float]) -> 'Range':
     if isinstance(other, Range):
       corners = [self.lower * other.lower,
@@ -161,3 +167,9 @@ class Range:
       return Range(other / self.upper, other / self.lower)
     else:
       return NotImplemented
+
+  def extend_upper_to(self, new_upper: float) -> 'Range':
+    if new_upper > self.upper:
+      return Range(self.lower, new_upper)
+    else:
+      return self

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -123,6 +123,15 @@ class Range:
     else:
       return NotImplemented
 
+  def __truediv__(self, other: float) -> 'Range':
+    if isinstance(other, (float, int)):
+      if other >= 0:
+        return Range(self.lower / other, self.upper / other)
+      else:
+        return Range(self.upper / other, self.lower / other)
+    else:
+      return NotImplemented
+
   def __rtruediv__(self, other: float) -> 'Range':
     assert (self.lower >= 0 and self.upper >= 0) or (self.lower <= 0 and self.upper <= 0), \
       "TODO invert with range crossing zero not supported"

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -7,6 +7,42 @@ class Range:
    """
 
   @staticmethod
+  def cancel_multiply(input_side: 'Range', output_side: 'Range') -> 'Range':
+    """
+    Range multiplication is weird and 1/x * x does not cancel out, because it's tolerance-expanding.
+    Using the RC frequency example, w = 1/(2 pi R C), which solves for the output and tolerances of w
+    given R and C (with tolerances), if we want instead solve for C given R and target w,
+    we can't simply do C = 1/(2 pi R w) - which would be tolerance-expanding from R and w to C.
+
+    To understand why, it helps to break ranges into vectors:
+
+    [w_max  = 1/2pi * [1/R_min  * [1/C_min
+     w_min]            1/R_max]    1/C_max]
+
+    Note that to cancel the vectors (so they equal [1, 1], we need to invert the vector components
+    without flipping the order. For example, to move the C to the left side, we need to multiply
+    both sides by:
+
+    [C_min
+     C_max]
+
+    which itself is an invalid range, since the top element is lower than the bottom element.
+    Doing the same with w, this resolves into
+
+    [C_min  = 1/2pi * [1/R_min  * [1/w_max
+     C_max]            1/R_max]    1/w_min]
+
+    So that this function does is:
+    flip(input_side * flip(output_side))
+    and the above would be expressed as:
+    C = cancel_multiply(1/(2*pi*R), 1/w)
+
+    THIS MAY RETURN AN EMPTY RANGE - for example, if the input tolerance is larger than the
+    output tolerance (so no result would satisfy the original equiation).
+    """
+    pass
+
+  @staticmethod
   def from_tolerance(center: float, tolerance: Union[float, Tuple[float, float]]) -> 'Range':
     """Creates a Range given a center value and normalized tolerance percentage.
     If a single tolerance is given, it is treated as bidirectional (+/- value).

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -35,6 +35,9 @@ class Range:
     """Creates a Range that is a superset of every range"""
     return Range(float('-inf'), float('inf'))
 
+  def __repr__(self) -> str:
+    return f"Range({self.lower, self.upper})"
+
   def __init__(self, lower: float, upper: float):
     assert lower <= upper, f"invalid range with lower {lower} > upper {upper}"
     self.lower = lower

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -137,8 +137,16 @@ class Range:
     else:
       return NotImplemented
 
-  def __truediv__(self, other: float) -> 'Range':
-    if isinstance(other, (float, int)):
+  def __truediv__(self, other: Union['Range', float]) -> 'Range':
+    if isinstance(other, Range):
+      assert (self.lower >= 0 and self.upper >= 0) or (self.lower <= 0 and self.upper <= 0), \
+        "TODO invert with range crossing zero not supported"
+      corners = [self.lower / other.lower,
+                 self.lower / other.upper,
+                 self.upper / other.lower,
+                 self.upper / other.upper]
+      return Range(min(corners), max(corners))
+    elif isinstance(other, (float, int)):
       if other >= 0:
         return Range(self.lower / other, self.upper / other)
       else:

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -9,17 +9,20 @@ class Range:
   @staticmethod
   def cancel_multiply(input_side: 'Range', output_side: 'Range') -> 'Range':
     """
+    This satisfies the property, for Range x:
+    cancel_multiply(x, 1/x) = Range(1, 1)
+
     Range multiplication is weird and 1/x * x does not cancel out, because it's tolerance-expanding.
     Using the RC frequency example, w = 1/(2 pi R C), which solves for the output and tolerances of w
     given R and C (with tolerances), if we want instead solve for C given R and target w,
     we can't simply do C = 1/(2 pi R w) - which would be tolerance-expanding from R and w to C.
 
-    To understand why, it helps to break ranges into vectors:
+    To understand why, it helps to break ranges into tuples:
 
     [w_max  = 1/2pi * [1/R_min  * [1/C_min
      w_min]            1/R_max]    1/C_max]
 
-    Note that to cancel the vectors (so they equal [1, 1], we need to invert the vector components
+    Note that to cancel the tuples (so they equal [1, 1], we need to invert the components
     without flipping the order. For example, to move the C to the left side, we need to multiply
     both sides by:
 

--- a/edg_core/Range.py
+++ b/edg_core/Range.py
@@ -50,11 +50,13 @@ class Range:
       raise ValueError(f"unknown other {item}")
 
   def __mul__(self, other: float) -> 'Range':
-    assert isinstance(other, (float, int))
-    if other >= 0:
-      return Range(self.lower * other, self.upper * other)
+    if isinstance(other, (float, int)):
+      if other >= 0:
+        return Range(self.lower * other, self.upper * other)
+      else:
+        return Range(self.upper * other, self.lower * other)
     else:
-      return Range(self.upper * other, self.lower * other)
+      return NotImplemented
 
   def __eq__(self, other) -> bool:
     if not isinstance(other, Range):

--- a/edg_core/__init__.py
+++ b/edg_core/__init__.py
@@ -1,6 +1,5 @@
 from .ConstraintExpr import BoolExpr, FloatExpr, IntExpr, RangeExpr, StringExpr
 from .ConstraintExpr import BoolLike, FloatLike, IntLike, RangeLike, StringLike, LiteralConstructor
-from .ConstraintExpr import RangeLit as RangeVal
 from .ConstraintExpr import Default
 from .Ports import Port, Bundle
 from .NotConnectablePort import NotConnectableBlock, NotConnectablePort

--- a/edg_core/__init__.py
+++ b/edg_core/__init__.py
@@ -11,6 +11,8 @@ from .PortBlocks import PortBridge, PortAdapter
 from .Array import Vector
 from .PortTag import PortTag, Input, Output, InOut
 
+from .Range import Range
+
 from .IdentityDict import IdentityDict
 from .MultiBiDict import MultiBiDict
 

--- a/edg_core/test_block.py
+++ b/edg_core/test_block.py
@@ -85,5 +85,5 @@ class BlockProtoTestCase(unittest.TestCase):
 
   def test_param_init(self) -> None:
     self.assertEqual(
-      edgir.AssignLit(['range_init'], (-4.2, -1.3)),
+      edgir.AssignLit(['range_init'], Range(-4.2, -1.3)),
       self.pb.constraints["(init)range_init"])

--- a/edg_core/test_generator.py
+++ b/edg_core/test_generator.py
@@ -150,7 +150,7 @@ class TestGeneratorConnect(unittest.TestCase):
 
     self.assertEqual(compiled.get_value(['generator', 'connected']), True)
     self.assertEqual(compiled.get_value(['link', 'source_float']), 2.0)
-    self.assertEqual(compiled.get_value(['link', 'sinks_range']), (0.5, 2.5))
+    self.assertEqual(compiled.get_value(['link', 'sinks_range']), Range(0.5, 2.5))
 
   def test_generator_not_connected(self):
     compiled = ScalaCompiler.compile(TestGeneratorNotConnectedTop)
@@ -161,7 +161,7 @@ class TestGeneratorConnect(unittest.TestCase):
     compiled = ScalaCompiler.compile(TestGeneratorInnerConnectTop)
 
     self.assertEqual(compiled.get_value(['link', 'source_float']), 4.5)
-    self.assertEqual(compiled.get_value(['link', 'sinks_range']), (1.5, 3.5))
+    self.assertEqual(compiled.get_value(['link', 'sinks_range']), Range(1.5, 3.5))
 
 
 class TestGeneratorException(BaseException):

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -45,6 +45,10 @@ class RangeTestCase(unittest.TestCase):
 
     self.assertTrue(Range(1.1, 5) * 2 == Range(2.2, 10))
 
+  def test_cancel_property(self) -> None:
+    range1 = Range(10, 20)
+    self.assertEqual(Range.cancel_multiply(range1, 1/range1), Range(1, 1))
+
   def test_frequency(self) -> None:
     """Tests (back-)calculating C from target w and R - so tolerancing flows from R and C to w
     instead of w and R to C."""

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -1,0 +1,32 @@
+import unittest
+
+from . import Range
+
+class RangeTestCase(unittest.TestCase):
+  def test_range_contains(self) -> None:
+    self.assertTrue(Range(0, 1).contains(0.5))
+    self.assertTrue(Range(0, 1).contains(Range(0, 1)))
+
+    self.assertFalse(Range(0, 1).contains(Range(0, 1.1)))
+
+  def test_range_tolerance(self) -> None:
+    self.assertEqual(Range.from_tolerance(100, 0.05).upper, 105)
+    self.assertEqual(Range.from_tolerance(100, 0.05).lower, 95)
+    self.assertEqual(Range.from_tolerance(1000, (-0.1, 0.05)).lower, 900)
+    self.assertEqual(Range.from_tolerance(1000, (-0.1, 0.05)).upper, 1050)
+
+  def test_from(self) -> None:
+    self.assertEqual(Range.from_lower(500).upper, float('inf'))
+    self.assertEqual(Range.from_lower(500).lower, 500)
+    self.assertTrue(Range.from_lower(500).contains(500))
+    self.assertTrue(Range.from_lower(500).contains(1e12))
+    self.assertFalse(Range.from_lower(500).contains(499))
+    self.assertFalse(Range.from_lower(500).contains(0))
+    self.assertFalse(Range.from_lower(500).contains(float('-inf')))
+
+    self.assertEqual(Range.from_upper(500).upper, 500)
+    self.assertEqual(Range.from_upper(500).lower, float('-inf'))
+    self.assertTrue(Range.from_upper(500).contains(0))
+    self.assertTrue(Range.from_upper(500).contains(-1e12))
+    self.assertFalse(Range.from_upper(500).contains(1000))
+    self.assertFalse(Range.from_upper(500).contains(float('inf')))

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -43,7 +43,9 @@ class RangeTestCase(unittest.TestCase):
     self.assertTrue(Range.all() == Range.all())
     self.assertTrue(Range.all() != Range(1.2, 5))
 
-    self.assertTrue(Range(1.1, 5) * 2 == Range(2.2, 10))
+    self.assertEqual(Range(1.1, 5) * 2, Range(2.2, 10))
+
+    self.assertEqual(Range(1, 5).center(), 3)
 
   def test_intersect(self) -> None:
     self.assertTrue(Range(-1, 2).intersects(Range(2, 3)))

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -4,10 +4,10 @@ from . import Range
 
 class RangeTestCase(unittest.TestCase):
   def test_range_contains(self) -> None:
-    self.assertTrue(Range(0, 1).contains(0.5))
-    self.assertTrue(Range(0, 1).contains(Range(0, 1)))
+    self.assertTrue(0.5 in Range(0, 1))
+    self.assertTrue(Range(0, 1) in Range(0, 1))
 
-    self.assertFalse(Range(0, 1).contains(Range(0, 1.1)))
+    self.assertFalse(Range(0, 1.1) in Range(0, 1))
 
   def test_range_tolerance(self) -> None:
     self.assertEqual(Range.from_tolerance(100, 0.05).upper, 105)
@@ -18,15 +18,15 @@ class RangeTestCase(unittest.TestCase):
   def test_from(self) -> None:
     self.assertEqual(Range.from_lower(500).upper, float('inf'))
     self.assertEqual(Range.from_lower(500).lower, 500)
-    self.assertTrue(Range.from_lower(500).contains(500))
-    self.assertTrue(Range.from_lower(500).contains(1e12))
-    self.assertFalse(Range.from_lower(500).contains(499))
-    self.assertFalse(Range.from_lower(500).contains(0))
-    self.assertFalse(Range.from_lower(500).contains(float('-inf')))
+    self.assertTrue(500 in Range.from_lower(500))
+    self.assertTrue(1e12 in Range.from_lower(500))
+    self.assertFalse(499 in Range.from_lower(500))
+    self.assertFalse(0 in Range.from_lower(500))
+    self.assertFalse(float('-inf') in Range.from_lower(500))
 
     self.assertEqual(Range.from_upper(500).upper, 500)
     self.assertEqual(Range.from_upper(500).lower, float('-inf'))
-    self.assertTrue(Range.from_upper(500).contains(0))
-    self.assertTrue(Range.from_upper(500).contains(-1e12))
-    self.assertFalse(Range.from_upper(500).contains(1000))
-    self.assertFalse(Range.from_upper(500).contains(float('inf')))
+    self.assertTrue(0 in Range.from_upper(500))
+    self.assertTrue(-1e12 in Range.from_upper(500))
+    self.assertFalse(1000 in Range.from_upper(500))
+    self.assertFalse(float('inf') in Range.from_upper(500))

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -45,6 +45,15 @@ class RangeTestCase(unittest.TestCase):
 
     self.assertTrue(Range(1.1, 5) * 2 == Range(2.2, 10))
 
+  def test_intersect(self) -> None:
+    self.assertTrue(Range(-1, 2).intersects(Range(2, 3)))
+    self.assertTrue(Range(-1, 2).intersects(Range(0, 3)))
+    self.assertTrue(Range(-1, 2).intersects(Range(-2, -1)))
+    self.assertTrue(Range(-1, 2).intersects(Range(-2, 0)))
+    self.assertTrue(Range(-1, 2).intersects(Range(0, 1)))
+    self.assertFalse(Range(-1, 2).intersects(Range(3, 4)))
+    self.assertFalse(Range(-1, 2).intersects(Range(-3, -2)))
+
   def test_cancel_property(self) -> None:
     range1 = Range(10, 20)
     self.assertEqual(Range.cancel_multiply(range1, 1/range1), Range(1, 1))

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -58,3 +58,16 @@ class RangeTestCase(unittest.TestCase):
     solved = Range.cancel_multiply(1/(2*math.pi * R), 1/w)
     self.assertTrue(math.isclose(C.lower, solved.lower))
     self.assertTrue(math.isclose(C.upper, solved.upper))
+
+  def test_bound(self) -> None:
+    """Tests (back-)calculating C from target w and R - so tolerancing flows from R and C to w
+    instead of w and R to C."""
+    self.assertEqual(Range(0, 1).bound_to(Range(0.5, 1.5)),
+                     Range(0.5, 1))
+    self.assertEqual(Range(0, 1).bound_to(Range(-0.5, 0.5)),
+                     Range(0, 0.5))
+
+    self.assertEqual(Range(0, 1).bound_to(Range(10, 20)),
+                     Range(10, 10))
+    self.assertEqual(Range(0, 1).bound_to(Range(-20, -10)),
+                     Range(-10, -10))

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 from . import Range
@@ -43,3 +44,13 @@ class RangeTestCase(unittest.TestCase):
     self.assertTrue(Range.all() != Range(1.2, 5))
 
     self.assertTrue(Range(1.1, 5) * 2 == Range(2.2, 10))
+
+  def test_frequency(self) -> None:
+    """Tests (back-)calculating C from target w and R - so tolerancing flows from R and C to w
+    instead of w and R to C."""
+    R = Range(90, 110)
+    C = Range.from_tolerance(1e-6, 0.05)
+    w = 1 / (2 * math.pi * R * C)
+    solved = Range.cancel_multiply(1/(2*math.pi * R), 1/w)
+    self.assertTrue(math.isclose(C.lower, solved.lower))
+    self.assertTrue(math.isclose(C.upper, solved.upper))

--- a/edg_core/test_range.py
+++ b/edg_core/test_range.py
@@ -30,3 +30,16 @@ class RangeTestCase(unittest.TestCase):
     self.assertTrue(-1e12 in Range.from_upper(500))
     self.assertFalse(1000 in Range.from_upper(500))
     self.assertFalse(float('inf') in Range.from_upper(500))
+
+  def test_all(self) -> None:
+    self.assertTrue(Range.all() in Range.all())
+    self.assertTrue(0 in Range.all())
+    self.assertTrue(1e12 in Range.all())
+
+  def test_ops(self) -> None:
+    self.assertTrue(Range(1.1, 5) == Range(1.1, 5))
+    self.assertTrue(Range(1.1, 5) != Range(1.2, 5))
+    self.assertTrue(Range.all() == Range.all())
+    self.assertTrue(Range.all() != Range(1.2, 5))
+
+    self.assertTrue(Range(1.1, 5) * 2 == Range(2.2, 10))

--- a/edg_core/test_simple_const_prop.py
+++ b/edg_core/test_simple_const_prop.py
@@ -26,7 +26,7 @@ class TestParameterConstProp(Block):
     self.assign(self.float_const, 2.0)
     self.assign(self.float_param, self.float_const)
 
-    self.assign(self.range_const, (1.0, 42.0))
+    self.assign(self.range_const, Range(1.0, 42.0))
     self.assign(self.range_param, self.range_const)
 
     self.block = self.Block(TestConstPropInternal())
@@ -43,8 +43,8 @@ class ConstPropTestCase(unittest.TestCase):
     self.assertEqual(self.compiled.get_value(['block', 'float_param']), 2.0)
 
   def test_range_prop(self) -> None:
-    self.assertEqual(self.compiled.get_value(['range_const']), (1.0, 42.0))
-    self.assertEqual(self.compiled.get_value(['block', 'range_param']), (1.0, 42.0))
+    self.assertEqual(self.compiled.get_value(['range_const']), Range(1.0, 42.0))
+    self.assertEqual(self.compiled.get_value(['block', 'range_param']), Range(1.0, 42.0))
 
 
 class TestPortConstPropLink(Link):

--- a/edg_core/test_simple_expr_eval.py
+++ b/edg_core/test_simple_expr_eval.py
@@ -21,7 +21,7 @@ class EvalExprTestCase(unittest.TestCase):
 
   def test_sum(self) -> None:
     self.assertEqual(self.compiled.get_value(['sum_float']), 5.0)
-    self.assertEqual(self.compiled.get_value(['sum_range']), (9.0, 14.0))
+    self.assertEqual(self.compiled.get_value(['sum_range']), Range(9.0, 14.0))
 
 
 class TestReductionLink(Link):
@@ -61,6 +61,6 @@ class EvalReductionTestCase(unittest.TestCase):
     self.compiled = ScalaCompiler.compile(TestEvalReductionBlock)
 
   def test_reduce(self) -> None:
-    self.assertEqual(self.compiled.get_value(['link', 'range_sum']), (6.0, 130.0))
-    self.assertEqual(self.compiled.get_value(['link', 'range_intersection']), (5.0, 10.0))
+    self.assertEqual(self.compiled.get_value(['link', 'range_sum']), Range(6.0, 130.0))
+    self.assertEqual(self.compiled.get_value(['link', 'range_intersection']), Range(5.0, 10.0))
     self.assertEqual(self.compiled.get_value(['link', 'ports', edgir.LENGTH]), 3)

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -123,9 +123,6 @@ class DiscreteBuckConverter(BuckConverter):
     # This range must be constructed manually to not double-count the tolerance stackup of the voltages
     inductance_min = (output_voltage.lower * (input_voltage.upper - output_voltage.lower) /
                       (ripple_current.upper * frequency.lower * input_voltage.upper))
-    # if ripple_current.lower == 0:
-    #   inductance_max = float('inf')
-    # else:
     inductance_max = (output_voltage.lower * (input_voltage.upper - output_voltage.lower) /
                       (ripple_current.upper * frequency.lower / input_voltage.upper))
     inductance = Range(inductance_min, inductance_max)

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -87,9 +87,9 @@ class DiscreteBuckConverter(BuckConverter):
   WORST_EFFICIENCY_ESTIMATE = 0.9  # from TI reference
 
   def _generate_converter(self, switch_node: VoltageSource, rated_max_current_amps: float,
-                          input_voltage: RangeVal, output_voltage: RangeVal,
-                          output_current_max: float, frequency: RangeVal,
-                          spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal
+                          input_voltage: Range, output_voltage: Range,
+                          output_current_max: float, frequency: Range,
+                          spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range
                           ) -> Passive:
     """
     Given the switch node, generates the passive (in and out filter caps, inductor) components,
@@ -185,9 +185,9 @@ class DiscreteBoostConverter(BoostConverter):
   WORST_EFFICIENCY_ESTIMATE = 0.8  # from TI reference
 
   def _generate_converter(self, switch_node: VoltageSource, rated_max_current_amps: float,
-                          input_voltage: RangeVal, output_voltage: RangeVal,
-                          output_current_max: float, frequency: RangeVal,
-                          spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal
+                          input_voltage: Range, output_voltage: Range,
+                          output_current_max: float, frequency: Range,
+                          spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range
                           ) -> None:
     """
     - diode needs to be fast, consider forward voltage drop, forward current (> peak inductor current), reverse volts (> Vout)

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -106,55 +106,53 @@ class DiscreteBuckConverter(BuckConverter):
     TODO support capacitor ESR calculation
     TODO unify rated max current with something else, perhaps a block param?
     """
-
-    in_voltage_min, in_voltage_max = input_voltage
-    out_voltage_min, out_voltage_max = output_voltage
-    freq_min, freq_max = frequency
-
-    dc_max = out_voltage_max / in_voltage_min / self.WORST_EFFICIENCY_ESTIMATE
-    dc_min = out_voltage_min / in_voltage_max
-    self.assign(self.dutycycle, (dc_min, dc_max))
+    dutycycle = output_voltage / input_voltage / Range(self.WORST_EFFICIENCY_ESTIMATE, 1)
+    dutycycle_limit = Range(self.DUTYCYCLE_MIN_LIMIT, self.DUTYCYCLE_MAX_LIMIT)
+    self.assign(self.dutycycle, dutycycle)
     # if these are violated, these generally mean that the converter will start tracking the input
     # these can (maybe?) be waived if tracking (plus losses) is acceptable
-    self.require(self.dutycycle.upper() <= self.DUTYCYCLE_MAX_LIMIT, f"dutycycle max outside limit {self.DUTYCYCLE_MAX_LIMIT}")
-    self.require(self.dutycycle.lower() >= self.DUTYCYCLE_MIN_LIMIT, f"dutycycle min outside limit {self.DUTYCYCLE_MIN_LIMIT}")
-
+    self.require(self.dutycycle.within(dutycycle_limit), f"dutycycle {dutycycle} outside limit {dutycycle_limit}")
     # these are actual numbers to be used in calculations
-    effective_dc_min = max(self.DUTYCYCLE_MIN_LIMIT, dc_min)
-    effective_dc_max = min(self.DUTYCYCLE_MAX_LIMIT, dc_max)
+    effective_dutycycle = Range(max(dutycycle_limit.lower, dutycycle.lower),
+                                min(dutycycle_limit.upper, dutycycle.upper))
 
-    ripple_current_min = output_current_max * ripple_factor[0]  # peak-peak
-    ripple_current_max = max(
-      output_current_max * ripple_factor[1],  # peak-peak
-      rated_max_current_amps * ripple_factor[0]  # see LMR33630 datasheet, use rating if current draw much lower
+    ripple_current = (output_current_max * ripple_factor).extend_upper_to(
+      rated_max_current_amps * ripple_factor.lower  # see LMR33630 datasheet, use rating if current draw much lower
     )
 
     # Calculate minimum inductance based on worst case values (operating range corners producing maximum inductance)
-    inductance_min = out_voltage_min * (in_voltage_max - out_voltage_min) / ripple_current_max / freq_min / in_voltage_max
-    if ripple_current_min == 0:
-      inductance_max = float('inf')
-    else:
-      inductance_max = out_voltage_min * (in_voltage_max - out_voltage_min) / ripple_current_min / freq_min / in_voltage_max
+    # This range must be constructed manually to not double-count the tolerance stackup of the voltages
+    inductance_min = (output_voltage.lower * (input_voltage.upper - output_voltage.lower) /
+                      (ripple_current.upper * frequency.lower * input_voltage.upper))
+    # if ripple_current.lower == 0:
+    #   inductance_max = float('inf')
+    # else:
+    inductance_max = (output_voltage.lower * (input_voltage.upper - output_voltage.lower) /
+                      (ripple_current.upper * frequency.lower / input_voltage.upper))
+    inductance = Range(inductance_min, inductance_max)
 
-    out_capacitance_min = ripple_current_max / 8 / freq_min / spec_output_ripple  # TODO size based on transient response, add to voltage tolerance stackups
-    in_capacitance_min = output_current_max * effective_dc_max * (1 - effective_dc_min) / freq_min / spec_input_ripple
+    # TODO size based on transient response, add to voltage tolerance stackups
+    output_capacitance = Range.from_lower(ripple_current.upper / (8 * frequency.lower * spec_output_ripple))
+    # TODO pick a single worst-case DC
+    input_capacitance = Range.from_lower(output_current_max * effective_dutycycle.upper * (1 - effective_dutycycle.lower) /
+                                         (frequency.lower / spec_input_ripple))
 
-    sw_current_max = output_current_max + ripple_current_max / 2
+    sw_current_max = output_current_max + ripple_current.upper / 2
 
     self.inductor = self.Block(Inductor(
-      inductance=(inductance_min, inductance_max)*Henry,
+      inductance=inductance*Henry,
       current=(0, sw_current_max)*Amp,
-      frequency=(freq_min, freq_max)*Hertz
+      frequency=frequency*Hertz
     ))
 
     # TODO: DC derating
     # Note, implicit connect is not great here because of the different power in / power out rails
     # But maybe something can be done with ground?
     self.in_cap = self.Block(DecouplingCapacitor(
-      capacitance=(in_capacitance_min, float('inf'))*Farad,
+      capacitance=input_capacitance*Farad,
     ))
     self.out_cap = self.Block(DecouplingCapacitor(
-      capacitance=(out_capacitance_min, float('inf'))*Farad,
+      capacitance=output_capacitance*Farad,
     ))
     self._pwr_in_net = self.connect(self.pwr_in, self.in_cap.pwr)
     self._pwr_out_net = self.connect(self.pwr_out, self.out_cap.pwr)
@@ -211,52 +209,48 @@ class DiscreteBoostConverter(BoostConverter):
 
     TODO support capacitor ESR calculation
     """
-
-    in_voltage_min, in_voltage_max = input_voltage
-    out_voltage_min, out_voltage_max = output_voltage
-    freq_min, freq_max = frequency
-
-    dc_max = 1 - in_voltage_min * self.WORST_EFFICIENCY_ESTIMATE / out_voltage_max
-    dc_min = 1 - in_voltage_max / out_voltage_min
-
-    self.assign(self.dutycycle, (dc_min, dc_max))
+    dutycycle = output_voltage / input_voltage / Range(self.WORST_EFFICIENCY_ESTIMATE, 1)
+    dutycycle_limit = Range(self.DUTYCYCLE_MIN_LIMIT, self.DUTYCYCLE_MAX_LIMIT)
+    self.assign(self.dutycycle, dutycycle)
     # if these are violated, these generally mean that the converter will start tracking the input
     # these can (maybe?) be waived if tracking (plus losses) is acceptable
-    self.require(self.dutycycle.upper() <= self.DUTYCYCLE_MAX_LIMIT, f"dutycycle max outside limit {self.DUTYCYCLE_MAX_LIMIT}")
-    self.require(self.dutycycle.lower() >= self.DUTYCYCLE_MIN_LIMIT, f"dutycycle min outside limit {self.DUTYCYCLE_MIN_LIMIT}")
-
+    self.require(self.dutycycle.within(dutycycle_limit), f"dutycycle {dutycycle} outside limit {dutycycle_limit}")
     # these are actual numbers to be used in calculations
-    effective_dc_min = max(self.DUTYCYCLE_MIN_LIMIT, dc_min)
-    effective_dc_max = min(self.DUTYCYCLE_MAX_LIMIT, dc_max)
+    effective_dutycycle = Range(max(dutycycle_limit.lower, dutycycle.lower),
+                                min(dutycycle_limit.upper, dutycycle.upper))
 
-    ripple_current_min = output_current_max * ripple_factor[0]  # peak-peak
-    ripple_current_max = max(
-      output_current_max * ripple_factor[1],  # peak-peak
-      rated_max_current_amps * ripple_factor[0]  # see LMR33630 datasheet, use rating if current draw much lower
+    ripple_current = (output_current_max * ripple_factor).extend_upper_to(
+      rated_max_current_amps * ripple_factor.lower  # see LMR33630 datasheet, use rating if current draw much lower
     )
 
     # Calculate minimum inductance based on worst case values (operating range corners producing maximum inductance)
-    inductance_min = in_voltage_min * (out_voltage_max - in_voltage_min) / ripple_current_max / freq_min / out_voltage_min
-    inductance_max = in_voltage_min * (out_voltage_max - in_voltage_min) / ripple_current_min / freq_min / out_voltage_min
-    out_capacitance_min = output_current_max * effective_dc_max / freq_min / spec_output_ripple
-    in_capacitance_min = (output_current_max / effective_dc_min) * (1 - effective_dc_min) / freq_min / spec_input_ripple
+    # This range must be constructed manually to not double-count the tolerance stackup of the voltages
+    inductance_min = (input_voltage.lower * (output_voltage.upper - input_voltage.lower) /
+                      (ripple_current.upper * frequency.lower * output_voltage.lower))
+    inductance_max = (input_voltage.lower * (output_voltage.upper - input_voltage.lower) /
+                      (ripple_current.lower * frequency.lower * output_voltage.lower))
+    inductance = Range(inductance_min, inductance_max)
+    output_capacitance = Range.from_lower(output_current_max * effective_dutycycle.upper /
+                                          (frequency.lower * spec_output_ripple))
+    input_capacitance = Range.from_lower((output_current_max / effective_dutycycle.lower) * (1 - effective_dutycycle.lower) /
+                                         (frequency.lower * spec_input_ripple))
 
-    sw_current_max = ripple_current_max / 2 + output_current_max / (1 - effective_dc_max)
+    sw_current_max = ripple_current.upper / 2 + output_current_max / (1 - effective_dutycycle.upper)
 
     self.inductor = self.Block(Inductor(
-      inductance=(inductance_min, inductance_max)*Henry,
+      inductance=inductance*Henry,
       current=(0, sw_current_max)*Amp,
-      frequency=(freq_min, freq_max)*Hertz
+      frequency=frequency*Hertz
     ))
 
     # TODO: DC derating
     # Note, implicit connect is not great here because of the different power in / power out rails
     # But maybe something can be done with ground?
     self.in_cap = self.Block(DecouplingCapacitor(
-      capacitance=(in_capacitance_min, float('inf'))*Farad,
+      capacitance=input_capacitance*Farad,
     ))
     self.out_cap = self.Block(DecouplingCapacitor(
-      capacitance=(out_capacitance_min, float('inf'))*Farad,
+      capacitance=output_capacitance*Farad,
     ))
     self.connect(self.pwr_in, self.in_cap.pwr, self.inductor.a.as_voltage_sink())
     self.connect(self.pwr_out, self.out_cap.pwr)

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -124,14 +124,14 @@ class DiscreteBuckConverter(BuckConverter):
     inductance_min = (output_voltage.lower * (input_voltage.upper - output_voltage.lower) /
                       (ripple_current.upper * frequency.lower * input_voltage.upper))
     inductance_max = (output_voltage.lower * (input_voltage.upper - output_voltage.lower) /
-                      (ripple_current.upper * frequency.lower / input_voltage.upper))
+                      (ripple_current.lower * frequency.lower * input_voltage.upper))
     inductance = Range(inductance_min, inductance_max)
 
     # TODO size based on transient response, add to voltage tolerance stackups
     output_capacitance = Range.from_lower(ripple_current.upper / (8 * frequency.lower * spec_output_ripple))
     # TODO pick a single worst-case DC
     input_capacitance = Range.from_lower(output_current_max * effective_dutycycle.upper * (1 - effective_dutycycle.lower) /
-                                         (frequency.lower / spec_input_ripple))
+                                         (frequency.lower * spec_input_ripple))
 
     sw_current_max = output_current_max + ripple_current.upper / 2
 

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -209,7 +209,7 @@ class DiscreteBoostConverter(BoostConverter):
 
     TODO support capacitor ESR calculation
     """
-    dutycycle = output_voltage / input_voltage / Range(self.WORST_EFFICIENCY_ESTIMATE, 1)
+    dutycycle = 1 - input_voltage / output_voltage * Range(self.WORST_EFFICIENCY_ESTIMATE, 1)
     dutycycle_limit = Range(self.DUTYCYCLE_MIN_LIMIT, self.DUTYCYCLE_MAX_LIMIT)
     self.assign(self.dutycycle, dutycycle)
     # if these are violated, these generally mean that the converter will start tracking the input

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -86,6 +86,10 @@ class DiscreteBuckConverter(BuckConverter):
   DUTYCYCLE_MAX_LIMIT = 0.9
   WORST_EFFICIENCY_ESTIMATE = 0.9  # from TI reference
 
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+    self.dutycycle = self.Parameter(RangeExpr())  # calculated duty cycle
+
   def _generate_converter(self, switch_node: VoltageSource, rated_max_current_amps: float,
                           input_voltage: Range, output_voltage: Range,
                           output_current_max: float, frequency: Range,
@@ -109,9 +113,15 @@ class DiscreteBuckConverter(BuckConverter):
 
     dc_max = out_voltage_max / in_voltage_min / self.WORST_EFFICIENCY_ESTIMATE
     dc_min = out_voltage_min / in_voltage_max
+    self.assign(self.dutycycle, (dc_min, dc_max))
+    # if these are violated, these generally mean that the converter will start tracking the input
+    # these can (maybe?) be waived if tracking (plus losses) is acceptable
+    self.require(self.dutycycle.upper() <= self.DUTYCYCLE_MAX_LIMIT, f"dutycycle max outside limit {self.DUTYCYCLE_MAX_LIMIT}")
+    self.require(self.dutycycle.lower() >= self.DUTYCYCLE_MIN_LIMIT, f"dutycycle min outside limit {self.DUTYCYCLE_MIN_LIMIT}")
 
-    assert dc_max <= self.DUTYCYCLE_MAX_LIMIT, f"dutycycle max {dc_max} outside limit {self.DUTYCYCLE_MAX_LIMIT}"
-    assert dc_min >= self.DUTYCYCLE_MIN_LIMIT, f"dutycycle min {dc_min} outside limit {self.DUTYCYCLE_MIN_LIMIT}"
+    # these are actual numbers to be used in calculations
+    effective_dc_min = max(self.DUTYCYCLE_MIN_LIMIT, dc_min)
+    effective_dc_max = min(self.DUTYCYCLE_MAX_LIMIT, dc_max)
 
     ripple_current_min = output_current_max * ripple_factor[0]  # peak-peak
     ripple_current_max = max(
@@ -127,7 +137,7 @@ class DiscreteBuckConverter(BuckConverter):
       inductance_max = out_voltage_min * (in_voltage_max - out_voltage_min) / ripple_current_min / freq_min / in_voltage_max
 
     out_capacitance_min = ripple_current_max / 8 / freq_min / spec_output_ripple  # TODO size based on transient response, add to voltage tolerance stackups
-    in_capacitance_min = output_current_max * dc_max * (1 - dc_min) / freq_min / spec_input_ripple
+    in_capacitance_min = output_current_max * effective_dc_max * (1 - effective_dc_min) / freq_min / spec_input_ripple
 
     sw_current_max = output_current_max + ripple_current_max / 2
 
@@ -184,6 +194,10 @@ class DiscreteBoostConverter(BoostConverter):
   DUTYCYCLE_MAX_LIMIT = 0.85  # by datasheet
   WORST_EFFICIENCY_ESTIMATE = 0.8  # from TI reference
 
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+    self.dutycycle = self.Parameter(RangeExpr())  # calculated duty cycle
+
   def _generate_converter(self, switch_node: VoltageSource, rated_max_current_amps: float,
                           input_voltage: Range, output_voltage: Range,
                           output_current_max: float, frequency: Range,
@@ -202,15 +216,18 @@ class DiscreteBoostConverter(BoostConverter):
     out_voltage_min, out_voltage_max = output_voltage
     freq_min, freq_max = frequency
 
-    dc_max = 1 - in_voltage_max / out_voltage_min
-    dc_min = 1 - in_voltage_min * self.WORST_EFFICIENCY_ESTIMATE / out_voltage_max
+    dc_max = 1 - in_voltage_min * self.WORST_EFFICIENCY_ESTIMATE / out_voltage_max
+    dc_min = 1 - in_voltage_max / out_voltage_min
 
-    assert dc_max <= self.DUTYCYCLE_MAX_LIMIT, f"duty cycle {dc_max} over maximum {self.DUTYCYCLE_MAX_LIMIT}, " \
-                                               f"in converting {in_voltage_min}-{in_voltage_max} -> " \
-                                               f"in converting {out_voltage_min}-{out_voltage_max}"
-    assert dc_min >= self.DUTYCYCLE_MIN_LIMIT, f"duty cycle {dc_min} under minimum {self.DUTYCYCLE_MIN_LIMIT}, " \
-                                               f"in converting {in_voltage_min}-{in_voltage_max} -> " \
-                                               f"in converting {out_voltage_min}-{out_voltage_max}"
+    self.assign(self.dutycycle, (dc_min, dc_max))
+    # if these are violated, these generally mean that the converter will start tracking the input
+    # these can (maybe?) be waived if tracking (plus losses) is acceptable
+    self.require(self.dutycycle.upper() <= self.DUTYCYCLE_MAX_LIMIT, f"dutycycle max outside limit {self.DUTYCYCLE_MAX_LIMIT}")
+    self.require(self.dutycycle.lower() >= self.DUTYCYCLE_MIN_LIMIT, f"dutycycle min outside limit {self.DUTYCYCLE_MIN_LIMIT}")
+
+    # these are actual numbers to be used in calculations
+    effective_dc_min = max(self.DUTYCYCLE_MIN_LIMIT, dc_min)
+    effective_dc_max = min(self.DUTYCYCLE_MAX_LIMIT, dc_max)
 
     ripple_current_min = output_current_max * ripple_factor[0]  # peak-peak
     ripple_current_max = max(
@@ -221,10 +238,10 @@ class DiscreteBoostConverter(BoostConverter):
     # Calculate minimum inductance based on worst case values (operating range corners producing maximum inductance)
     inductance_min = in_voltage_min * (out_voltage_max - in_voltage_min) / ripple_current_max / freq_min / out_voltage_min
     inductance_max = in_voltage_min * (out_voltage_max - in_voltage_min) / ripple_current_min / freq_min / out_voltage_min
-    out_capacitance_min = output_current_max * dc_max / freq_min / spec_output_ripple
-    in_capacitance_min = (output_current_max / dc_min) * (1 - dc_min) / freq_min / spec_input_ripple
+    out_capacitance_min = output_current_max * effective_dc_max / freq_min / spec_output_ripple
+    in_capacitance_min = (output_current_max / effective_dc_min) * (1 - effective_dc_min) / freq_min / spec_input_ripple
 
-    sw_current_max = ripple_current_max / 2 + output_current_max / (1 - dc_max)
+    sw_current_max = ripple_current_max / 2 + output_current_max / (1 - effective_dc_max)
 
     self.inductor = self.Block(Inductor(
       inductance=(inductance_min, inductance_max)*Henry,

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -113,8 +113,7 @@ class DiscreteBuckConverter(BuckConverter):
     # these can (maybe?) be waived if tracking (plus losses) is acceptable
     self.require(self.dutycycle.within(dutycycle_limit), f"dutycycle {dutycycle} outside limit {dutycycle_limit}")
     # these are actual numbers to be used in calculations
-    effective_dutycycle = Range(max(dutycycle_limit.lower, dutycycle.lower),
-                                min(dutycycle_limit.upper, dutycycle.upper))
+    effective_dutycycle = dutycycle.bound_to(dutycycle_limit)
 
     ripple_current = (output_current_max * ripple_factor).extend_upper_to(
       rated_max_current_amps * ripple_factor.lower  # see LMR33630 datasheet, use rating if current draw much lower
@@ -216,8 +215,7 @@ class DiscreteBoostConverter(BoostConverter):
     # these can (maybe?) be waived if tracking (plus losses) is acceptable
     self.require(self.dutycycle.within(dutycycle_limit), f"dutycycle {dutycycle} outside limit {dutycycle_limit}")
     # these are actual numbers to be used in calculations
-    effective_dutycycle = Range(max(dutycycle_limit.lower, dutycycle.lower),
-                                min(dutycycle_limit.upper, dutycycle.upper))
+    effective_dutycycle = dutycycle.bound_to(dutycycle_limit)
 
     ripple_current = (output_current_max * ripple_factor).extend_upper_to(
       rated_max_current_amps * ripple_factor.lower  # see LMR33630 datasheet, use rating if current draw much lower

--- a/electronics_abstract_parts/PassiveFilters.py
+++ b/electronics_abstract_parts/PassiveFilters.py
@@ -26,10 +26,7 @@ class LowPassRc(AnalogFilter, GeneratorBlock):
     super().generate()
     self.r = self.Block(Resistor(resistance=self.impedance))  # TODO maybe support power?
     # cutoff frequency is 1/(2 pi R C)
-    c_min = 1 / (2 * pi * impedance.lower * cutoff_freq.upper)
-    c_max = 1 / (2 * pi * impedance.upper * cutoff_freq.lower)
-    assert c_min <= c_max, "tighter cutoff frequency tolerance than resistor tolerance"
-    capacitance = Range(c_min, c_max)
+    capacitance = Range.cancel_multiply(1 / (2 * pi * impedance), 1 / cutoff_freq)
 
     self.c = self.Block(Capacitor(capacitance=capacitance * Farad, voltage=self.voltage))
     self.connect(self.input, self.r.a)

--- a/electronics_abstract_parts/PassiveFilters.py
+++ b/electronics_abstract_parts/PassiveFilters.py
@@ -28,7 +28,7 @@ class LowPassRc(AnalogFilter, GeneratorBlock):
     # cutoff frequency is 1/(2 pi R C)
     capacitance = Range.cancel_multiply(1 / (2 * pi * impedance), 1 / cutoff_freq)
 
-    self.c = self.Block(Capacitor(capacitance=capacitance * Farad, voltage=self.voltage))
+    self.c = self.Block(Capacitor(capacitance=capacitance*Farad, voltage=self.voltage))
     self.connect(self.input, self.r.a)
     self.connect(self.r.b, self.c.pos, self.output)  # TODO support negative voltages?
     self.connect(self.c.neg, self.gnd)

--- a/electronics_abstract_parts/test_resistive_divider.py
+++ b/electronics_abstract_parts/test_resistive_divider.py
@@ -1,6 +1,7 @@
 import unittest
 
-from .ResistiveDivider import ResistiveDivider, Range
+from edg_core import Range
+from .ResistiveDivider import ResistiveDivider
 
 
 class ResistorDividerTest(unittest.TestCase):
@@ -8,34 +9,34 @@ class ResistorDividerTest(unittest.TestCase):
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
       Range(0, 1), Range(0.1, 1), 0.01),
-      Range(1, 1))
+      (1, 1))
 
     self.assertEqual(ResistiveDivider._select_resistor(  # test a tighter range
       ResistiveDivider.E24_SERIES,
       Range(0.48, 0.52), Range(0.1, 1), 0.01),
-      Range(1, 1))
+      (1, 1))
 
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
       Range(0.106, 0.111), Range(0.1, 1), 0.01),  # test E12
-      Range(8.2, 1))
+      (8.2, 1))
 
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
       Range(0.208, 0.215), Range(1, 10), 0.01),  # test E12
-      Range(8.2, 2.2))
+      (8.2, 2.2))
 
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
       Range(0.7241, 0.7321), Range(1, 10), 0.01),  # test E12 across decades
-      Range(5.6, 15))
+      (5.6, 15))
 
     self.assertEqual(ResistiveDivider._select_resistor(  # test impedance decade shift
       ResistiveDivider.E24_SERIES,
       Range(0, 1), Range(10, 100), 0.01),
-      Range(100, 100))
+      (100, 100))
 
     self.assertEqual(ResistiveDivider._select_resistor(  # test everything
       ResistiveDivider.E24_SERIES,
       Range(0.106, 0.111), Range(11, 99), 0.01),  # test E12
-      Range(820, 100))
+      (820, 100))

--- a/electronics_abstract_parts/test_resistive_divider.py
+++ b/electronics_abstract_parts/test_resistive_divider.py
@@ -1,40 +1,41 @@
 import unittest
 
-from .ResistiveDivider import ResistiveDivider
+from .ResistiveDivider import ResistiveDivider, Range
+
 
 class ResistorDividerTest(unittest.TestCase):
   def test_resistor_divider(self) -> None:
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
-      (0, 1), (0.1, 1), 0.01),
-      (1, 1))
+      Range(0, 1), Range(0.1, 1), 0.01),
+      Range(1, 1))
 
     self.assertEqual(ResistiveDivider._select_resistor(  # test a tighter range
       ResistiveDivider.E24_SERIES,
-      (0.48, 0.52), (0.1, 1), 0.01),
-      (1, 1))
+      Range(0.48, 0.52), Range(0.1, 1), 0.01),
+      Range(1, 1))
 
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
-      (0.106, 0.111), (0.1, 1), 0.01),  # test E12
-      (8.2, 1))
+      Range(0.106, 0.111), Range(0.1, 1), 0.01),  # test E12
+      Range(8.2, 1))
 
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
-      (0.208, 0.215), (1, 10), 0.01),  # test E12
-      (8.2, 2.2))
+      Range(0.208, 0.215), Range(1, 10), 0.01),  # test E12
+      Range(8.2, 2.2))
 
     self.assertEqual(ResistiveDivider._select_resistor(
       ResistiveDivider.E24_SERIES,
-      (0.7241, 0.7321), (1, 10), 0.01),  # test E12 across decades
-      (5.6, 15))
+      Range(0.7241, 0.7321), Range(1, 10), 0.01),  # test E12 across decades
+      Range(5.6, 15))
 
     self.assertEqual(ResistiveDivider._select_resistor(  # test impedance decade shift
       ResistiveDivider.E24_SERIES,
-      (0, 1), (10, 100), 0.01),
-      (100, 100))
+      Range(0, 1), Range(10, 100), 0.01),
+      Range(100, 100))
 
     self.assertEqual(ResistiveDivider._select_resistor(  # test everything
       ResistiveDivider.E24_SERIES,
-      (0.106, 0.111), (11, 99), 0.01),  # test E12
-      (820, 100))
+      Range(0.106, 0.111), Range(11, 99), 0.01),  # test E12
+      Range(820, 100))

--- a/electronics_lib/Crystals.py
+++ b/electronics_lib/Crystals.py
@@ -76,7 +76,7 @@ class OscillatorCrystal(DiscreteApplication, GeneratorBlock):  # TODO rename to 
     # Output values
     self.selected_frequency = self.Parameter(RangeExpr())
 
-  def select_part(self, frequency: RangeVal):
+  def select_part(self, frequency: Range):
     # TODO this should be part of the crystal block, but that needs a post-generate elaborate
     parts = self.product_table.filter(RangeContains(Lit(frequency), Column('frequency'))) \
       .sort(Column('Unit Price (USD)'))  # TODO actually make this into float

--- a/electronics_lib/DcDcConverters.py
+++ b/electronics_lib/DcDcConverters.py
@@ -57,9 +57,9 @@ class Tps61023(DiscreteBoostConverter, GeneratorBlock):
                    targets=[self.fb, self.pwr_in, self.pwr_out, self.gnd])
 
 
-  def generate_converter(self, input_voltage: RangeVal, output_voltage: RangeVal,
-                         output_current: RangeVal, frequency: RangeVal,
-                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal) -> None:
+  def generate_converter(self, input_voltage: Range, output_voltage: Range,
+                         output_current: Range, frequency: Range,
+                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range) -> None:
     self.ic = self.Block(Tps61023_Device(
       current_draw=(self.pwr_out.link().current_drawn.lower() * self.pwr_out.voltage_out.lower() / self.pwr_in.link().voltage.upper() / self.efficiency.upper(),
                     self.pwr_out.link().current_drawn.upper() * self.pwr_out.voltage_out.upper() / self.pwr_in.link().voltage.lower() / self.efficiency.lower())
@@ -73,7 +73,7 @@ class Tps61023(DiscreteBoostConverter, GeneratorBlock):
 
     self._generate_converter(self.ic.sw, self.VALLEY_SWITCH_CURRENT_LIMIT,
                              input_voltage=input_voltage, output_voltage=output_voltage,
-                             output_current_max=output_current[1], frequency=frequency,
+                             output_current_max=output_current.upper, frequency=frequency,
                              spec_output_ripple=spec_output_ripple, spec_input_ripple=spec_input_ripple,
                              ripple_factor=ripple_factor)
 
@@ -138,9 +138,9 @@ class Tps561201(DiscreteBuckConverter, GeneratorBlock):
                    self.frequency, self.output_ripple_limit, self.input_ripple_limit, self.ripple_current_factor,
                    targets=[self.fb, self.pwr_in, self.pwr_out, self.gnd])
 
-  def generate_converter(self, input_voltage: RangeVal, output_voltage: RangeVal,
-                         output_current: RangeVal, frequency: RangeVal,
-                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal) -> None:
+  def generate_converter(self, input_voltage: Range, output_voltage: Range,
+                         output_current: Range, frequency: Range,
+                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range) -> None:
     self.ic = self.Block(Tps561201_Device(
       current_draw=(self.pwr_out.link().current_drawn.lower() * self.pwr_out.voltage_out.lower() / self.pwr_in.link().voltage.upper() / self.efficiency.upper(),
                     self.pwr_out.link().current_drawn.upper() * self.pwr_out.voltage_out.upper() / self.pwr_in.link().voltage.lower() / self.efficiency.lower())
@@ -162,7 +162,7 @@ class Tps561201(DiscreteBuckConverter, GeneratorBlock):
     # TODO dedup across all converters
     inductor_out = self._generate_converter(self.ic.sw, 1.2,
                                             input_voltage=input_voltage, output_voltage=output_voltage,
-                                            output_current_max=output_current[1], frequency=frequency,
+                                            output_current_max=output_current.upper, frequency=frequency,
                                             spec_output_ripple=spec_output_ripple, spec_input_ripple=spec_input_ripple,
                                             ripple_factor=ripple_factor)
 
@@ -238,9 +238,9 @@ class Tps54202h(DiscreteBuckConverter, GeneratorBlock):
                    self.frequency, self.output_ripple_limit, self.input_ripple_limit, self.ripple_current_factor,
                    targets=[self.fb, self.pwr_in, self.pwr_out, self.gnd])
 
-  def generate_converter(self, input_voltage: RangeVal, output_voltage: RangeVal,
-                         output_current: RangeVal, frequency: RangeVal,
-                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal) -> None:
+  def generate_converter(self, input_voltage: Range, output_voltage: Range,
+                         output_current: Range, frequency: Range,
+                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range) -> None:
     self.ic = self.Block(Tps54202h_Device(
       current_draw=(self.pwr_out.link().current_drawn.lower() * self.pwr_out.voltage_out.lower() / self.pwr_in.link().voltage.upper() / self.efficiency.upper(),
                     self.pwr_out.link().current_drawn.upper() * self.pwr_out.voltage_out.upper() / self.pwr_in.link().voltage.lower() / self.efficiency.lower())
@@ -268,7 +268,7 @@ class Tps54202h(DiscreteBuckConverter, GeneratorBlock):
     # TODO dedup across all converters
     inductor_out = self._generate_converter(self.ic.sw, 2,
                                             input_voltage=input_voltage, output_voltage=output_voltage,
-                                            output_current_max=output_current[1], frequency=frequency,
+                                            output_current_max=output_current.upper, frequency=frequency,
                                             spec_output_ripple=spec_output_ripple, spec_input_ripple=spec_input_ripple,
                                             ripple_factor=ripple_factor)
 
@@ -357,9 +357,9 @@ class Lmr33630(DiscreteBuckConverter, GeneratorBlock):
                    self.frequency, self.output_ripple_limit, self.input_ripple_limit, self.ripple_current_factor,
                    targets=[self.fb, self.pwr_in, self.pwr_out, self.gnd])
 
-  def generate_converter(self, input_voltage: RangeVal, output_voltage: RangeVal,
-                         output_current: RangeVal, frequency: RangeVal,
-                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal) -> None:
+  def generate_converter(self, input_voltage: Range, output_voltage: Range,
+                         output_current: Range, frequency: Range,
+                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range) -> None:
     self.ic = self.Block(Lmr33630_Device(
       current_draw=(self.pwr_out.link().current_drawn.lower() * self.pwr_out.voltage_out.lower() / self.pwr_in.link().voltage.upper() / self.efficiency.upper(),
                     self.pwr_out.link().current_drawn.upper() * self.pwr_out.voltage_out.upper() / self.pwr_in.link().voltage.lower() / self.efficiency.lower())
@@ -390,7 +390,7 @@ class Lmr33630(DiscreteBuckConverter, GeneratorBlock):
 
     inductor_out = self._generate_converter(self.ic.sw, 3.0,
                                             input_voltage=input_voltage, output_voltage=output_voltage,
-                                            output_current_max=output_current[1], frequency=frequency,
+                                            output_current_max=output_current.upper, frequency=frequency,
                                             spec_output_ripple=spec_output_ripple, spec_input_ripple=spec_input_ripple,
                                             ripple_factor=ripple_factor)
     self.connect(self.pwr_out, inductor_out.as_voltage_source(
@@ -458,9 +458,9 @@ class Ap3012(DiscreteBoostConverter, GeneratorBlock):
                    targets=[self.fb, self.pwr_in, self.pwr_out, self.gnd])
 
 
-  def generate_converter(self, input_voltage: RangeVal, output_voltage: RangeVal,
-                         output_current: RangeVal, frequency: RangeVal,
-                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: RangeVal) -> None:
+  def generate_converter(self, input_voltage: Range, output_voltage: Range,
+                         output_current: Range, frequency: Range,
+                         spec_output_ripple: float, spec_input_ripple: float, ripple_factor: Range) -> None:
     self.ic = self.Block(Ap3012_Device(
       current_draw=(self.pwr_out.link().current_drawn.lower() * self.pwr_out.voltage_out.lower() / self.pwr_in.link().voltage.upper() / self.efficiency.upper(),
                     self.pwr_out.link().current_drawn.upper() * self.pwr_out.voltage_out.upper() / self.pwr_in.link().voltage.lower() / self.efficiency.lower())
@@ -487,6 +487,6 @@ class Ap3012(DiscreteBoostConverter, GeneratorBlock):
 
     self._generate_converter(self.ic.sw, 0.5,
                              input_voltage=input_voltage, output_voltage=output_voltage,
-                             output_current_max=output_current[1], frequency=frequency,
+                             output_current_max=output_current.upper, frequency=frequency,
                              spec_output_ripple=spec_output_ripple, spec_input_ripple=spec_input_ripple,
                              ripple_factor=ripple_factor)

--- a/electronics_lib/DcDcConverters.py
+++ b/electronics_lib/DcDcConverters.py
@@ -30,8 +30,8 @@ class Tps61023_Device(DiscreteChip, FootprintBlock):
     )
 
 class Tps61023(DiscreteBoostConverter, GeneratorBlock):
-
   VALLEY_SWITCH_CURRENT_LIMIT = 3.7
+  DUTYCYCLE_MIN_LIMIT = 0.0  # goes into PFM at light load
 
   def contents(self):
     super().contents()

--- a/electronics_lib/Diodes.py
+++ b/electronics_lib/Diodes.py
@@ -68,8 +68,8 @@ class SmtDiode(Diode, FootprintBlock, GeneratorBlock):
                    self.reverse_recovery_time)
     # TODO: also support optional part and footprint name
 
-  def select_part(self, reverse_voltage: RangeVal, current: RangeVal, voltage_drop: RangeVal,
-                  reverse_recovery_time: RangeVal) -> None:
+  def select_part(self, reverse_voltage: Range, current: Range, voltage_drop: Range,
+                  reverse_recovery_time: Range) -> None:
     # TODO maybe apply ideal diode law / other simple static model to better bound Vf?
     parts = self.product_table.filter(RangeContains(Column('Vr,max'), Lit(reverse_voltage))) \
       .filter(RangeContains(Column('I,max'), Lit(current))) \
@@ -177,7 +177,7 @@ class SmtZenerDiode(ZenerDiode, FootprintBlock, GeneratorBlock):
     self.selected_zener_voltage = self.Parameter(RangeExpr())
     self.selected_forward_voltage_drop = self.Parameter(RangeExpr())
 
-  def select_part(self, zener_voltage: RangeVal, forward_voltage_drop: RangeVal) -> None:
+  def select_part(self, zener_voltage: Range, forward_voltage_drop: Range) -> None:
     # TODO maybe apply ideal diode law / other simple static model to better bound Vf?
     parts = self.product_table.filter(RangeContains(Column('Vz'), Lit(zener_voltage))) \
       .filter(RangeContains(Lit(forward_voltage_drop), Column('Vf,max'))) \

--- a/electronics_lib/Fets.py
+++ b/electronics_lib/Fets.py
@@ -24,8 +24,8 @@ def generate_fet_table(TABLES: List[str]) -> ProductTable:
                     RangeFromUpper(ParseValue(Column('Current - Continuous Drain (Id) @ 25°C'), 'A')),
                     missing='discard') \
     .derived_column('Vgs',
-                    Range(ParseValue(Column('Drive Voltage (Max Rds On,  Min Rds On)'), 'V'),
-                          ParseValue(Column('Vgs (Max)'), 'V')),
+                    MakeRange(ParseValue(Column('Drive Voltage (Max Rds On,  Min Rds On)'), 'V'),
+                              ParseValue(Column('Vgs (Max)'), 'V')),
                     missing='discard') \
     .derived_column('Rds,max',
                     RangeFromUpper(ParseValue(Column('Rds On (Max) @ Id, Vgs'), 'Ohm'), lower=0),

--- a/electronics_lib/Fets.py
+++ b/electronics_lib/Fets.py
@@ -63,8 +63,8 @@ class SmtFet(Fet, FootprintBlock, GeneratorBlock):
                    self.drain_voltage, self.drain_current,
                    self.gate_voltage, self.rds_on, self.gate_charge, self.power)
 
-  def select_part(self, drain_voltage: RangeVal, drain_current: RangeVal,
-                  gate_voltage: RangeVal, rds_on: RangeVal, gate_charge: RangeVal, power: RangeVal) -> None:
+  def select_part(self, drain_voltage: Range, drain_current: Range,
+                  gate_voltage: Range, rds_on: Range, gate_charge: Range, power: Range) -> None:
     parts = self.product_table.filter(RangeContains(Column('Vds,max'), Lit(drain_voltage))) \
       .filter(RangeContains(Column('Ids,max'), Lit(drain_current))) \
       .filter(RangeContains(Column('Vgs'), Lit(gate_voltage))) \
@@ -152,13 +152,13 @@ class SmtSwitchFet(SwitchFet, FootprintBlock, GeneratorBlock):  # TODO dedup w/ 
                    self.drain_voltage, self.drain_current,
                    self.gate_voltage, self.rds_on, self.gate_charge, self.power)
 
-  def select_part(self, frequency: RangeVal, drive_current: RangeVal,
-                  drain_voltage: RangeVal, drain_current: RangeVal,
-                  gate_voltage: RangeVal, rds_on: RangeVal, gate_charge: RangeVal, power: RangeVal) -> None:
-    i_max = drain_current[1]
-    v_max = drain_voltage[1]
-    gate_drive_rise, gate_drive_fall = drive_current[1], -drive_current[0]
-    f_max = frequency[1]
+  def select_part(self, frequency: Range, drive_current: Range,
+                  drain_voltage: Range, drain_current: Range,
+                  gate_voltage: Range, rds_on: Range, gate_charge: Range, power: Range) -> None:
+    i_max = drain_current.upper
+    v_max = drain_voltage.upper
+    gate_drive_rise, gate_drive_fall = drive_current.upper, -drive_current.lower
+    f_max = frequency.upper
     assert gate_drive_rise > 0 and gate_drive_fall > 0, \
       f"got nonpositive gate currents rise={gate_drive_rise} A and fall={gate_drive_fall} A"
 

--- a/electronics_lib/Passives.py
+++ b/electronics_lib/Passives.py
@@ -30,10 +30,10 @@ def zigzag_range(start: int, end: int) -> Sequence[int]:
 def round_sig(x: float, sig: int) -> float:
   return round(x, sig-int(math.floor(math.log10(abs(x))))-1)
 
-def choose_preferred_number(range: Tuple[float, float], tolerance: float, series: List[float], sig: int) ->\
+def choose_preferred_number(range: Range, tolerance: float, series: List[float], sig: int) ->\
     Optional[float]:
-  lower_pow10 = math.floor(math.log10(range[0]))
-  upper_pow10 = math.ceil(math.log10(range[1]))
+  lower_pow10 = math.floor(math.log10(range.lower))
+  upper_pow10 = math.ceil(math.log10(range.upper))
 
   powers = zigzag_range(lower_pow10, upper_pow10)  # prefer the center power first, then zigzag away from it
   # TODO given the tolerance we can actually bound this further
@@ -43,7 +43,7 @@ def choose_preferred_number(range: Tuple[float, float], tolerance: float, series
       pow10_mult = math.pow(10, power)
       value_mult = round_sig(value * pow10_mult, sig)  # this prevents floating point weirdness, eg 819.999
       value_tol = value_mult * tolerance
-      if value_mult - value_tol >= range[0] and value_mult + value_tol <= range[1]:
+      if value_mult - value_tol >= range.lower and value_mult + value_tol <= range.upper:
         return value_mult
 
   return None
@@ -70,22 +70,22 @@ class ESeriesResistor(Resistor, FootprintBlock, GeneratorBlock):
   exact value at 1%.
   If below 1% tolerance is needed, fails. TODO: non-preferentially pick tolerances down to 0.1%, though pricey!
   Picks the minimum (down to 0603, up to 2512) SMD size for the power requirement. TODO: consider PTH types"""
-  def select_resistor(self, resistance: RangeVal, power: RangeVal, footprint_spec: str) -> None:
+  def select_resistor(self, resistance: Range, power: Range, footprint_spec: str) -> None:
     value = choose_preferred_number(resistance, self.TOLERANCE, self.E24_SERIES_ZIGZAG, 2)
 
     if value is None:  # failed to find a preferred resistor, choose the center within tolerance
-      center = (resistance[0] + resistance[1]) / 2
+      center = (resistance.lower + resistance.upper) / 2
       min_tolerance = center * self.TOLERANCE
-      if (center - resistance[0]) < min_tolerance or (resistance[1] - center < min_tolerance):
+      if (center - resistance.lower) < min_tolerance or (resistance.upper - center < min_tolerance):
         # TODO should there be a better way of communicating generator failures?
         raise ValueError(f"Cannot generate 1% resistor within {resistance}")
       value = center
 
     # TODO we only need the first really so this is a bit inefficient
     suitable_packages = [(package_power, package) for package_power, package in self.PACKAGE_POWER
-                         if package_power >= power[1] and (not footprint_spec or package == footprint_spec)]
+                         if package_power >= power.upper and (not footprint_spec or package == footprint_spec)]
     if not suitable_packages:
-      raise ValueError(f"Cannot find suitable package for resistor needing {power[1]} W power")
+      raise ValueError(f"Cannot find suitable package for resistor needing {power.upper} W power")
 
     self.assign(self.resistance, value * Ohm(tol=self.TOLERANCE))
     self.assign(self.selected_power_rating, suitable_packages[0][0])
@@ -203,11 +203,11 @@ class SmtCeramicCapacitor(Capacitor, FootprintBlock, GeneratorBlock):
     'Capacitor_SMD:C_1206_3216Metric': 0.04,
   }
 
-  def select_capacitor(self, capacitance: RangeVal, voltage: RangeVal,
-                       single_nominal_capacitance: RangeVal,
+  def select_capacitor(self, capacitance: Range, voltage: Range,
+                       single_nominal_capacitance: Range,
                        part_spec: str, footprint_spec: str) -> None:
     def derated_capacitance(row: Dict[str, Any]) -> Tuple[float, float]:
-      if voltage[1] < 3.6:  # x-intercept at 3.6v
+      if voltage.upper < 3.6:  # x-intercept at 3.6v
         return row['capacitance']
       if (row['capacitance'][0] + row['capacitance'][1]) / 2 <= 1e-6:  # don't derate below 1uF
         return row['capacitance']
@@ -215,11 +215,11 @@ class SmtCeramicCapacitor(Capacitor, FootprintBlock, GeneratorBlock):
         return (0, 0)  # can't derate, generate obviously bogus and ignored value
       voltco = self.DERATE_VOLTCO[row['footprint']]
       return (
-        row['capacitance'][0] * (1 - voltco * (voltage[1] - 3.6)),
-        row['capacitance'][1] * (1 - voltco * (voltage[0] - 3.6))
+        row['capacitance'][0] * (1 - voltco * (voltage.upper - 3.6)),
+        row['capacitance'][1] * (1 - voltco * (voltage.lower - 3.6))
       )
 
-    single_cap_max = single_nominal_capacitance[1]
+    single_cap_max = single_nominal_capacitance.upper
 
     parts = self.product_table \
       .filter(Implication(  # enforce minimum package size by capacitance
@@ -263,14 +263,14 @@ class SmtCeramicCapacitor(Capacitor, FootprintBlock, GeneratorBlock):
         value=f"{part['Capacitance']}, {part['Voltage - Rated']}",
         datasheet=part['Datasheets']
       )
-    elif capacitance[1] >= single_cap_max:
+    elif capacitance.upper >= single_cap_max:
       parts = parts.sort(Column('Unit Price (USD)')) \
         .sort(Column('footprint')) \
         .sort(Column('nominal_capacitance'), reverse=True)  # pick the largest capacitor available
       part = parts.first(err=f"no parallel capacitors in ({capacitance}) F")
 
-      num_caps = math.ceil(capacitance[0] / part['derated_capacitance'][0])
-      assert num_caps * part['derated_capacitance'][1] < capacitance[1], "can't generate parallel caps within max capacitance limit"
+      num_caps = math.ceil(capacitance.lower / part['derated_capacitance'][0])
+      assert num_caps * part['derated_capacitance'][1] < capacitance.upper, "can't generate parallel caps within max capacitance limit"
 
       self.assign(self.selected_capacitance, (
         num_caps * part['capacitance'][0],
@@ -383,7 +383,7 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
     ),
   ]
 
-  def select_capacitor_no_prod_table(self, capacitance: RangeVal, voltage: RangeVal,
+  def select_capacitor_no_prod_table(self, capacitance: Range, voltage: Range,
                                      footprint_spec: str, derating_coeff: float) -> None:
     """
     Selects a generic capacitor without using product tables
@@ -396,7 +396,7 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
     :param derating_coeff: user-specified derating coefficient, if used then footprint_spec must be specified
     """
 
-    def select_package(nominal_capacitance: float, voltage: RangeVal) -> Optional[str]:
+    def select_package(nominal_capacitance: float, voltage: Range) -> Optional[str]:
 
       if footprint_spec == "":
         package_options = self.PACKAGE_SPECS
@@ -406,19 +406,19 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
       for package in package_options:
         if package.max >= nominal_capacitance:
             for package_max_voltage, package_max_capacitance in package.vc_pairs.items():
-              if package_max_voltage >= voltage[1] and package_max_capacitance >= nominal_capacitance:
+              if package_max_voltage >= voltage.upper and package_max_capacitance >= nominal_capacitance:
                 return package.name
       return None
 
-    nominal_capacitance = (capacitance[0] / derating_coeff, capacitance[1] / derating_coeff)
+    nominal_capacitance = capacitance / derating_coeff
 
-    num_caps = math.ceil(nominal_capacitance[0] / self.SINGLE_CAP_MAX)
+    num_caps = math.ceil(nominal_capacitance.lower / self.SINGLE_CAP_MAX)
     if num_caps > 1:
-      assert num_caps * self.SINGLE_CAP_MAX < nominal_capacitance[1], "can't generate parallel caps within max capacitance limit"
+      assert num_caps * self.SINGLE_CAP_MAX < nominal_capacitance.upper, "can't generate parallel caps within max capacitance limit"
 
       self.assign(self.selected_nominal_capacitance, (
-        num_caps * nominal_capacitance[0],
-        num_caps * nominal_capacitance[1],
+        num_caps * nominal_capacitance.lower,
+        num_caps * nominal_capacitance.upper,
       ))
 
       if footprint_spec == "":
@@ -461,14 +461,14 @@ class DummyCapacitor(DummyDevice, Capacitor, FootprintBlock, GeneratorBlock):
     self.footprint_spec = self.Parameter(StringExpr(footprint_spec))
     self.generator(self.select_capacitor, self.capacitance, self.footprint_spec)
 
-  def select_capacitor(self, capacitance: RangeVal, footprint_spec: str) -> None:
+  def select_capacitor(self, capacitance: Range, footprint_spec: str) -> None:
     self.footprint(
       'C', footprint_spec,
       {
         '1': self.pos,
         '2': self.neg,
       },
-      value=f'{UnitUtils.num_to_prefix(capacitance[0], 3)}F'
+      value=f'{UnitUtils.num_to_prefix(capacitance.lower, 3)}F'
     )
 
 def generate_inductor_table(TABLES: List[str]) -> ProductTable:
@@ -535,7 +535,7 @@ class SmtInductor(Inductor, FootprintBlock, GeneratorBlock):
     self.selected_current_rating = self.Parameter(RangeExpr())
     self.selected_frequency_rating = self.Parameter(RangeExpr())
 
-  def select_inductor(self, inductance: RangeVal, current: RangeVal, frequency: RangeVal,
+  def select_inductor(self, inductance: Range, current: Range, frequency: Range,
                part_spec: str, footprint_spec: str) -> None:
     # TODO eliminate arbitrary DCR limit in favor of exposing max DCR to upper levels
     parts = self.product_table.filter(RangeContains(Lit(inductance), Column('inductance'))) \

--- a/electronics_lib/ProductTableUtils.py
+++ b/electronics_lib/ProductTableUtils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import *
 
+from edg_core import Range
 
 SourceMap = Callable[[Dict[str, Any]], Optional[Any]]
 SourceFilter = Callable[[Dict[str, Any]], bool]
@@ -78,6 +79,9 @@ SI_PREFIX_DICT = {
 
 
 def Lit(value: Any) -> SourceMap:
+  if isinstance(value, Range):  # TODO hack-patch convert ranges to tuple format
+    # pending deprecation and removal of this old ProductTableUtils API
+    value = (value.lower, value.upper)
   def inner(row: Dict[str, Any]) -> Optional[Any]:
     return value
   return inner

--- a/electronics_lib/ProductTableUtils.py
+++ b/electronics_lib/ProductTableUtils.py
@@ -138,7 +138,7 @@ def Not(src: SourceFilter) -> SourceFilter:
   return inner
 
 
-def Range(lower_source: SourceMap, upper_source: SourceMap) -> SourceMap:
+def MakeRange(lower_source: SourceMap, upper_source: SourceMap) -> SourceMap:
   def inner(row: Dict[str, Any]) -> Optional[Tuple[float, float]]:
     lower_result = lower_source(row)
     upper_result = upper_source(row)

--- a/electronics_lib/test_preferred_number.py
+++ b/electronics_lib/test_preferred_number.py
@@ -1,5 +1,6 @@
 import unittest
 
+from edg_core import Range
 from .Passives import Resistor, choose_preferred_number, zigzag_range
 
 class PreferredNumberTestCase(unittest.TestCase):
@@ -11,19 +12,19 @@ class PreferredNumberTestCase(unittest.TestCase):
 
   def test_preferred_number(self) -> None:
     # Test a few different powers
-    self.assertEqual(choose_preferred_number((0.09, 0.11), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 0.1)
-    self.assertEqual(choose_preferred_number((0.9, 1.1), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1)
-    self.assertEqual(choose_preferred_number((9, 11), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 10)
-    self.assertEqual(choose_preferred_number((900, 1100), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1000)
+    self.assertEqual(choose_preferred_number(Range(0.09, 0.11), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 0.1)
+    self.assertEqual(choose_preferred_number(Range(0.9, 1.1), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1)
+    self.assertEqual(choose_preferred_number(Range(9, 11), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 10)
+    self.assertEqual(choose_preferred_number(Range(900, 1100), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1000)
 
     # Test a few different numbers
-    self.assertEqual(choose_preferred_number((8100, 8300), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 8200)
-    self.assertEqual(choose_preferred_number((460, 480), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 470)
+    self.assertEqual(choose_preferred_number(Range(8100, 8300), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 8200)
+    self.assertEqual(choose_preferred_number(Range(460, 480), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 470)
 
     # Test preference for lower E-series first
-    self.assertEqual(choose_preferred_number((101, 9999), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1000)
-    self.assertEqual(choose_preferred_number((220, 820), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 470)
+    self.assertEqual(choose_preferred_number(Range(101, 9999), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1000)
+    self.assertEqual(choose_preferred_number(Range(220, 820), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 470)
 
     # Test dynamic range edge cases
-    self.assertEqual(choose_preferred_number((999, 1500), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1200)
-    self.assertEqual(choose_preferred_number((680, 1001), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 820)
+    self.assertEqual(choose_preferred_number(Range(999, 1500), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 1200)
+    self.assertEqual(choose_preferred_number(Range(680, 1001), 0.01, Resistor.E24_SERIES_ZIGZAG, 2), 820)

--- a/electronics_model/NetlistGenerator.py
+++ b/electronics_model/NetlistGenerator.py
@@ -113,7 +113,7 @@ class NetlistCollect(TransformUtil.Transform):
 
       # Uncomment one to set refdes type
       # TODO this should be a user flag
-      # self.names[path] = TransformUtil.Path.empty().append_block(vals['refdes_prefix'] + str(refdes_id))
+      # self.names[path] = TransformUtil.Path.empty().append_block(refdes_prefix + str(refdes_id))
       self.names[path] = self.short_paths[path]
 
       for pin_name, pin_path_pb in block.meta.members.node['pinning'].members.node.items():

--- a/electronics_model/Units.py
+++ b/electronics_model/Units.py
@@ -2,8 +2,6 @@ from edg_core import *
 
 import math
 
-Range = LiteralConstructor(1)
-
 Farad = LiteralConstructor(1, 'F')
 uFarad = LiteralConstructor(1e-6, 'F')
 nFarad = LiteralConstructor(1e-9, 'F')

--- a/electronics_model/test_analog_link.py
+++ b/electronics_model/test_analog_link.py
@@ -55,12 +55,15 @@ class AnalogMixedTest(Block):
 class CapacitorTestCase(unittest.TestCase):
   def test_analog_two_infinite(self) -> None:
     compiled = ScalaCompiler.compile(AnalogTwoInfiniteTest)
-    self.assertEqual(compiled.get_value(['link', 'sink_impedance']), (float('inf'), float('inf')))
+    self.assertEqual(compiled.get_value(['link', 'sink_impedance']),
+                     Range(float('inf'), float('inf')))
 
   def test_analog_two_one_ohm(self) -> None:
     compiled = ScalaCompiler.compile(AnalogTwoOneOhmTest)
-    self.assertEqual(compiled.get_value(['link', 'sink_impedance']), (0.5, 0.5))
+    self.assertEqual(compiled.get_value(['link', 'sink_impedance']),
+                     Range(0.5, 0.5))
 
   def test_analog_mixed(self) -> None:
     compiled = ScalaCompiler.compile(AnalogMixedTest)
-    self.assertEqual(compiled.get_value(['link', 'sink_impedance']), (1.0, 1.0))
+    self.assertEqual(compiled.get_value(['link', 'sink_impedance']),
+                     Range(1.0, 1.0))

--- a/examples/test_battery_protector.py
+++ b/examples/test_battery_protector.py
@@ -8,28 +8,17 @@ from electronics_lib.DcDcConverters import Tps61023
 class BatteryProtectorCircuit(SimpleBoardTop):
   def contents(self) -> None:
     super().contents()
-    self.mcu = self.Block(Stm32f103_48())
     self.battery_protector = self.Block(BatteryProtector_S8200A())
     self.li_ion_bat = self.Block(Li18650(voltage=(2.5, 4.2) * Volt))
+    self.boost = self.Block(Tps61023(output_voltage=5.0 * Volt(tol=0.05)))
     self.led = self.Block(VoltageIndicatorLed())
-    self.boost = self.Block(Tps61023(output_voltage=3.3 * Volt(tol=0.07)))
-    self.swd = self.Block(SwdCortexTargetHeader())
 
     self.link_bat_neg = self.connect(self.li_ion_bat.gnd, self.battery_protector.gnd_in)
     self.link_bat_pos = self.connect(self.li_ion_bat.pwr, self.battery_protector.pwr_in)
 
-    self.link_protect_neg = self.connect(self.battery_protector.gnd_out, self.boost.gnd)
+    self.link_protect_neg = self.connect(self.battery_protector.gnd_out, self.boost.gnd, self.led.gnd)
     self.link_protect_pos = self.connect(self.battery_protector.pwr_out, self.boost.pwr_in)
-
-    self.link_boost_neg = self.connect(self.boost.gnd, self.mcu.gnd)
-    self.link_boost_pos = self.connect(self.boost.pwr_out, self.mcu.pwr)
-
-    self.connect(self.mcu.gnd, self.led.gnd)
-    self.connect(self.led.signal, self.mcu.pwr)
-
-    self.connect(self.swd.swd, self.mcu.swd)
-    self.connect(self.mcu.gnd, self.swd.gnd)
-    self.connect(self.mcu.pwr, self.swd.pwr)
+    self.link_boost_pos = self.connect(self.boost.pwr_out, self.led.signal)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a Range type, for interval arithmetic, and including unit tests. Core definition is in Range.py, and refactors the code that uses tuples to use this. It's really mostly refactoring 🤪...

Additionally modifies the power converters dutycycle limits to be a constraint (instead of an assertion) so a design still generates, and a user may waive the constraint if it's fine for the converter to go into tracking mode. Fixes the battery protector example by removing the voltage-sensitive MCU and upping the output to 5V - previously it would have tracked up to the battery voltage of 4.2 and probably blew up the micro.

Prerequisite for #59, to replace the hacktastic old parts table adhoc range constructors.

TODO:
- [x] Refactor RangeExpr to use this internally
- [x] Refactor libraries to use this (mainly generators)
- [x] Define range operators as needed be examples
- [x] Clean up
- [x] Double-check the switching converter calculations
- [x] Netlist checks - spot checks seem fine, while the datalogger changes the converter values, it seems to match current master