### PR TITLE
Update IR to be more explicit by separating out ops on set-like values.

### DIFF
--- a/edg_core/Binding.py
+++ b/edg_core/Binding.py
@@ -49,6 +49,7 @@ class OrdOp(Enum):
   gt = auto()
   le = auto()
   lt = auto()
+  within = auto()
 
 class RangeSetOp(Enum):
   # Range/Set
@@ -60,7 +61,6 @@ class RangeSetOp(Enum):
   intersection = auto()
   center = auto()
   width = auto()
-  within = auto()
 
   # Set
   equal_any = auto()
@@ -306,13 +306,13 @@ class BinaryOpBinding(Binding):
       OrdOp.le: edgir.BinaryExpr.LTE,
       OrdOp.gt: edgir.BinaryExpr.GT,
       OrdOp.ge: edgir.BinaryExpr.GTE,
+      OrdOp.within: edgir.BinaryExpr.WITHIN,
       # Range/Set
       RangeSetOp.min: edgir.BinaryExpr.MIN,
       RangeSetOp.max: edgir.BinaryExpr.MAX,
       # Range
       RangeSetOp.intersection: edgir.BinaryExpr.INTERSECTION,
       RangeSetOp.hull: edgir.BinaryExpr.HULL,
-      RangeSetOp.within: edgir.BinaryExpr.WITHIN,
     }
 
     super().__init__()

--- a/edg_core/Binding.py
+++ b/edg_core/Binding.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from enum import Enum
+from enum import Enum, auto
 from itertools import chain
 from typing import *
 
@@ -16,39 +16,54 @@ if TYPE_CHECKING:
   from .Blocks import BaseBlock
   from .ConstraintExpr import ConstraintExpr, FloatExpr, BoolExpr
 
+## These are split mostly to let us have some finer grained types on various
+## binding helper functions.
 
-class ReductionOp(Enum):
-  min = 0
-  max = 1
-  sum = 2
-  equal_any = 3
-  all_equal = 4
-  all_unique = 5
-  intersection = 6
-  hull = 7
-  op_and = 8
-  op_or = 9
+class NumericOp(Enum):
 
+  # Additive
+  add = auto()
+  negate = auto()
+  sum = auto()
 
-class BinaryNumOp(Enum):
-  add = 0
-  sub = 1
-  mul = 2
-  div = 3
+  # Multiplicative
+  mul = auto()
+  invert = auto()
 
+class BoolOp(Enum):
+  op_and = auto()
+  op_not = auto()
+  op_or = auto()
+  op_xor = auto()
+  implies = auto()
 
-class BinaryBoolOp(Enum):
-  eq = 0
-  ne = 1
-  lt = 2
-  le = 3
-  gt = 4
-  ge = 5
-  subset = 6
-  op_and = 7,
-  op_or = 8,
-  op_xor = 9,
-  implies = 10,
+class EqOp(Enum):
+  eq = auto()
+  ne = auto()
+  all_equal = auto()
+  all_unique = auto()
+
+class OrdOp(Enum):
+  # Ordering
+  ge = auto()
+  gt = auto()
+  le = auto()
+  lt = auto()
+
+class RangeSetOp(Enum):
+  # Range/Set
+  max = auto()
+  min = auto()
+
+  # Range
+  hull = auto()
+  intersection = auto()
+  center = auto()
+  width = auto()
+  within = auto()
+
+  # Set
+  equal_any = auto()
 
 
 class Binding:
@@ -199,23 +214,21 @@ class RangeBuilderBinding(Binding):
     pb.binary.rhs.CopyFrom(self.upper._expr_to_proto(ref_map))
     return pb
 
-
-class ReductionOpBinding(Binding):
+class UnaryOpBinding(Binding):
   def __repr__(self) -> str:
-    return f"ReductionOp({self.op}, ...)"
+    return f"UnaryOp({self.op}, ...)"
 
-  def __init__(self, src: ConstraintExpr, op: ReductionOp):
+  def __init__(self,
+               src: ConstraintExpr,
+               op: Union[NumericOp,BoolOp,RangeSetOp]):
     self.op_map = {
-      ReductionOp.min: edgir.ReductionExpr.MINIMUM,
-      ReductionOp.max: edgir.ReductionExpr.MAXIMUM,
-      ReductionOp.sum: edgir.ReductionExpr.SUM,
-      ReductionOp.equal_any: edgir.ReductionExpr.SET_EXTRACT,
-      ReductionOp.all_equal: edgir.ReductionExpr.ALL_EQ,
-      ReductionOp.all_unique: edgir.ReductionExpr.ALL_UNIQUE,
-      ReductionOp.intersection: edgir.ReductionExpr.INTERSECTION,
-      ReductionOp.hull: edgir.ReductionExpr.HULL,
-      ReductionOp.op_and: edgir.ReductionExpr.ALL_TRUE,
-      ReductionOp.op_or: edgir.ReductionExpr.ANY_TRUE,
+      NumericOp.negate: edgir.UnaryExpr.NEGATE,
+      NumericOp.invert: edgir.UnaryExpr.INVERT,
+      BoolOp.op_not: edgir.UnaryExpr.NOT,
+      RangeSetOp.min: edgir.UnaryExpr.MIN,
+      RangeSetOp.max: edgir.UnaryExpr.MAX,
+      RangeSetOp.center: edgir.UnaryExpr.CENTER,
+      RangeSetOp.width: edgir.UnaryExpr.WIDTH,
     }
 
     super().__init__()
@@ -225,38 +238,81 @@ class ReductionOpBinding(Binding):
   def get_subexprs(self) -> Iterable[Union[ConstraintExpr, BasePort]]:
     return chain(self.src._get_exprs())
 
-  def expr_to_proto(self, expr: ConstraintExpr, ref_map: IdentityDict[Refable, edgir.LocalPath]) -> edgir.ValueExpr:
+  def expr_to_proto(self, expr: ConstraintExpr,
+                    ref_map: IdentityDict[Refable, edgir.LocalPath]) -> edgir.ValueExpr:
     pb = edgir.ValueExpr()
-    pb.reduce.op = self.op_map[self.op]
-    pb.reduce.vals.CopyFrom(self.src._expr_to_proto(ref_map))
+    pb.unary.op = self.op_map[self.op]
+    pb.unary.val.CopyFrom(self.src._expr_to_proto(ref_map))
     return pb
 
+class UnarySetOpBinding(Binding):
+  def __repr__(self) -> str:
+    return f"UnarySetOp({self.op}, ...)"
+
+  def __init__(self,
+               src: ConstraintExpr,
+               op: Union[NumericOp,BoolOp,EqOp,RangeSetOp]):
+    self.op_map = {
+      NumericOp.negate :edgir.UnarySetExpr.NEGATE,
+      NumericOp.invert: edgir.UnarySetExpr.INVERT,
+      NumericOp.sum: edgir.UnarySetExpr.SUM,
+      BoolOp.op_and: edgir.UnarySetExpr.ALL_TRUE,
+      BoolOp.op_or: edgir.UnarySetExpr.ANY_TRUE,
+      EqOp.all_equal: edgir.UnarySetExpr.ALL_EQ,
+      EqOp.all_unique: edgir.UnarySetExpr.ALL_UNIQUE,
+      RangeSetOp.min: edgir.UnarySetExpr.MINIMUM,
+      RangeSetOp.max: edgir.UnarySetExpr.MAXIMUM,
+      RangeSetOp.intersection: edgir.UnarySetExpr.INTERSECTION,
+      RangeSetOp.hull: edgir.UnarySetExpr.HULL,
+      RangeSetOp.equal_any: edgir.UnarySetExpr.SET_EXTRACT,
+    }
+
+    super().__init__()
+    self.src = src
+    self.op = op
+
+  def get_subexprs(self) -> Iterable[Union[ConstraintExpr, BasePort]]:
+    return chain(self.src._get_exprs())
+
+  def expr_to_proto(self, expr: ConstraintExpr,
+                    ref_map: IdentityDict[Refable, edgir.LocalPath]) -> edgir.ValueExpr:
+    pb = edgir.ValueExpr()
+    pb.unary_set.op = self.op_map[self.op]
+    pb.unary_set.vals.CopyFrom(self.src._expr_to_proto(ref_map))
+    return pb
 
 class BinaryOpBinding(Binding):
   def __repr__(self) -> str:
     return f"BinaryOp({self.op}, ...)"
 
-  def __init__(self, lhs: ConstraintExpr, rhs: ConstraintExpr, op: Union[BinaryNumOp, BinaryBoolOp, ReductionOp]):
+  def __init__(self,
+               lhs: ConstraintExpr,
+               rhs: ConstraintExpr,
+               op: Union[NumericOp,BoolOp,EqOp,OrdOp,RangeSetOp]):
     self.op_map = {
-      BinaryNumOp.add: edgir.BinaryExpr.ADD,
-      BinaryNumOp.sub: edgir.BinaryExpr.SUB,
-      BinaryNumOp.mul: edgir.BinaryExpr.MULT,
-      BinaryNumOp.div: edgir.BinaryExpr.DIV,
-      BinaryBoolOp.eq: edgir.BinaryExpr.EQ,
-      BinaryBoolOp.ne: edgir.BinaryExpr.NEQ,
-      BinaryBoolOp.lt: edgir.BinaryExpr.LT,
-      BinaryBoolOp.le: edgir.BinaryExpr.LTE,
-      BinaryBoolOp.gt: edgir.BinaryExpr.GT,
-      BinaryBoolOp.ge: edgir.BinaryExpr.GTE,
-      BinaryBoolOp.subset: edgir.BinaryExpr.SUBSET,
-      BinaryBoolOp.op_and: edgir.BinaryExpr.AND,
-      BinaryBoolOp.op_or: edgir.BinaryExpr.OR,
-      BinaryBoolOp.op_xor: edgir.BinaryExpr.XOR,
-      BinaryBoolOp.implies: edgir.BinaryExpr.IMPLIES,
-      ReductionOp.min: edgir.BinaryExpr.MIN,
-      ReductionOp.max: edgir.BinaryExpr.MAX,
-      ReductionOp.intersection: edgir.BinaryExpr.INTERSECTION,
-      ReductionOp.hull: edgir.BinaryExpr.HULL,
+      # Numeric
+      NumericOp.add: edgir.BinaryExpr.ADD,
+      NumericOp.mul: edgir.BinaryExpr.MULT,
+      # Boolean
+      BoolOp.op_and: edgir.BinaryExpr.AND,
+      BoolOp.op_or: edgir.BinaryExpr.OR,
+      BoolOp.op_xor: edgir.BinaryExpr.XOR,
+      BoolOp.implies: edgir.BinaryExpr.IMPLIES,
+      # Equality
+      EqOp.eq: edgir.BinaryExpr.EQ,
+      EqOp.ne: edgir.BinaryExpr.NEQ,
+      # Ordering
+      OrdOp.lt: edgir.BinaryExpr.LT,
+      OrdOp.le: edgir.BinaryExpr.LTE,
+      OrdOp.gt: edgir.BinaryExpr.GT,
+      OrdOp.ge: edgir.BinaryExpr.GTE,
+      # Range/Set
+      RangeSetOp.min: edgir.BinaryExpr.MIN,
+      RangeSetOp.max: edgir.BinaryExpr.MAX,
+      # Range
+      RangeSetOp.intersection: edgir.BinaryExpr.INTERSECTION,
+      RangeSetOp.hull: edgir.BinaryExpr.HULL,
+      RangeSetOp.within: edgir.BinaryExpr.WITHIN,
     }
 
     super().__init__()
@@ -272,6 +328,35 @@ class BinaryOpBinding(Binding):
     pb.binary.op = self.op_map[self.op]
     pb.binary.lhs.CopyFrom(self.lhs._expr_to_proto(ref_map))
     pb.binary.rhs.CopyFrom(self.rhs._expr_to_proto(ref_map))
+    return pb
+
+class BinarySetOpBinding(Binding):
+  def __repr__(self) -> str:
+    return f"BinaryOp({self.op}, ...)"
+
+  def __init__(self,
+               lhset: ConstraintExpr,
+               rhs: ConstraintExpr,
+               op: NumericOp):
+    self.op_map = {
+      # Numeric
+      NumericOp.add: edgir.BinarySetExpr.ADD,
+      NumericOp.mul: edgir.BinarySetExpr.MULT,
+    }
+
+    super().__init__()
+    self.lhset = lhset
+    self.rhs = rhs
+    self.op = op
+
+  def get_subexprs(self) -> Iterable[Union[ConstraintExpr, BasePort]]:
+    return chain(self.lhset._get_exprs(), self.rhs._get_exprs())
+
+  def expr_to_proto(self, expr: ConstraintExpr, ref_map: IdentityDict[Refable, edgir.LocalPath]) -> edgir.ValueExpr:
+    pb = edgir.ValueExpr()
+    pb.binary_set.op = self.op_map[self.op]
+    pb.binary_set.lhset.CopyFrom(self.lhset._expr_to_proto(ref_map))
+    pb.binary_set.rhs.CopyFrom(self.rhs._expr_to_proto(ref_map))
     return pb
 
 
@@ -312,7 +397,6 @@ class IsConnectedBinding(Binding):
     pb.ref.CopyFrom(ref_map[self.src])
     pb.ref.steps.add().reserved_param = edgir.IS_CONNECTED
     return pb
-
 
 class NameBinding(Binding):
   def __repr__(self) -> str:

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -7,9 +7,9 @@ from typing import *
 
 from . import edgir
 from .Binding import Binding, ParamBinding, ParamVariableBinding, BoolLiteralBinding, IntLiteralBinding, \
-  FloatLiteralBinding, RangeLiteralBinding, StringLiteralBinding, RangeBuilderBinding, ReductionOpBinding, \
-  BinaryOpBinding, IfThenElseBinding
-from .Binding import ReductionOp, BinaryNumOp, BinaryBoolOp
+  FloatLiteralBinding, RangeLiteralBinding, StringLiteralBinding, RangeBuilderBinding, \
+  UnaryOpBinding, UnarySetOpBinding, BinaryOpBinding, BinarySetOpBinding, IfThenElseBinding
+from .Binding import NumericOp, BoolOp, EqOp, OrdOp, RangeSetOp
 from .Builder import builder
 from .Core import Refable
 from .IdentityDict import IdentityDict
@@ -93,7 +93,7 @@ class ConstraintExpr(Refable, Generic[WrappedType]):
   # for now we define that all constraints can be checked for equivalence
   def __eq__(self: SelfType, other: ConstraintExprCastable) -> BoolExpr:  #type: ignore
     # TODO: avoid creating excess BoolExpr
-    return BoolExpr()._bind(BinaryOpBinding(self, self._to_expr_type(other), BinaryBoolOp.eq))
+    return BoolExpr()._bind(BinaryOpBinding(self, self._to_expr_type(other), EqOp.eq))
 
 
 BoolLike = Union[bool, 'BoolExpr']
@@ -116,7 +116,10 @@ class BoolExpr(ConstraintExpr[bool]):
     return pb
 
   @classmethod
-  def _create_binary_op(cls, lhs: BoolExpr, rhs: BoolExpr, op: BinaryBoolOp) -> BoolExpr:  # TODO dedup w/ NumLike
+  def _create_binary_op(cls,
+                        lhs: BoolExpr,
+                        rhs: BoolExpr,
+                        op: Union[NumericOp, BoolOp, EqOp, OrdOp, RangeSetOp]) -> BoolExpr:  # TODO dedup w/ NumLike
     """Creates a new expression that is the result of a binary operation on inputs"""
     if type(lhs) != type(rhs):
       raise TypeError(f"op args must be of same type, "
@@ -126,25 +129,29 @@ class BoolExpr(ConstraintExpr[bool]):
     return lhs._new_bind(BinaryOpBinding(lhs, rhs, op))
 
   def __and__(self, rhs: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryBoolOp.op_and)
+    return self._create_binary_op(self, self._to_expr_type(rhs), BoolOp.op_and)
 
   def __rand__(self, lhs: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryBoolOp.op_and)
+    return self._create_binary_op(self._to_expr_type(lhs), self, BoolOp.op_and)
 
   def __or__(self, rhs: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryBoolOp.op_or)
+    return self._create_binary_op(self, self._to_expr_type(rhs), BoolOp.op_or)
 
   def __ror__(self, lhs: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryBoolOp.op_or)
+    return self._create_binary_op(self._to_expr_type(lhs), self, BoolOp.op_or)
 
   def __xor__(self, rhs: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryBoolOp.op_xor)
+    return self._create_binary_op(self, self._to_expr_type(rhs), BoolOp.op_xor)
 
   def __rxor__(self, lhs: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryBoolOp.op_xor)
+    return self._create_binary_op(self._to_expr_type(lhs), self, BoolOp.op_xor)
 
   def implies(self, target: BoolLike) -> BoolExpr:
-    return self._create_binary_op(self, self._to_expr_type(target), BinaryBoolOp.implies)
+    return self._create_binary_op(self, self._to_expr_type(target), BoolOp.implies)
+
+  def __bnot__(self) -> BoolExpr:
+    return self._new_bind(UnaryOpBinding(self,BoolOp.op_not))
+
 
   IteType = TypeVar('IteType', bound=ConstraintExpr)
   def then_else(self, then_val: IteType, else_val: IteType) -> IteType:
@@ -186,7 +193,19 @@ class NumLikeExpr(ConstraintExpr[WrappedType], Generic[WrappedType, NumLikeCasta
     raise NotImplementedError
 
   @classmethod
-  def _create_binary_op(cls, lhs: SelfType, rhs: SelfType, op: Union[BinaryNumOp, ReductionOp]) -> SelfType:
+  def _create_unary_op(cls,
+                       var: SelfType,
+                       op: NumericOp) -> SelfType:
+    """Creates a new expression that is the result of a unary operation on the input"""
+
+    assert var._is_bound()
+    return var._new_bind(UnaryOpBinding(var, op))
+
+  @classmethod
+  def _create_binary_op(cls,
+                        lhs: SelfType,
+                        rhs: SelfType,
+                        op: Union[NumericOp,RangeSetOp]) -> SelfType:
     """Creates a new expression that is the result of a binary operation on inputs"""
     if type(lhs) != type(rhs):
       raise TypeError(f"op args must be of same type, "
@@ -195,32 +214,41 @@ class NumLikeExpr(ConstraintExpr[WrappedType], Generic[WrappedType, NumLikeCasta
     assert lhs._is_bound() and rhs._is_bound()
     return lhs._new_bind(BinaryOpBinding(lhs, rhs, op))
 
+  def __neg__(self: NumLikeSelfType) -> NumLikeSelfType:
+    return self._create_unary_op(self, NumericOp.negate)
+
+  def __mul_inv__(self: NumLikeSelfType) -> NumLikeSelfType:
+    return self._create_unary_op(self, NumericOp.invert)
+
   def __add__(self: NumLikeSelfType, rhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryNumOp.add)
+    return self._create_binary_op(self, self._to_expr_type(rhs), NumericOp.add)
 
   def __radd__(self: NumLikeSelfType, lhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryNumOp.add)
+    return self._create_binary_op(self._to_expr_type(lhs), self, NumericOp.add)
 
   def __sub__(self: NumLikeSelfType, rhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryNumOp.sub)
+    return self.__add__(self._to_expr_type(rhs).__neg__())
 
   def __rsub__(self: NumLikeSelfType, lhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryNumOp.sub)
+    return self.__neg__().__radd__(self._to_expr_type(lhs))
 
   def __mul__(self: NumLikeSelfType, rhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryNumOp.mul)
+    return self._create_binary_op(self, self._to_expr_type(rhs), NumericOp.mul)
 
   def __rmul__(self: NumLikeSelfType, lhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryNumOp.mul)
+    return self._create_binary_op(self._to_expr_type(lhs), self, NumericOp.mul)
 
   def __truediv__(self: NumLikeSelfType, rhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self, self._to_expr_type(rhs), BinaryNumOp.div)
+    return self.__mul__(self._to_expr_type(rhs).__mul_inv__())
 
   def __rtruediv__(self: NumLikeSelfType, lhs: NumLikeCastable) -> NumLikeSelfType:
-    return self._create_binary_op(self._to_expr_type(lhs), self, BinaryNumOp.div)
+    return self.__mul_inv__().__mul__(self._to_expr_type(lhs))
 
   @classmethod
-  def _create_bool_op(cls, lhs: ConstraintExpr, rhs: ConstraintExpr, op: BinaryBoolOp) -> BoolExpr:
+  def _create_bool_op(cls,
+                      lhs: ConstraintExpr,
+                      rhs: ConstraintExpr,
+                      op:  Union[BoolOp,EqOp,OrdOp]) -> BoolExpr:
     if not isinstance(lhs, ConstraintExpr):
       raise TypeError(f"op args must be of type ConstraintExpr, got {lhs} of type {type(lhs)}")
     if not isinstance(rhs, ConstraintExpr):
@@ -229,19 +257,19 @@ class NumLikeExpr(ConstraintExpr[WrappedType], Generic[WrappedType, NumLikeCasta
     return BoolExpr()._bind(BinaryOpBinding(lhs, rhs, op))
 
   def __ne__(self: NumLikeSelfType, other: NumLikeCastable) -> BoolExpr:  #type: ignore
-    return self._create_bool_op(self, self._to_expr_type(other), BinaryBoolOp.ne)
+    return self._create_bool_op(self, self._to_expr_type(other), EqOp.ne)
 
   def __gt__(self: NumLikeSelfType, other: NumLikeCastable) -> BoolExpr:  #type: ignore
-    return self._create_bool_op(self, self._to_expr_type(other), BinaryBoolOp.gt)
+    return self._create_bool_op(self, self._to_expr_type(other), OrdOp.gt)
 
   def __ge__(self: NumLikeSelfType, other: NumLikeCastable) -> BoolExpr:  #type: ignore
-    return self._create_bool_op(self, self._to_expr_type(other), BinaryBoolOp.ge)
+    return self._create_bool_op(self, self._to_expr_type(other), OrdOp.ge)
 
   def __lt__(self: NumLikeSelfType, other: NumLikeCastable) -> BoolExpr:  #type: ignore
-    return self._create_bool_op(self, self._to_expr_type(other), BinaryBoolOp.lt)
+    return self._create_bool_op(self, self._to_expr_type(other), OrdOp.lt)
 
   def __le__(self: NumLikeSelfType, other: NumLikeCastable) -> BoolExpr:  #type: ignore
-    return self._create_bool_op(self, self._to_expr_type(other), BinaryBoolOp.le)
+    return self._create_bool_op(self, self._to_expr_type(other), OrdOp.le)
 
 
 IntLike = Union['IntExpr', int]
@@ -281,10 +309,10 @@ class FloatExpr(NumLikeExpr[float, FloatLike]):
     return pb
 
   def min(self, other: FloatLike) -> FloatExpr:
-    return self._create_binary_op(self._to_expr_type(other), self, ReductionOp.min)
+    return self._create_binary_op(self._to_expr_type(other), self, RangeSetOp.min)
 
   def max(self, other: FloatLike) -> FloatExpr:
-    return self._create_binary_op(self._to_expr_type(other), self, ReductionOp.max)
+    return self._create_binary_op(self._to_expr_type(other), self, RangeSetOp.max)
 
 
 RangeLit = Tuple[FloatLit, FloatLit]
@@ -307,8 +335,10 @@ class RangeExpr(NumLikeExpr[Range, RangeLike]):
     if initializer is not None and not isinstance(initializer, RangeExpr):
       initializer = self._to_expr_type(initializer)
     super().__init__(initializer)
-    self._lower = FloatExpr()._bind(ParamVariableBinding(ReductionOpBinding(self, ReductionOp.min)))
-    self._upper = FloatExpr()._bind(ParamVariableBinding(ReductionOpBinding(self, ReductionOp.max)))
+    self._lower = FloatExpr()._bind(ParamVariableBinding(
+      UnaryOpBinding(self, RangeSetOp.min)))
+    self._upper = FloatExpr()._bind(ParamVariableBinding(
+      UnaryOpBinding(self, RangeSetOp.max)))
 
   @classmethod
   def _to_expr_type(cls, input: RangeLike) -> RangeExpr:
@@ -346,19 +376,19 @@ class RangeExpr(NumLikeExpr[Range, RangeLike]):
     return pb
 
   def within(self, item: RangeLike) -> BoolExpr:
-    return self._create_bool_op(self, RangeExpr._to_expr_type(item), BinaryBoolOp.subset)
+    return self._create_bool_op(self, RangeExpr._to_expr_type(item), OrdOp.within)
 
   def contains(self, item: Union[RangeLike, FloatLike]) -> BoolExpr:
     if isinstance(item, (RangeExpr, tuple, Range)):
       return RangeExpr._to_expr_type(item).within(self)
     elif isinstance(item, (int, float, FloatExpr)):
-      return self._create_bool_op(FloatExpr._to_expr_type(item), self, BinaryBoolOp.subset)
+      return self._create_bool_op(FloatExpr._to_expr_type(item), self, OrdOp.within)
 
   def intersect(self, other: RangeLike) -> RangeExpr:
-    return self._create_binary_op(self._to_expr_type(other), self, ReductionOp.intersection)
+    return self._create_binary_op(self._to_expr_type(other), self, RangeSetOp.intersection)
 
   def hull(self, other: RangeLike) -> RangeExpr:
-    return self._create_binary_op(self._to_expr_type(other), self, ReductionOp.hull)
+    return self._create_binary_op(self._to_expr_type(other), self, RangeSetOp.hull)
 
   def lower(self) -> FloatExpr:
     return self._lower
@@ -367,7 +397,10 @@ class RangeExpr(NumLikeExpr[Range, RangeLike]):
     return self._upper
 
   @classmethod
-  def _create_range_float_binary_op(cls, lhs: RangeExpr, rhs: Union[RangeExpr, FloatExpr], op: BinaryNumOp) -> RangeExpr:
+  def _create_range_float_binary_op(cls,
+                                    lhs: RangeExpr,
+                                    rhs: Union[RangeExpr, FloatExpr],
+                                    op: Union[NumericOp]) -> RangeExpr:
     """Creates a new expression that is the result of a binary operation on inputs"""
     if not isinstance(lhs, RangeExpr):
       raise TypeError(f"range mul and div lhs must be range type, "
@@ -388,7 +421,7 @@ class RangeExpr(NumLikeExpr[Range, RangeLike]):
       rhs_cast = self._to_expr_type(rhs)  # type: ignore
     else:
       rhs_cast = rhs
-    return self._create_range_float_binary_op(self, rhs_cast, BinaryNumOp.mul)
+    return self._create_range_float_binary_op(self, rhs_cast, NumericOp.mul)
 
   # special option to allow range / float
   def __truediv__(self, rhs: RangeLike) -> RangeExpr:
@@ -398,8 +431,7 @@ class RangeExpr(NumLikeExpr[Range, RangeLike]):
       rhs_cast = self._to_expr_type(rhs)  # type: ignore
     else:
       rhs_cast = rhs
-    return self._create_range_float_binary_op(self, rhs_cast, BinaryNumOp.div)
-
+    return self * rhs_cast.__mul_inv__()
 
 StringLike = Union['StringExpr', str]
 class StringExpr(ConstraintExpr[str]):

--- a/edgir/expr.proto
+++ b/edgir/expr.proto
@@ -33,22 +33,150 @@ import "common.proto";
 import "lit.proto";
 import "type.proto";
 
+message UnaryExpr {
+ enum Op {
+   UNDEFINED = 0;
+
+   /** Negate :: Numeric a =>       a -> a
+              :: Numeric a => Range a -> Range a
+    */
+   NEGATE = 1;
+
+   /** Not :: Bool -> Bool */
+   NOT = 2;
+
+   /** Invert ::       Float -> Float
+              :: Range Float -> Range Float
+    */
+   INVERT = 3;
+
+   /** Min :: Range a -> a */
+   MIN = 4;
+
+   /** Max :: Range a -> a */
+   MAX = 5;
+
+   /** Center :: Range a -> a */
+   CENTER = 6;
+
+   /** Width :: Range a -> a */
+   WIDTH = 7;
+ }
+ Op op = 1;
+ ValueExpr val = 2;
+}
+
+message ReductionExpr {
+  enum Op{
+    UNDEFINED = 0;
+
+    /** Sum :: (Numeric a) => Set a -> a
+            :: (Numeric a) => Set (Range a) -> Range a
+
+        Sum({}) = 0 */
+    SUM = 1;
+
+    /** All :: Set Bool -> Bool
+
+      All inputs are true
+      All({}) = True */
+    ALL_TRUE = 2;
+
+    /** Any :: Set Bool -> Bool
+
+      Any of the inputs are true
+      Any({}) = False */
+    ANY_TRUE = 3;
+
+    /** AllEq :: (Equality a) => Set a -> Bool
+
+      AllEq({}) = True */
+    ALL_EQ = 4;
+
+    /** AllUnique :: (Equality a) => Set a -> Bool
+
+      AllUnique(EmptySet) = True */
+    ALL_UNIQUE = 5;
+
+    /** Size :: Set a -> Integer */
+    // SIZE = 6;
+
+    /** Maximum :: (Ordered a) => Set a -> a
+
+        This op requires that the non-emptyness of the relevant set is assured
+        before being valid. */
+    MAXIMUM = 10;
+
+    /** Minimum :: (Ordered a) => Set a -> a
+
+        This op requires that the non-emptyness of the relevant set is assured
+        before being valid. */
+    MINIMUM = 11;
+
+    /** SetExtract :: Set a -> a
+
+        This op requires that the non-emptyness of the relevant set is assured
+        before being valid. In addition this assumes all values in the set are equal. */
+    SET_EXTRACT = 12;
+
+    /** Intersection :: Set (Range a) -> Range a
+
+        May produce an empty range.
+        Intersection({}) = [-inf, +inf] */
+    INTERSECTION = 13;
+
+    /** Hull :: Set (Range a) -> Range a
+        Returns the convex hull (union with all the inner missing bits filled in)
+        Hull({}) = EmptyRange */
+    HULL = 14;
+
+    /** Negate :: Numeric a => Set a         -> Set a
+               :: Numeric a => Set (Range a) -> Set (Range a)
+
+     Pointwise negate */
+    NEGATE = 20;
+
+    /** Invert :: Set Float         -> Set Float
+               :: Set (Range Float) -> Set (Range Float)
+
+     Pointwise Invert */
+    INVERT = 21;
+  }
+  Op op = 1;
+  ValueExpr vals = 4;
+}
+
 message BinaryExpr {
   enum Op {
     UNDEFINED = 0;
 
-    /** Add :: Numeric a => (lhs : a,  rhs : a) -> a */
+    /** Add :: Numeric a => (lhs ::       a, rhs ::       a) -> a
+            :: Numeric a => (lhs ::       a, rhs :: Range a) -> Range a
+            :: Numeric a => (lhs :: Range a, rhs ::       a) -> Range a
+            :: Numeric a => (lhs :: Range a, rhs :: Range a) -> Range a
+    */
     ADD = 10;
 
-    /** Sub :: Numeric a => (lhs : a,  rhs : a) -> a */
-    SUB = 11;
+    /** Sub :: Numeric a => (lhs ::       a, rhs ::       a) -> a
+            :: Numeric a => (lhs ::       a, rhs :: Range a) -> Range a
+            :: Numeric a => (lhs :: Range a, rhs ::       a) -> Range a
+            :: Numeric a => (lhs :: Range a, rhs :: Range a) -> Range a
+     */
+    // SUB = 11; // Use ADD and NEGATE instead
 
-    /** Mult :: Numeric a => (lhs : a,  rhs : a) -> a */
+    /** Mult :: Numeric a => (lhs ::       a, rhs ::       a) -> a
+             :: Numeric a => (lhs ::       a, rhs :: Range a) -> Range a
+             :: Numeric a => (lhs :: Range a, rhs ::       a) -> Range a
+             :: Numeric a => (lhs :: Range a, rhs :: Range a) -> Range a
+     */
     MULT = 12;
 
-    /** Div :: Numeric a => (lhs :: a, rhs :: a) -> a */
-    DIV = 13;
-
+    /** Div :: Numeric a => (lhs ::       a, rhs ::       a) -> a
+            :: Numeric a => (lhs ::       a, rhs :: Range a) -> Range a
+            :: Numeric a => (lhs :: Range a, rhs ::       a) -> Range a
+            :: Numeric a => (lhs :: Range a, rhs :: Range a) -> Range a
+     */
+    // DIV = 13; // Use MULT and INVERT instead
 
     /** And :: (lhs :: Bool, rhs :: Bool) -> Bool */
     AND = 20;
@@ -62,19 +190,14 @@ message BinaryExpr {
     /** Implies :: (lhs :: Bool, rhs :: Bool) -> Bool */
     IMPLIES = 23;
 
-    /** Iff :: (lhs :: Bool, rhs :: Bool) -> Bool
-
-      If and Only If := (\ a b -> Not (Xor a b))
-    */
-//    IFF = 24;
-
+    /** Iff :: (lhs :: Bool, rhs :: Bool) -> Bool */
+    // IFF = 24; // Use EQ instead
 
     /** Eq :: (Equality a) =>  (lhs :: a, rhs :: a)  -> Bool */
     EQ = 30;
 
     /** Neq :: (Equality a) => (lhs :: a, rhs : a)  -> Bool */
     NEQ = 31;
-
 
     /** GT :: (Comparable a) =>  (lhs :: a, rhs :: a)  -> Bool */
     GT = 40;
@@ -94,45 +217,35 @@ message BinaryExpr {
     /** Min :: (Comparable a) =>  (lhs :: a, rhs :: a)  -> a */
     MIN = 46;
 
-    /** union :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Set a
+    /** Union :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Set a
 
       Note how, no matter the type of setlike thing we use as
-      input, the output is alwys an unordered set.
-    */
-//    UNION = 50;
+      input, the output is alwys an unordered set. */
+    // UNION = 50;
 
-    /** intersection :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Set a
-
-      Note how, no matter the type of setlike thing we use as
-      input, the output is always an unordered set.
-
-      Alternate Type
-      intersection :: (lhs :: Range a, rhs :: Range a) -> Range a
-
-      May produce an empty range */
+    /** Intersection :: (Numeric a) => (lhs : Range a, rhs : Range a) -> Range a */
     INTERSECTION = 51;
 
-    /** hull :: (Range a) => (lhs :: a, rhs :: a) -> Set a
-      Given two input ranges, returns the convex hull (union with all the inner missing bits filled in)
-    */
+    /** Hull :: (lhs :: Range a, rhs :: Range a) -> Range a
+      Given two input ranges, returns the convex hull (union with
+      all the inner missing bits filled in) */
     HULL = 54;
 
-    /** intersects :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Bool */
-//    INTERSECTS = 52;
+    /** Intersects :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Bool */
+    // INTERSECTS = 52;
 
-   /** subset :: (Set_Like s, Equality a) => (lhs :: s a, rhs :: s a) -> Bool
-       subset :: (Set_Like s, Equality a) => (lhs :: a, rhs :: s a) -> Bool
-       subset :: (lhs :: Range a, rhs :: Range a) -> Bool
-       subset :: (lhs :: a, rhs :: Range a) -> Bool
+    /** Within :: (Numeric a) => (lhs :: Range a, rhs :: Range a) -> Bool
+               :: (Numeric a) => (lhs ::       a, rhs :: Range a) -> Bool
 
-       Whether lhs is a subset of (or, in the single element case, contained in) rhs */
-    SUBSET = 53;
+        Whether the lhs range or point is entirely within (contained by) the rhs.
+        Used to be named SUBSET changed to a name that doesn't also imply a set op. */
+    WITHIN = 53;
 
     /** Range :: (Comparable a) => (lower :: a, upper :: a) -> Range a */
     RANGE = 1;
 
     /** PlusOrMinus :: (Comparable a) => (midpoint :: a, variance :: a) -> Range a */
-//    PLUS_OR_MINUS = 2;
+    // PLUS_OR_MINUS = 2;
   }
 
   Op op = 1;
@@ -140,80 +253,27 @@ message BinaryExpr {
   ValueExpr rhs = 3;
 }
 
-//message UnaryExpr {
-//  enum Op {
-//    UNDEFINED = 0;
-//
-//    /** Negate :: Numeric a => (val :: a) -> a */
-//    NEGATE = 1;
-//
-//    /** Not :: (val :: Bool) -> Bool */
-//    NOT = 2;
-//
-//  }
-//  Op op = 1;
-//  ValueExpr val = 2;
-//}
-
-message ReductionExpr {
-  enum Op{
+message BroadcastExpr {
+  enum Op {
     UNDEFINED = 0;
 
-    /** Sum :: (SetLike s, Numeric a) => (vals :: s a) -> a */
-    SUM = 1;
+    /** Add :: Numeric a => (lhset :         Set a, rhs :       a) -> Set a
+            :: Numeric a => (lhset :         Set a, rhs : Range a) -> Set (Range a)
+            :: Numeric a => (lhset : Set (Range a), rhs :       a) -> Set (Range a)
+            :: Numeric a => (lhset : Set (Range a), rhs : Range a) -> Set (Range a)
+     */
+    ADD = 10;
 
-    /** All :: (Set_like s) => (vars :: s Bool) -> Bool
-
-      All inputs are true
-      All(EmptySet) = True */
-
-    ALL_TRUE = 2;
-
-    /** Any :: (Set_like s) => (vars :: s Bool) -> Bool
-
-      Any of the inputs are true
-      Any(EmptySet) = False */
-    ANY_TRUE = 3;
-
-    /** AllEq :: (Set_like s, Equality a) => (vals :: s a) -> Bool
-
-      AllEq(EmptySet) = True */
-    ALL_EQ = 4;
-
-    /** AllUnique :: (Set_like s, Equality a) => (vals :: s a) -> Bool
-
-      AllUnique(EmptySet) = True */
-    ALL_UNIQUE = 5;
-
-    /** Size :: SetLike s => (val :: s a) -> Integer */
-//    SIZE = 6;
-
-
-    /** Maximum :: (Set_like s, Equality a) => (base :: a, vals :: s a) -> Bool
-
-        This op requires that the non-emptyness of the relevant set is assured
-        before being valid. */
-    MAXIMUM = 10;
-
-    /** Minimum :: (Set_like s, Equality a) => (base :: a, vals :: s a) -> Bool
-
-        This op requires that the non-emptyness of the relevant set is assured
-        before being valid. */
-    MINIMUM = 11;
-
-    /** SetExtract :: s a -> a */
-    SET_EXTRACT = 12;
-
-    /** Intersection :: (Set_like s) => s Range -> Range
-        May produce an empty range */
-    INTERSECTION = 13;
-
-    /** Hull :: (Set_like s) => s Range -> Range
-        Returns the convex hull (union with all the inner missing bits filled in) */
-    HULL = 14;
+    /** Mult :: Numeric a => (lhset :         Set a, rhs :       a) -> Set a
+             :: Numeric a => (lhset :         Set a, rhs : Range a) -> Set (Range a)
+             :: Numeric a => (lhset : Set (Range a), rhs :       a) -> Set (Range a)
+             :: Numeric a => (lhset : Set (Range a), rhs : Range a) -> Set (Range a)
+     */
+    MULT = 12;
   }
   Op op = 1;
-  ValueExpr vals = 4;
+  ValueExpr lhset = 2;
+  ValueExpr rhs = 3;
 }
 
 /** Arrays have an expression form, allowing you to define them with a set of
@@ -306,21 +366,22 @@ message AssignExpr {
 
 message ValueExpr {
   oneof expr {
-    edg.lit.ValueLit literal    = 1;
-    BinaryExpr      binary     = 2;
-//    UnaryExpr       unary      = 3;
-    ReductionExpr   reduce     = 4;
-    // SetExpr         set        = 5;
-    // ArrayExpr       array      = 6;
-    StructExpr      struct     = 7;
-    RangeExpr       range      = 8;
-//    WithinExpr      within     = 9;
-    IfThenElseExpr  ifThenElse = 10;
-    ExtractExpr     extract    = 12;
-    //SetExtractExpr  set_extrat = 13;
-    MapExtractExpr  map_extract = 14;
-    ConnectedExpr   connected = 15;
-    ExportedExpr   exported = 16;
+    edg.lit.ValueLit literal     = 1;
+    BinaryExpr       binary      = 2;
+    BroadcastExpr    broadcast   = 18;
+    UnaryExpr        unary       = 3;
+    ReductionExpr    reduce      = 4;
+    // SetExpr          set         = 5;
+    // ArrayExpr        array       = 6;
+    StructExpr       struct      = 7;
+    RangeExpr        range       = 8;
+    // WithinExpr       within      = 9;
+    IfThenElseExpr   ifThenElse  = 10;
+    ExtractExpr      extract     = 12;
+    // SetExtractExpr   set_extract = 13;
+    MapExtractExpr   map_extract = 14;
+    ConnectedExpr    connected   = 15;
+    ExportedExpr     exported    = 16;
 
     AssignExpr assign    = 17;
 

--- a/edgir/expr.proto
+++ b/edgir/expr.proto
@@ -66,7 +66,7 @@ message UnaryExpr {
  ValueExpr val = 2;
 }
 
-message ReductionExpr {
+message UnarySetExpr {
   enum Op{
     UNDEFINED = 0;
 
@@ -253,7 +253,7 @@ message BinaryExpr {
   ValueExpr rhs = 3;
 }
 
-message BroadcastExpr {
+message BinarySetExpr {
   enum Op {
     UNDEFINED = 0;
 
@@ -368,9 +368,9 @@ message ValueExpr {
   oneof expr {
     edg.lit.ValueLit literal     = 1;
     BinaryExpr       binary      = 2;
-    BroadcastExpr    broadcast   = 18;
+    BinarySetExpr    binary_set  = 18;
     UnaryExpr        unary       = 3;
-    ReductionExpr    reduce      = 4;
+    UnarySetExpr     unary_set   = 4;
     // SetExpr          set         = 5;
     // ArrayExpr        array       = 6;
     StructExpr       struct      = 7;


### PR DESCRIPTION
This has the updated expr.proto discussing in [this issue](https://github.com/BerkeleyHCI/PolymorphicBlocks/issues/70).

Broadly, this follows the changes describes there to separate operations for working with struct-like quantities.

There are a few differences from the version in that issue: 
- `ReductionExpr` was renamed to `UnarySetExpr` to better reflect that it contains both reduction and pointwise operations. 
- `BroadcastExpr` was renamed `BinarySetExpr` to better reflect that it *can* contain  binary set operations that don't just map over the set. For instance a true SUBSET op later on. 
- The definitions are reordered so that they go: `UnaryExpr`, `UnarySetExpr`, `BinaryExpr`, `BinarySetExpr` 
- The SUBSET binop has been renamed to WITHIN, which is functionally identical but the new name doesn't imply a set-like structure. Its semantics have not changed. 

Also, I've made sure the new protos compile but made no effort to update the python or scala code to compensate. 
