### PR TITLE
Adding scala-free dumping of library and examples. 

### DIFF
--- a/LibraryDump.py
+++ b/LibraryDump.py
@@ -1,44 +1,13 @@
 # Simple tool that scans for libraries and dumps the whole thing to a proto file
-from typing import cast
+# from typing import cast
 
-import edgir
-from edg_core.HdlInterfaceServer import LibraryElementResolver
-import edg_core
+# import edgir
+# from edg_core.HdlInterfaceServer import LibraryElementResolver
+# import edg_core
 import edg
-from edg_core.Builder import builder
+from edg.BoardCompiler import dump_library
 
-
-OUTPUT_FILE = "library.edg"
 
 if __name__ == '__main__':
-  library = LibraryElementResolver()
-  library.load_module(edg)
-  pb = edgir.Library()
 
-  count = 0
-  for (name, cls) in library.lib_class_map.items():
-    obj = cls()
-    if isinstance(obj, edg_core.Block):
-      print(f"Elaborating block {name}")
-      block_proto = builder.elaborate_toplevel(obj, f"in elaborating library block {cls}")
-      pb.root.members[name].hierarchy_block.CopyFrom(block_proto)
-    elif isinstance(obj, edg_core.Link):
-      print(f"Elaborating link {name}")
-      link_proto = builder.elaborate_toplevel(obj, f"in elaborating library link {cls}")
-      assert isinstance(link_proto, edgir.Link)  # TODO this needs to be cleaned up
-      pb.root.members[name].link.CopyFrom(link_proto)
-    elif isinstance(obj, edg_core.Bundle):  # TODO: note Bundle extends Port, so this must come first
-      print(f"Elaborating bundle {name}")
-      pb.root.members[name].bundle.CopyFrom(obj._def_to_proto())
-    elif isinstance(obj, edg_core.Port):
-      print(f"Elaborating port {name}")
-      pb.root.members[name].port.CopyFrom(cast(edgir.Port, obj._def_to_proto()))
-    else:
-      print(f"Unknown category for class {cls}")
-
-    count += 1
-
-  with open(OUTPUT_FILE, 'wb') as file:
-    file.write(pb.SerializeToString())
-
-  print(f"Wrote {count} classes to {OUTPUT_FILE}")
+  dump_library(edg, target_name = 'library', print_log = True)

--- a/edg/BoardCompiler.py
+++ b/edg/BoardCompiler.py
@@ -60,7 +60,7 @@ def compile_board_inplace(design: Type[Block], errors_fatal: bool = True) -> Com
 
 def dump_library(module : ModuleType,
                  target_dir: Optional[str] = None,
-                 target_name: Optional[str] = None,
+                 target_name: str = 'library',
                  print_log : bool = False):
 
   def log(s:str):
@@ -70,7 +70,6 @@ def dump_library(module : ModuleType,
   library.load_module(module)
   pb = edgir.Library()
   target_dir = target_dir if target_dir else os.getcwd()
-  target_name = target_name if target_name else 'library'
   output_file = os.path.join(target_dir, f'{target_name}.edg')
 
   count = 0
@@ -100,3 +99,31 @@ def dump_library(module : ModuleType,
     file.write(pb.SerializeToString())
 
   log(f"Wrote {count} classes to {output_file}")
+
+def dump_design(design : Type[Block],
+                target_dir : Optional[str] = None,
+                target_name : str = 'design',
+                print_log : bool = False):
+
+  def log(s:str):
+    if print_log: print(s)
+
+  target_dir = target_dir if target_dir else os.getcwd()
+  module_name = design.__module__.split(".")[-1]
+  design_name = design.__name__
+
+  if not os.path.exists(target_dir):
+    os.makedirs(target_dir)
+  assert os.path.isdir(target_dir), f"target_dir {target_dir} to compile_board must be directory"
+
+  output_file = os.path.join(target_dir, f'{target_name}.edg')
+
+  # assert isinstance(design, Block)
+
+  log(f"Dumping design {design_name}")
+  pb = builder.elaborate_toplevel(design, f"in elaborating design {design_name}")
+
+  with open(output_file, 'wb') as file:
+    file.write(pb.SerializeToString())
+
+  log(f"Wrote {design_name} to {output_file}")

--- a/examples/test_AA_battery.py
+++ b/examples/test_AA_battery.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 from electronics_lib.Batteries import AABattery
 from electronics_lib.DcDcConverters import Tps61023
@@ -28,9 +28,12 @@ class AABatteryCircuit(SimpleBoardTop):
     self.connect(self.mcu.pwr, self.swd.pwr)
 
 
-if __name__ == "__main__":
-  compile_board_inplace(AABatteryCircuit)
-
 class AABatteryCircuitTestCase(unittest.TestCase):
   def test_design_aa_battery(self) -> None:
     compile_board_inplace(AABatteryCircuit)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    AABatteryCircuit,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_battery_protector.py
+++ b/examples/test_battery_protector.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 from electronics_lib.BatteryProtector_S8200A import BatteryProtector_S8200A
 from electronics_lib.DcDcConverters import Tps61023
@@ -20,10 +20,12 @@ class BatteryProtectorCircuit(SimpleBoardTop):
     self.link_protect_pos = self.connect(self.battery_protector.pwr_out, self.boost.pwr_in)
     self.link_boost_pos = self.connect(self.boost.pwr_out, self.led.signal)
 
-
-if __name__ == "__main__":
-  compile_board_inplace(BatteryProtectorCircuit)
-
 class BatteryProtectorCircuitTestCase(unittest.TestCase):
   def test_design_battery_protector(self) -> None:
     compile_board_inplace(BatteryProtectorCircuit)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    BatteryProtectorCircuit,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -1,7 +1,7 @@
 import unittest
 
 from edg import *
-
+import edg
 
 class TestBlinkyBasic(BoardTop):
   def contents(self):
@@ -182,6 +182,7 @@ class TestBlinkyComplete(BoardTop):
 
     self.v3v3 = self.connect(self.usb_reg.pwr_out)
 
+
     with self.implicit_connect(
         ImplicitConnect(self.usb_reg.pwr_out, [Power]),
         ImplicitConnect(self.usb.gnd, [Common]),
@@ -228,7 +229,11 @@ class BlinkyTestCase(unittest.TestCase):
     compile_board_inplace(TestBlinkyComplete)
 
 if __name__ == "__main__":
-  BoardCompiler.dump_design(
+  BoardCompiler.dump_examples(
     TestBlinkyBasic,
-    target_name="testblinkybase",
+    TestBlinkySimpleChain,
+    TestBlinkySimple,
+    TestBlinkyFlattened,
+    TestBlinkyComplete,
+    base_library=edg,
     print_log=True)

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -226,3 +226,9 @@ class BlinkyTestCase(unittest.TestCase):
 
   def test_design_complete(self) -> None:
     compile_board_inplace(TestBlinkyComplete)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_design(
+    TestBlinkyBasic,
+    target_name="testblinkybase",
+    print_log=True)

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 
 
@@ -292,3 +292,12 @@ class BlinkyNewTestCase(unittest.TestCase):
 
   def test_design_lightsense(self) -> None:
     compile_board_inplace(NewBlinkyLightsense)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    NewBlinkyBuck,
+    NewBlinkyRefactored,
+    NewBlinkyMagsense,
+    NewBlinkyLightsense,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 
 
@@ -113,3 +113,9 @@ class CanAdapter(BoardTop):
 class CanAdapterTestCase(unittest.TestCase):
   def test_design(self) -> None:
     compile_board_inplace(CanAdapter)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    CanAdapter,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_datalogger.py
+++ b/examples/test_datalogger.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 
 
@@ -197,3 +197,9 @@ class TestDatalogger(BoardTop):
 class DataloggerTestCase(unittest.TestCase):
   def test_design(self) -> None:
     compile_board_inplace(TestDatalogger)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    TestDatalogger,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -1,4 +1,5 @@
 import unittest
+import edg
 
 from edg import *
 
@@ -157,3 +158,9 @@ class Debugger(BoardTop):
 class DebuggerTestCase(unittest.TestCase):
   def test_design(self) -> None:
     compile_board_inplace(Debugger)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    Debugger,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_high_switch.py
+++ b/examples/test_high_switch.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 
 
@@ -176,3 +176,9 @@ class TestHighSwitch(BoardTop):
 class HighSwitchTestCase(unittest.TestCase):
   def test_design(self) -> None:
     compile_board_inplace(TestHighSwitch)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    TestHighSwitch,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_simon.py
+++ b/examples/test_simon.py
@@ -1,5 +1,5 @@
 import unittest
-
+import edg
 from edg import *
 
 
@@ -126,3 +126,9 @@ class TestSimon(BoardTop):
 class SimonTestCase(unittest.TestCase):
   def test_design(self) -> None:
     compile_board_inplace(TestSimon)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    TestSimon,
+    base_library=edg,
+    print_log=True)

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -1,4 +1,5 @@
 import unittest
+import edg
 from typing import cast
 
 from electronics_abstract_parts.ESeriesUtil import ESeriesRatioUtil
@@ -473,3 +474,9 @@ class UsbSourceMeasureTest(BoardTop):
 class UsbTestCase(unittest.TestCase):
   def test_design(self) -> None:
     compile_board_inplace(UsbSourceMeasureTest)
+
+if __name__ == "__main__":
+  BoardCompiler.dump_examples(
+    UsbSourceMeasureTest,
+    base_library=edg,
+    print_log=True)


### PR DESCRIPTION
I'm trying to add a way to dump the base part library and assorted examples that doesn't use the existing scala compiler infrastructure. This means that all the examples will have to be elaborated by whatever uses the dumps, but that's fine. 

Current plan: 
- [X] Move library dump code from `LibraryDump.py` to `edg/Boardcompiler.py`
- [ ] Add code to dump the topmost layer of an example to `edg/BoardCompiler.py`
- [ ] Add code to dump various sub-components of a example to an associated library. 
- [ ] Annotate all the examples so running them as "__main__" will dump their top-level design and associated library. 

I've been using `examples/test_blinky.py` as my main test case. Because of module lookup shenanigans it needs to be run with `python3 -m examples.test_blinky` from the project root. 

@ducky64: I'm having some trouble with using `elaborate_toplevel` directly on a design. It's asking for a self argument that seems to be present.

```
> pipenv run python3 -m examples.test_blinky
Dumping design TestBlinkyBasic
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "PolymorphicBlocks/examples/test_blinky.py", line 231, in <module>
    BoardCompiler.dump_design(
  File "PolymorphicBlocks/edg/BoardCompiler.py", line 124, in dump_design
    pb = builder.elaborate_toplevel(design, f"in elaborating design {design_name}")
  File "PolymorphicBlocks/edg_core/Builder.py", line 44, in elaborate_toplevel
    elaborated = block._elaborated_def_to_proto()
TypeError: _elaborated_def_to_proto() missing 1 required positional argument: 'self'
```