### PR TITLE
Use self.ArgParameter for __init__ argument list parameters

### DIFF
--- a/blinky_skeleton.py
+++ b/blinky_skeleton.py
@@ -1,7 +1,7 @@
 from edg import *
 
 
-class BlinkyExample(SimpleBoardTop):
+class BlinkyExample(BoardTop):
   def contents(self) -> None:
     super().contents()
     # your implementation here

--- a/edg/BoardTop.py
+++ b/edg/BoardTop.py
@@ -20,17 +20,3 @@ class BoardTop(DesignTop):
         (SwitchPFet, SmtSwitchPFet)
       ]
     )
-
-
-class SimpleBoardTop(BoardTop):
-  """Temporary / hackaround design top with explicit empty pin assignments
-  (automatically allocate) for microcontrollers, for simplicity of tutorials."""
-  def refinements(self) -> Refinements:
-    return super().refinements() + Refinements(
-      class_values=[
-        (Lpc1549_48, ['pin_assigns'], ''),
-        (Lpc1549_64, ['pin_assigns'], ''),
-        (Stm32f103_48, ['pin_assigns'], ''),
-        (Nucleo_F303k8, ['pin_assigns'], ''),
-      ]
-    )

--- a/edg/__init__.py
+++ b/edg/__init__.py
@@ -5,6 +5,6 @@ from electronics_model import *
 from electronics_abstract_parts import *
 from electronics_lib import *
 
-from .BoardTop import BoardTop, SimpleBoardTop
+from .BoardTop import BoardTop
 
 from .BoardCompiler import compile_board, compile_board_inplace

--- a/edg_core/Binding.py
+++ b/edg_core/Binding.py
@@ -105,8 +105,12 @@ class ParamBinding(Binding):
     return pb
 
 
+class InitParamBinding(ParamBinding):
+  """Binding that indicates this is a parameter from an __init__ argument"""
+
+
 class ParamVariableBinding(Binding):
-  """Variable internal to a parameter, treated as a pseudo-parameter"""
+  """Variable internal to a parameter (eg, LENGTH, RangeExpr.upper()), treated as a pseudo-parameter"""
   def __repr__(self) -> str:
     return f"ParamVar({self.binding})"
 

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -475,6 +475,24 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
 
     return elt
 
+  CastableType = TypeVar('CastableType')
+  from .ConstraintExpr import BoolLike, BoolExpr, FloatLike, FloatExpr, RangeLike, RangeExpr
+  @overload
+  def ArgParameter(self, param: BoolLike) -> BoolExpr: ...
+  @overload
+  def ArgParameter(self, param: FloatLike) -> FloatExpr: ...
+  @overload
+  def ArgParameter(self, param: RangeLike) -> RangeExpr: ...
+
+  def ArgParameter(self, param: CastableType) -> ConstraintExpr[Any, CastableType]:
+    """Registers a constructor argument parameter for this Blo/ck.
+    This doesn't actually do anything, but is needed to help the type system converter the *Like to a *Expr."""
+    if not isinstance(param, ConstraintExpr):
+      raise TypeError(f"param to ArgParameter(...) must be ConstraintExpr, got {param} of type {type(param)}")
+    if param.binding is None:
+      raise TypeError(f"param to ArgParameter(...) must have binding")
+    return param
+
   def connect(self, *ports: BasePort) -> ConnectedPorts:
     for port in ports:
       if not isinstance(port, BasePort):

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -475,23 +475,6 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
 
     return elt
 
-  CastableType = TypeVar('CastableType')
-  from .ConstraintExpr import BoolLike, BoolExpr, FloatLike, FloatExpr, RangeLike, RangeExpr
-  @overload
-  def ArgParameter(self, param: BoolLike) -> BoolExpr: ...
-  @overload
-  def ArgParameter(self, param: FloatLike) -> FloatExpr: ...
-  @overload
-  def ArgParameter(self, param: RangeLike) -> RangeExpr: ...
-
-  def ArgParameter(self, param: CastableType) -> ConstraintExpr[Any, CastableType]:
-    """Registers a constructor argument parameter for this Blo/ck.
-    This doesn't actually do anything, but is needed to help the type system converter the *Like to a *Expr."""
-    if not isinstance(param, ConstraintExpr):
-      raise TypeError(f"param to ArgParameter(...) must be ConstraintExpr, got {param} of type {type(param)}")
-    if param.binding is None:
-      raise TypeError(f"param to ArgParameter(...) must have binding")
-    return param
 
   def connect(self, *ports: BasePort) -> ConnectedPorts:
     for port in ports:

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -475,7 +475,6 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
 
     return elt
 
-
   def connect(self, *ports: BasePort) -> ConnectedPorts:
     for port in ports:
       if not isinstance(port, BasePort):

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -315,11 +315,12 @@ class FloatExpr(NumLikeExpr[float, FloatLike]):
     return self._create_binary_op(self._to_expr_type(other), self, RangeSetOp.max)
 
 
-RangeLit = Tuple[FloatLit, FloatLit]
+# RangeLit = Tuple[FloatLit, FloatLit]
 # A RangeLike type excluding the float-to-range implicit conversion
-RangeLikeNonFloat = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike]]
-RangeLike = Union[RangeLikeNonFloat, FloatLike]
-class RangeExpr(NumLikeExpr[Range, RangeLike]):
+# RangeLikeNonFloat = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike]]
+# RangeLike = Union[RangeLikeNonFloat, FloatLike]
+RangeLike = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike]]
+class RangeExpr(NumLikeExpr[Range, Union[RangeLike, FloatLike]]):
   # Some range literals for defaults
   POSITIVE: Range = Range.from_lower(0.0)
   NEGATIVE: Range = Range.from_upper(0.0)

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -315,10 +315,6 @@ class FloatExpr(NumLikeExpr[float, FloatLike]):
     return self._create_binary_op(self._to_expr_type(other), self, RangeSetOp.max)
 
 
-# RangeLit = Tuple[FloatLit, FloatLit]
-# A RangeLike type excluding the float-to-range implicit conversion
-# RangeLikeNonFloat = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike]]
-# RangeLike = Union[RangeLikeNonFloat, FloatLike]
 RangeLike = Union['RangeExpr', Range, Tuple[FloatLike, FloatLike]]
 class RangeExpr(NumLikeExpr[Range, Union[RangeLike, FloatLike]]):
   # Some range literals for defaults

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -342,7 +342,7 @@ class RangeExpr(NumLikeExpr[Range, Union[RangeLike, FloatLike]]):
       UnaryOpBinding(self, RangeSetOp.max)))
 
   @classmethod
-  def _to_expr_type(cls, input: RangeLike) -> RangeExpr:
+  def _to_expr_type(cls, input: Union[RangeLike, FloatLike]) -> RangeExpr:
     if isinstance(input, RangeExpr):
       assert input._is_bound()
       return input
@@ -415,7 +415,7 @@ class RangeExpr(NumLikeExpr[Range, Union[RangeLike, FloatLike]]):
     return lhs._new_bind(BinaryOpBinding(lhs, rhs, op))
 
   # special option to allow range * float
-  def __mul__(self, rhs: RangeLike) -> RangeExpr:
+  def __mul__(self, rhs: Union[RangeLike, FloatLike]) -> RangeExpr:
     if isinstance(rhs, (int, float)):  # TODO clean up w/ literal to expr pass, then type based on that
       rhs_cast: Union[FloatExpr, RangeExpr] = FloatExpr._to_expr_type(rhs)
     elif not isinstance(rhs, FloatExpr):
@@ -425,7 +425,7 @@ class RangeExpr(NumLikeExpr[Range, Union[RangeLike, FloatLike]]):
     return self._create_range_float_binary_op(self, rhs_cast, NumericOp.mul)
 
   # special option to allow range / float
-  def __truediv__(self, rhs: RangeLike) -> RangeExpr:
+  def __truediv__(self, rhs: Union[RangeLike, FloatLike]) -> RangeExpr:
     if isinstance(rhs, (int, float)):  # TODO clean up w/ literal to expr pass, then type based on that
       rhs_cast: Union[FloatExpr, RangeExpr] = FloatExpr._to_expr_type(rhs)
     elif not isinstance(rhs, FloatExpr):

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -686,7 +686,8 @@ class GeneratorBlock(Block):
     self._parse_param_values(generate_values)
 
     fn = getattr(self, generate_fn_name)
-    fn(*self._generator.fn_args)
+    fn_args = [self.get(arg_param) for arg_param in self._generator.fn_args]
+    fn(*fn_args)
 
     self._elaboration_state = BlockElaborationState.post_generate
 

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import collections
-from itertools import chain
 from numbers import Number
 from typing import *
 
 import edgir
 from .Blocks import BaseBlock, BlockElaborationState, ConnectedPorts
-from .Binding import ParamBinding, AssignBinding
+from .Binding import InitParamBinding, AssignBinding
 from .ConstraintExpr import ConstraintExpr, BoolExpr, FloatExpr, IntExpr, RangeExpr, StringExpr
 from .ConstraintExpr import BoolLike, FloatLike, IntLike, RangeLike, StringLike
 from .Core import Refable, non_library
@@ -82,7 +81,7 @@ def init_in_parent(fn: InitType) -> InitType:
             raise ValueError(f"In {fn}, unknown argument type for {arg_name}: {arg_param.annotation}")
 
           # Create new parameter in self, and pass through this one instead of the original
-          param_bound = param_model._bind(ParamBinding(self))
+          param_bound = param_model._bind(InitParamBinding(self))
           self._init_params[arg_name] = param_bound
 
           if arg_name in kwargs:

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -364,6 +364,29 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
 
     return ImplicitScope(self, implicits)
 
+  CastableType = TypeVar('CastableType')
+  from .ConstraintExpr import BoolLike, BoolExpr, FloatLike, FloatExpr, RangeLike, RangeExpr
+  # type ignore is needed because IntLike overlaps BoolLike
+  @overload
+  def ArgParameter(self, param: BoolLike) -> BoolExpr: ...  # type: ignore
+  @overload
+  def ArgParameter(self, param: IntLike) -> IntExpr: ...  # type: ignore
+  @overload
+  def ArgParameter(self, param: FloatLike) -> FloatExpr: ...  # type: ignore
+  @overload
+  def ArgParameter(self, param: RangeLike) -> RangeExpr: ...  # type: ignore
+  @overload
+  def ArgParameter(self, param: StringLike) -> StringExpr: ...  # type: ignore
+
+  def ArgParameter(self, param: CastableType) -> ConstraintExpr[Any, CastableType]:
+    """Registers a constructor argument parameter for this Block.
+    This doesn't actually do anything, but is needed to help the type system converter the *Like to a *Expr."""
+    if not isinstance(param, ConstraintExpr):
+      raise TypeError(f"param to ArgParameter(...) must be ConstraintExpr, got {param} of type {type(param)}")
+    if param.binding is None:
+      raise TypeError(f"param to ArgParameter(...) must have binding")
+    return param
+
   T = TypeVar('T', bound=BasePort)
   def Port(self, tpe: T, tags: Iterable[PortTag]=[], *, optional: bool = False) -> T:
     """Registers a port for this Block"""

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -434,18 +434,6 @@ class GeneratorBlock(Block):
     req_ports: Tuple[BasePort, ...]  # all required ports for generator to fire
     fn_args: Tuple[ConstraintExpr, ...]  # params to unpack for the generator function
 
-  # DEPRECATED - pending experimentation to see if this can be removed
-  # This is an older API that has the .get(...) in the genreator function,
-  # instead of handling it in infrastructure and passing results to the generator as args.
-  # def generator_getfn(self, fn: Callable[[], None], *reqs: ConstraintExpr) -> None:
-  #   assert callable(fn), f"fn {fn} must be a method (callable)"
-  #   fn_name = fn.__name__
-  #   assert hasattr(self, fn_name), f"{self} does not contain {fn_name}"
-  #   assert getattr(self, fn_name) == fn, f"{self}.{fn_name} did not equal fn {fn}"
-  #
-  #   assert fn_name not in self._generators, f"redefinition of generator {fn_name}"
-  #   self._generators[fn_name] = GeneratorBlock.GeneratorRecord(reqs, (), ())
-
   ConstrType1 = TypeVar('ConstrType1', bound=Any)
   ConstrCastable1 = TypeVar('ConstrCastable1', bound=Any)
   ConstrType2 = TypeVar('ConstrType2', bound=Any)
@@ -628,19 +616,6 @@ class GeneratorBlock(Block):
       raise NotImplementedError(f"get({self._name_of(param)}) on unknown type, got {value}")
     return value  # type: ignore
 
-  def get_opt(self, param: ConstraintExpr[ConstrType, Any]) -> Optional[ConstrType]:
-    # TODO can this be unified with get() without a default? type inference seems to choke
-    if self._has(param):
-      return self.get(param)
-    else:
-      return None
-
-  def _has(self, param: ConstraintExpr) -> bool:  # temporary, hack: all ConstraintExpr should be solved with const prop
-    assert self._param_values is not None, "Can't call _has(...) outside generate()"
-    return param in self._param_values
-
-  # TODO maybe disallow Block from being called in contents() ?
-
   # Generator serialization and parsing
   #
   def _def_to_proto(self) -> edgir.HierarchyBlock:
@@ -693,8 +668,6 @@ class GeneratorBlock(Block):
 
     return self._def_to_proto()
 
-  def generate(self):
-    raise RuntimeError("generate deprecated")
 
 AbstractBlockType = TypeVar('AbstractBlockType', bound=Type[Block])
 def abstract_block(decorated: AbstractBlockType) -> AbstractBlockType:

--- a/edg_core/test_generator_error.py
+++ b/edg_core/test_generator_error.py
@@ -1,0 +1,45 @@
+import unittest
+
+from . import *
+from .ScalaCompilerInterface import ScalaCompiler
+
+
+class BadGeneratorTestCase(unittest.TestCase):
+  # These are internal classes to avoid this error case being auto-discovered in a library
+
+  class InvalidMissingGeneratorBlock(GeneratorBlock):
+    def __init__(self) -> None:
+      super().__init__()
+      # this is missing a self.generator statement
+
+  def test_missing_generator(self) -> None:
+    with self.assertRaises(AssertionError):
+      self.InvalidMissingGeneratorBlock()._elaborated_def_to_proto()
+
+
+  class InvalidMultiGeneratorBlock(GeneratorBlock):
+    def __init__(self) -> None:
+      super().__init__()
+      self.generator(self.dummy_gen)
+      self.generator(self.dummy_gen)
+
+    def dummy_gen(self) -> None:
+      pass
+
+  def test_multi_generator(self) -> None:
+    with self.assertRaises(AssertionError):
+      self.InvalidMultiGeneratorBlock()._elaborated_def_to_proto()
+
+
+  class InvalidNonArgGeneratorBlock(GeneratorBlock):
+    def __init__(self) -> None:
+      super().__init__()
+      self.param = self.Parameter(FloatExpr())
+      self.generator(self.dummy_gen, self.param)
+
+    def dummy_gen(self, x: float) -> None:
+      pass
+
+  def test_non_arg_generator(self) -> None:
+    with self.assertRaises(AssertionError):
+      self.InvalidNonArgGeneratorBlock()._elaborated_def_to_proto()

--- a/electronics_abstract_parts/AbstractCrystal.py
+++ b/electronics_abstract_parts/AbstractCrystal.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .Categories import *
 
@@ -10,7 +9,7 @@ class Crystal(DiscreteComponent):
     """Discrete crystal component."""
     super().__init__()
 
-    self.frequency = cast(RangeExpr, frequency)
+    self.frequency = self.ArgParameter(frequency)
 
     # actual frequency to be fulled in by subclass
     self.crystal = self.Port(CrystalPort(frequency=RangeExpr()), [InOut])

--- a/electronics_abstract_parts/AbstractDevices.py
+++ b/electronics_abstract_parts/AbstractDevices.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .Categories import *
 
@@ -15,8 +14,8 @@ class Battery(DiscreteApplication):
       voltage_out=RangeExpr(), current_limits=RangeExpr()))  # set by subclasses
     self.gnd = self.Port(GroundSource())
 
-    self.voltage = cast(RangeExpr, voltage)
-    self.capacity = cast(FloatExpr, capacity)
+    self.voltage = self.ArgParameter(voltage)
+    self.capacity = self.ArgParameter(capacity)
     self.actual_capacity = self.Parameter(RangeExpr())
 
     self.require(self.pwr.voltage_out.within(voltage))

--- a/electronics_abstract_parts/AbstractDiodes.py
+++ b/electronics_abstract_parts/AbstractDiodes.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .Categories import *
 
@@ -19,10 +18,10 @@ class Diode(DiscreteSemiconductor):
     self.anode = self.Port(Passive())
     self.cathode = self.Port(Passive())
 
-    self.reverse_voltage = cast(RangeExpr, reverse_voltage)
-    self.current = cast(RangeExpr, current)
-    self.voltage_drop = cast(RangeExpr, voltage_drop)
-    self.reverse_recovery_time = cast(RangeExpr, reverse_recovery_time)
+    self.reverse_voltage = self.ArgParameter(reverse_voltage)
+    self.current = self.ArgParameter(current)
+    self.voltage_drop = self.ArgParameter(voltage_drop)
+    self.reverse_recovery_time = self.ArgParameter(reverse_recovery_time)
 
 
 @abstract_block
@@ -40,8 +39,8 @@ class ZenerDiode(DiscreteSemiconductor):
     self.anode = self.Port(Passive())
     self.cathode = self.Port(Passive())
 
-    self.zener_voltage = cast(RangeExpr, zener_voltage)
-    self.forward_voltage_drop = cast(RangeExpr, forward_voltage_drop)
+    self.zener_voltage = self.ArgParameter(zener_voltage)
+    self.forward_voltage_drop = self.ArgParameter(forward_voltage_drop)
 
 
 class ProtectionZenerDiode(DiscreteApplication):
@@ -54,7 +53,7 @@ class ProtectionZenerDiode(DiscreteApplication):
     self.pwr = self.Port(VoltageSink(), [Power, Input])
     self.gnd = self.Port(Ground(), [Common])
 
-    self.voltage = cast(RangeExpr, voltage)
+    self.voltage = self.ArgParameter(voltage)
 
   def contents(self):
     super().contents()

--- a/electronics_abstract_parts/AbstractFets.py
+++ b/electronics_abstract_parts/AbstractFets.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .Categories import *
 
@@ -26,12 +25,12 @@ class Fet(DiscreteSemiconductor):
     self.drain = self.Port(Passive())
     self.gate = self.Port(Passive())
 
-    self.drain_voltage = cast(RangeExpr, drain_voltage)
-    self.drain_current = cast(RangeExpr, drain_current)
-    self.gate_voltage = cast(RangeExpr, gate_voltage)
-    self.rds_on = cast(RangeExpr, rds_on)
-    self.gate_charge = cast(RangeExpr, gate_charge)
-    self.power = cast(RangeExpr, power)
+    self.drain_voltage = self.ArgParameter(drain_voltage)
+    self.drain_current = self.ArgParameter(drain_current)
+    self.gate_voltage = self.ArgParameter(gate_voltage)
+    self.rds_on = self.ArgParameter(rds_on)
+    self.gate_charge = self.ArgParameter(gate_charge)
+    self.power = self.ArgParameter(power)
 
     self.actual_drain_voltage_rating = self.Parameter(RangeExpr())
     self.actual_drain_current_rating = self.Parameter(RangeExpr())
@@ -67,8 +66,8 @@ class SwitchFet(Fet):
   def __init__(self, frequency: RangeLike, drive_current: RangeLike, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.frequency = cast(RangeExpr, frequency)
-    self.drive_current = cast(RangeExpr, drive_current)  # positive is turn-on drive, negative is turn-off drive
+    self.frequency = self.ArgParameter(frequency)
+    self.drive_current = self.ArgParameter(drive_current)  # positive is turn-on drive, negative is turn-off drive
 
 
 @abstract_block

--- a/electronics_abstract_parts/AbstractFets.py
+++ b/electronics_abstract_parts/AbstractFets.py
@@ -19,7 +19,7 @@ class Fet(DiscreteSemiconductor):
   @init_in_parent
   def __init__(self, drain_voltage: RangeLike, drain_current: RangeLike, *,
                gate_voltage: RangeLike = Default(Range.all()), rds_on: RangeLike = Default(Range.all()),
-               gate_charge: RangeLike = Default(Range.all()), power: RangeLike = Default(0)) -> None:
+               gate_charge: RangeLike = Default(Range.all()), power: RangeLike = Default(Range.exact(0))) -> None:
     super().__init__()
 
     self.source = self.Port(Passive())

--- a/electronics_abstract_parts/AbstractFuse.py
+++ b/electronics_abstract_parts/AbstractFuse.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .Categories import *
 
@@ -10,7 +9,7 @@ class Fuse(DiscreteComponent, DiscreteApplication):
     """Model-wise, equivalent to a VoltageSource|Sink passthrough, with a trip rating."""
     super().__init__()
 
-    self.trip_current = cast(RangeExpr, trip_current)
+    self.trip_current = self.ArgParameter(trip_current)
 
     self.pwr_in = self.Port(VoltageSink(current_draw=RangeExpr(),
                                         voltage_limits=RangeExpr.ALL),

--- a/electronics_abstract_parts/AbstractPassives.py
+++ b/electronics_abstract_parts/AbstractPassives.py
@@ -137,8 +137,8 @@ class Inductor(PassiveComponent):
     self.a = self.Port(Passive())
     self.b = self.Port(Passive())
 
-    self.inductance = inductance
-    self.current = current  # defined as operating current range, non-directioned
-    self.frequency = frequency  # defined as operating frequency range
+    self.inductance = self.ArgParameter(inductance)
+    self.current = self.ArgParameter(current)  # defined as operating current range, non-directioned
+    self.frequency = self.ArgParameter(frequency)  # defined as operating frequency range
     # TODO: in the future, when we consider efficiency - for now, use current ratings
     # self.resistance_dc = self.Parameter(RangeExpr())

--- a/electronics_abstract_parts/AbstractPassives.py
+++ b/electronics_abstract_parts/AbstractPassives.py
@@ -4,7 +4,6 @@ from .Categories import *
 
 @abstract_block
 class Resistor(PassiveComponent):
-  # TODO no default resistance
   @init_in_parent
   def __init__(self, resistance: RangeLike, power: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
@@ -19,7 +18,6 @@ class Resistor(PassiveComponent):
 
 class PullupResistor(DiscreteApplication):
   """Pull-up resistor with an VoltageSink for automatic implicit connect to a Power line."""
-  # TODO no default resistance
   @init_in_parent
   def __init__(self, resistance: RangeLike) -> None:
     super().__init__()
@@ -32,7 +30,6 @@ class PullupResistor(DiscreteApplication):
 
 class PulldownResistor(DiscreteApplication):
   """Pull-down resistor with an VoltageSink for automatic implicit connect to a Ground line."""
-  # TODO no default resistance
   @init_in_parent
   def __init__(self, resistance: RangeLike) -> None:
     super().__init__()
@@ -96,7 +93,6 @@ class CurrentSenseResistor(DiscreteApplication):
 @abstract_block
 class UnpolarizedCapacitor(PassiveComponent):
   """Base type for a capacitor, that defines its parameters and without ports (since capacitors can be polarized)"""
-  # TODO no default capacitance and voltage rating
   @init_in_parent
   def __init__(self, capacitance: RangeLike, voltage: RangeLike) -> None:
     super().__init__()
@@ -108,7 +104,6 @@ class UnpolarizedCapacitor(PassiveComponent):
 @abstract_block
 class Capacitor(UnpolarizedCapacitor):
   """Polarized capacitor, which we assume will be the default"""
-  # TODO no default capacitance and voltage rating
   @init_in_parent
   def __init__(self, *args, **kwargs) -> None:
     super().__init__(*args, **kwargs)
@@ -120,21 +115,19 @@ class Capacitor(UnpolarizedCapacitor):
 class DecouplingCapacitor(DiscreteApplication):
   """Optionally polarized capacitor used for DC decoupling, with VoltageSink connections with voltage inference.
   Implemented as a shim block."""
-  # TODO no default capacitance
   @init_in_parent
   def __init__(self, capacitance: RangeLike) -> None:
     super().__init__()
 
     self.cap = self.Block(Capacitor(capacitance, voltage=RangeExpr()))
-    self.pwr = self.Export(self.cap.pos.as_voltage_sink())
-    self.gnd = self.Export(self.cap.neg.as_voltage_sink())
+    self.pwr = self.Export(self.cap.pos.as_voltage_sink(), [Power])
+    self.gnd = self.Export(self.cap.neg.as_voltage_sink(), [Common])
 
     self.assign(self.cap.voltage, self.pwr.link().voltage - self.gnd.link().voltage)
 
 
 @abstract_block
 class Inductor(PassiveComponent):
-  # TODO no default inductance
   @init_in_parent
   def __init__(self, inductance: RangeLike,
                current: RangeLike = Default(RangeExpr.ZERO),

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -1,4 +1,4 @@
-from typing import cast, Optional
+from typing import Optional
 from electronics_model import *
 from .Categories import *
 from .AbstractPassives import Inductor, DecouplingCapacitor
@@ -11,7 +11,7 @@ class DcDcConverter(PowerConditioner):
   def __init__(self, output_voltage: RangeLike) -> None:
     super().__init__()
 
-    self.output_voltage = cast(RangeExpr, output_voltage)
+    self.output_voltage = self.ArgParameter(output_voltage)
 
     self.pwr_in = self.Port(VoltageSink(
       voltage_limits=RangeExpr(),
@@ -98,9 +98,9 @@ class DcDcSwitchingConverter(DcDcConverter):
     """
     super().__init__(*args, **kwargs)
 
-    self.ripple_current_factor = cast(RangeExpr, ripple_current_factor)
-    self.input_ripple_limit = cast(FloatExpr, input_ripple_limit)
-    self.output_ripple_limit = cast(FloatExpr, output_ripple_limit)
+    self.ripple_current_factor = self.ArgParameter(ripple_current_factor)
+    self.input_ripple_limit = self.ArgParameter(input_ripple_limit)
+    self.output_ripple_limit = self.ArgParameter(output_ripple_limit)
 
     self.frequency = self.Parameter(RangeExpr())
 

--- a/electronics_abstract_parts/AbstractSwitch.py
+++ b/electronics_abstract_parts/AbstractSwitch.py
@@ -6,7 +6,7 @@ from .Categories import *
 @abstract_block
 class Switch(DiscreteComponent):
   @init_in_parent
-  def __init__(self, voltage: RangeLike, current: RangeLike = Default(0*Amp)) -> None:
+  def __init__(self, voltage: RangeLike, current: RangeLike = Default(0*Amp(tol=0))) -> None:
     super().__init__()
 
     self.a = self.Port(Passive())

--- a/electronics_abstract_parts/AbstractSwitch.py
+++ b/electronics_abstract_parts/AbstractSwitch.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .Categories import *
 
@@ -12,8 +11,8 @@ class Switch(DiscreteComponent):
     self.a = self.Port(Passive())
     self.b = self.Port(Passive())
 
-    self.current = cast(RangeExpr, current)
-    self.voltage = cast(RangeExpr, voltage)
+    self.current = self.ArgParameter(current)
+    self.voltage = self.ArgParameter(voltage)
 
 
 class DigitalSwitch(DiscreteApplication):

--- a/electronics_abstract_parts/AssignablePin.py
+++ b/electronics_abstract_parts/AssignablePin.py
@@ -10,13 +10,14 @@ class AssignablePinBlock(GeneratorBlock):
   new_io(tpe): returns a fresh IO port of type tpe
   suggest_pin(port, str): suggests a pinmap
   TODO should these be separate?"""
-  def __init__(self):
+  @init_in_parent
+  def __init__(self, pin_assigns: StringLike = ""):
     super().__init__()
 
     self._all_assignable_ios: List[Port] = []
     self._remaining_assignable_ios: Dict[Type[Port], List[Port]] = {}
 
-    self.pin_assigns = self.Parameter(StringExpr())
+    self.pin_assigns = cast(StringExpr, pin_assigns)
 
   # TODO type signature could be enhanced to only allow iterable pin with Bundle type
   PortType = TypeVar('PortType', bound=Union[CircuitPort, Bundle])

--- a/electronics_abstract_parts/AssignablePin.py
+++ b/electronics_abstract_parts/AssignablePin.py
@@ -17,7 +17,7 @@ class AssignablePinBlock(GeneratorBlock):
     self._all_assignable_ios: List[Port] = []
     self._remaining_assignable_ios: Dict[Type[Port], List[Port]] = {}
 
-    self.pin_assigns = cast(StringExpr, pin_assigns)
+    self.pin_assigns = self.ArgParameter(pin_assigns)
 
   # TODO type signature could be enhanced to only allow iterable pin with Bundle type
   PortType = TypeVar('PortType', bound=Union[CircuitPort, Bundle])

--- a/electronics_abstract_parts/DigitalAmplifiers.py
+++ b/electronics_abstract_parts/DigitalAmplifiers.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_model import *
 from .AbstractFets import SwitchNFet, SwitchPFet
 from .AbstractPassives import Resistor
@@ -23,9 +22,9 @@ class HighSideSwitch(Block):
       output_thresholds=(0, self.pwr.link().voltage.upper()),
     ), [Output])
 
-    self.pull_resistance = cast(RangeExpr, pull_resistance)
-    self.max_rds = cast(FloatExpr, max_rds)
-    self.frequency = cast(RangeExpr, frequency)
+    self.pull_resistance = self.ArgParameter(pull_resistance)
+    self.max_rds = self.ArgParameter(max_rds)
+    self.frequency = self.ArgParameter(frequency)
 
     pwr_voltage = self.pwr.link().voltage
     out_current = self.output.link().current_drawn
@@ -87,8 +86,8 @@ class HalfBridgeNFet(Block):
 
     self.output = self.Port(DigitalSource.from_supply(self.gnd, self.pwr))  # current limits from supply
 
-    self.max_rds = cast(FloatExpr, max_rds)
-    self.frequency = cast(RangeExpr, frequency)
+    self.max_rds = self.ArgParameter(max_rds)
+    self.frequency = self.ArgParameter(frequency)
 
     pwr_voltage = self.pwr.link().voltage
     out_current = self.output.link().current_drawn

--- a/electronics_abstract_parts/PassiveFilters.py
+++ b/electronics_abstract_parts/PassiveFilters.py
@@ -1,5 +1,3 @@
-from typing import *
-
 from math import pi
 
 from electronics_model import *
@@ -13,9 +11,9 @@ class LowPassRc(AnalogFilter, GeneratorBlock):
   def __init__(self, impedance: RangeLike, cutoff_freq: RangeLike,
                voltage: RangeLike):
     super().__init__()
-    self.impedance = cast(RangeExpr, impedance)
-    self.cutoff_freq = cast(RangeExpr, cutoff_freq)
-    self.voltage = cast(RangeExpr, voltage)
+    self.impedance = self.ArgParameter(impedance)
+    self.cutoff_freq = self.ArgParameter(cutoff_freq)
+    self.voltage = self.ArgParameter(voltage)
 
     self.input = self.Port(Passive())
     self.output = self.Port(Passive())

--- a/electronics_abstract_parts/ResistiveDivider.py
+++ b/electronics_abstract_parts/ResistiveDivider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from math import log10, ceil
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
 from edg_core import *
 from electronics_model import Common, Passive
@@ -63,8 +63,8 @@ class ResistiveDivider(DiscreteApplication, GeneratorBlock):
                series: IntLike = Default(24), tolerance: FloatLike = Default(0.01)) -> None:
     super().__init__()
 
-    self.ratio = cast(RangeExpr, ratio)
-    self.impedance = cast(RangeExpr, impedance)
+    self.ratio = self.ArgParameter(ratio)
+    self.impedance = self.ArgParameter(impedance)
 
     self.actual_ratio = self.Parameter(RangeExpr())
     self.actual_impedance = self.Parameter(RangeExpr())
@@ -145,7 +145,7 @@ class VoltageDivider(BaseVoltageDivider):
   def __init__(self, *, output_voltage: RangeLike, impedance: RangeLike) -> None:
     super().__init__(impedance=impedance)
 
-    self.output_voltage = cast(RangeExpr, output_voltage)
+    self.output_voltage = self.ArgParameter(output_voltage)
 
     ratio_lower = self.output_voltage.lower() / self.input.link().voltage.lower()
     ratio_upper = self.output_voltage.upper() / self.input.link().voltage.upper()
@@ -162,8 +162,8 @@ class FeedbackVoltageDivider(BaseVoltageDivider):
                assumed_input_voltage: RangeLike) -> None:
     super().__init__(impedance=impedance)
 
-    self.output_voltage = cast(RangeExpr, output_voltage)  # TODO eliminate this casting?
-    self.assumed_input_voltage = cast(RangeExpr, assumed_input_voltage)  # TODO eliminate this casting?
+    self.output_voltage = self.ArgParameter(output_voltage)
+    self.assumed_input_voltage = self.ArgParameter(assumed_input_voltage)
     self.actual_input_voltage = self.Parameter(RangeExpr(
       (self.output_voltage.lower() / self.actual_ratio.upper(),
        self.output_voltage.upper() / self.actual_ratio.lower())

--- a/electronics_lib/BatteryProtector_S8200A.py
+++ b/electronics_lib/BatteryProtector_S8200A.py
@@ -71,10 +71,9 @@ class BatteryProtector_S8200A(Block):
 
     self.connect(self.pwr_in, self.pwr_out)
 
-    (self.vdd_vss_cap, ), _ = self.chain(
-      self.ic.vdd,
-      self.Block(DecouplingCapacitor(0.1 * uFarad(tol=0.10))),
-      self.ic.vss)
+    self.vdd_vss_cap = self.Block(DecouplingCapacitor(0.1 * uFarad(tol=0.10)))
+    self.connect(self.ic.vdd, self.vdd_vss_cap.pwr)
+    self.connect(self.ic.vss, self.vdd_vss_cap.gnd)
 
     # do fet
     self.connect(self.ic.vss, self.do_fet.source.as_ground())

--- a/electronics_lib/BuckConverter_TexasInstruments.py
+++ b/electronics_lib/BuckConverter_TexasInstruments.py
@@ -138,7 +138,7 @@ class Tps54202h(DiscreteBuckConverter):
 
       # an internal 6.9v Zener clamps the enable voltage, datasheet recommends at 510k resistor
       # a pull-up resistor isn't used because
-      self.en_res = self.Block(Resistor(resistance=510*kOhm(tol=0.05), power=0))
+      self.en_res = self.Block(Resistor(resistance=510*kOhm(tol=0.05), power=0*Amp(tol=0)))
       self.connect(self.pwr_in, self.en_res.a.as_voltage_sink())
       self.connect(self.en_res.b.as_digital_source(), self.ic.en)
 

--- a/electronics_lib/Microcontroller_Nucleo32.py
+++ b/electronics_lib/Microcontroller_Nucleo32.py
@@ -46,13 +46,13 @@ class Nucleo_F303k8(Microcontroller, FootprintBlock, AssignablePinBlock):  # TOD
     adc_model = AnalogSink(
       voltage_limits=(-0.3, 3.6) * Volt,
       current_draw=(0, 0) * Amp,
-      impedance=100*kOhm  # TODO: actually spec'd as maximum external impedance; internal impedance not given
+      impedance=100*kOhm(tol=0)  # TODO: actually spec'd as maximum external impedance; internal impedance not given
     )
 
     dac_model = AnalogSource(
       voltage_out=(0.2, 3.1) * Volt,  # TODO should derive from common rail
       current_limits=(0, 0) * Amp,  # TODO not given by spec
-      impedance=15*kOhm  # assumes buffer off
+      impedance=15*kOhm(tol=0)  # assumes buffer off
     )
 
     self.digital = ElementDict[DigitalBidir]()

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -41,8 +41,12 @@ class Stm32f103_48_Device(DiscreteChip, FootprintBlock):
 
     self.swd = self.Port(SwdTargetPort(standard_dio_model))  # TODO maybe make optional?
 
-    self.osc32 = self.Port(CrystalDriver(frequency_limits=32.768*kHertz, voltage_out=self.vdd.link().voltage), optional=True)  # TODO other specs from Table 23
-    self.osc = self.Port(CrystalDriver(frequency_limits=(4, 16)*MHertz, voltage_out=self.vdd.link().voltage), optional=True)  # Table 22
+    self.osc32 = self.Port(CrystalDriver(frequency_limits=32.768*kHertz(tol=0),  # TODO actual tolerances
+                                         voltage_out=self.vdd.link().voltage),
+                           optional=True)  # TODO other specs from Table 23
+    self.osc = self.Port(CrystalDriver(frequency_limits=(4, 16)*MHertz,
+                                       voltage_out=self.vdd.link().voltage),
+                         optional=True)  # Table 22
 
     self.pa = ElementDict[DigitalBidir]()
     for i in chain(range(13), [15]):

--- a/electronics_lib/PowerConditioning.py
+++ b/electronics_lib/PowerConditioning.py
@@ -55,7 +55,7 @@ class BufferedSupply(PowerConditioner):
     ) as imp:
       self.sense = self.Block(Resistor(  # TODO replace with SeriesResistor/CurrentSenseResistor - that propagates current
         resistance=self.sense_resistance,
-        power=max_charge_current * max_charge_current * self.sense_resistance.upper()
+        power=(0, max_charge_current * max_charge_current * self.sense_resistance.upper())
       ))
       self.connect(self.pwr, self.sense.a.as_voltage_sink(
         current_draw=(0, max_charge_current)))

--- a/electronics_lib/PowerConditioning.py
+++ b/electronics_lib/PowerConditioning.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_abstract_parts import *
 
 
@@ -32,9 +31,9 @@ class BufferedSupply(PowerConditioner):
                voltage_drop: RangeLike) -> None:
     super().__init__()
 
-    self.charging_current = cast(RangeExpr, charging_current)
-    self.sense_resistance = cast(RangeExpr, sense_resistance)
-    self.voltage_drop = cast(RangeExpr, voltage_drop)
+    self.charging_current = self.ArgParameter(charging_current)
+    self.sense_resistance = self.ArgParameter(sense_resistance)
+    self.voltage_drop = self.ArgParameter(voltage_drop)
 
     self.pwr = self.Port(VoltageSink(), [Power, Input])
     self.pwr_out = self.Port(VoltageSource(), [Output])

--- a/electronics_lib/Speakers.py
+++ b/electronics_lib/Speakers.py
@@ -99,7 +99,7 @@ class Speaker(DiscreteApplication, FootprintBlock):
     super().__init__()
 
     self.input = self.Port(SpeakerPort(
-      impedance=8*Ohm
+      impedance=8*Ohm(tol=0)
     ), [Input])
 
   def contents(self):

--- a/electronics_lib/TableDeratingCapacitor.py
+++ b/electronics_lib/TableDeratingCapacitor.py
@@ -1,4 +1,3 @@
-from typing import cast
 from electronics_abstract_parts.Categories import DummyDevice
 from electronics_abstract_parts import *
 from .PartsTable import *

--- a/electronics_model/AnalogPort.py
+++ b/electronics_model/AnalogPort.py
@@ -26,7 +26,7 @@ class AnalogLink(CircuitLink):
     super().contents()
 
     self.assign(self.sink_impedance, 1 / (1 / self.sinks.map_extract(lambda x: x.impedance)).sum())
-    self.require(self.source.impedance <= self.sink_impedance * 0.1)  # about 10x to ensure signal integrity  # TODO make 100x?
+    self.require(self.source.impedance.upper() <= self.sink_impedance.lower() * 0.1)  # about 10x for signal integrity
     self.assign(self.current_drawn, self.sinks.sum(lambda x: x.current_draw))
 
     self.assign(self.voltage_limits, self.sinks.intersection(lambda x: x.voltage_limits))

--- a/examples/test_battery_protector.py
+++ b/examples/test_battery_protector.py
@@ -3,7 +3,7 @@ import unittest
 from edg import *
 
 
-class BatteryProtectorCircuit(SimpleBoardTop):
+class BatteryProtectorCircuit(BoardTop):
   def contents(self) -> None:
     super().contents()
     self.battery_protector = self.Block(BatteryProtector_S8200A())

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -247,12 +247,11 @@ class Ref_Bh1620fvc_Device(FootprintBlock):
 
 class Ref_Bh1620fvc(Block):
   @init_in_parent
-  def __init__(self, max_illuminance: FloatLike = FloatExpr(),
-               target_voltage: RangeLike = RangeExpr()) -> None:
+  def __init__(self, max_illuminance: FloatLike, target_voltage: RangeLike) -> None:
     super().__init__()
 
     # in L-gain mode, Vout = 0.0057e-6 * Ev * Rl
-    rload = RangeExpr._to_expr_type(target_voltage) / (0.0057e-6) / FloatExpr._to_expr_type(max_illuminance)
+    rload = RangeExpr._to_expr_type(target_voltage) / 0.0057e-6 / max_illuminance
     # without the typer, this would be written as:
     # rload = target_voltage / (0.0057e-6) / max_illuminance
 

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -250,10 +250,9 @@ class Ref_Bh1620fvc(Block):
   def __init__(self, max_illuminance: FloatLike, target_voltage: RangeLike) -> None:
     super().__init__()
 
+    self.target_voltage = self.ArgParameter(target_voltage)  # needed for the typer to not be unhappy
     # in L-gain mode, Vout = 0.0057e-6 * Ev * Rl
-    rload = RangeExpr._to_expr_type(target_voltage) / 0.0057e-6 / max_illuminance
-    # without the typer, this would be written as:
-    # rload = target_voltage / (0.0057e-6) / max_illuminance
+    rload = self.target_voltage / 0.0057e-6 / max_illuminance
 
     self.ic = self.Block(Ref_Bh1620fvc_Device(rload))
     self.pwr = self.Export(self.ic.vcc, [Power])

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -3,7 +3,7 @@ import unittest
 from edg import *
 
 
-class NewBlinkyOvervolt(SimpleBoardTop):
+class NewBlinkyOvervolt(BoardTop):
   def contents(self) -> None:
     super().contents()
 
@@ -18,7 +18,7 @@ class NewBlinkyOvervolt(SimpleBoardTop):
     self.connect(self.mcu.gnd, self.swd.gnd, self.jack.gnd)
 
 
-class NewBlinkyBuck(SimpleBoardTop):
+class NewBlinkyBuck(BoardTop):
   def contents(self) -> None:
     super().contents()
 
@@ -43,7 +43,7 @@ class NewBlinkyBuck(SimpleBoardTop):
       ])
 
 
-class NewBlinkyRefactored(SimpleBoardTop):
+class NewBlinkyRefactored(BoardTop):
   def contents(self) -> None:
     super().contents()
 
@@ -135,7 +135,7 @@ class Ref_Lf21215tmr(Block):
     super().contents()
 
 
-class NewBlinkyMagsense(SimpleBoardTop):
+class NewBlinkyMagsense(BoardTop):
   def contents(self) -> None:
     super().contents()
 
@@ -167,7 +167,7 @@ class NewBlinkyMagsense(SimpleBoardTop):
       ])
 
 
-class NewBlinkyLightsense(SimpleBoardTop):
+class NewBlinkyLightsense(BoardTop):
   def contents(self) -> None:
     super().contents()
 

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -1,4 +1,3 @@
-from typing import cast
 import unittest
 
 from edg import *
@@ -68,8 +67,8 @@ class MultimeterCurrentDriver(Block):
     self.control = self.Port(AnalogSink())
     self.enable = self.Port(DigitalSink())
 
-    self.resistance = cast(RangeExpr, resistance)
-    self.voltage_rating = cast(RangeExpr, voltage_rating)
+    self.resistance = self.ArgParameter(resistance)
+    self.voltage_rating = self.ArgParameter(voltage_rating)
 
   def contents(self):
     super().contents()

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -85,9 +85,6 @@ class MultimeterCurrentDriver(Block):
       drain_voltage=(0, max_in_voltage),
       drain_current=(0, max_in_voltage / self.resistance.lower()),
       gate_voltage=(max_in_voltage, max_in_voltage),  # allow all
-      rds_on=(0, 10)*Ohm,  # TODO kind of arbitrary
-      gate_charge=RangeExpr.ALL,
-      power=0*Watt  # TODO ignored
     ))
     self.connect(self.res.b, self.fet.source)
 
@@ -155,9 +152,6 @@ class FetPowerGate(Block):
       drain_voltage=(0, max_voltage),
       drain_current=(0, max_current),
       gate_voltage=(max_voltage, max_voltage),  # TODO this ignores the diode drop
-      rds_on=(0, max_voltage / max_current / 10),  # TODO kind of arbitrary, should really be lower
-      gate_charge=(0, float('inf')),
-      power=0*Watt  # TODO ignored
     ))
     self.connect(self.pwr_in, self.pwr_fet.source.as_voltage_sink(
       current_draw=self.pwr_out.link().current_drawn,
@@ -174,10 +168,7 @@ class FetPowerGate(Block):
     self.amp_fet = self.Block(NFet(
       drain_voltage=(0, max_voltage),
       drain_current=(0, 0),  # effectively no current
-      gate_voltage=(self.control.link().output_thresholds.upper(), self.control.link().voltage.upper()),
-      rds_on=RangeExpr.ALL,  # negligible
-      gate_charge=RangeExpr.ALL,
-      power=0*Watt  # TODO ignored
+      gate_voltage=(self.control.link().output_thresholds.upper(), self.control.link().voltage.upper())
     ))
     self.connect(self.control, self.amp_fet.gate.as_digital_sink(), self.amp_res.a.as_digital_sink())  # TODO more modeling here?
 
@@ -193,7 +184,7 @@ class FetPowerGate(Block):
       voltage_drop=(0, 0.4)*Volt,  # TODO kind of arbitrary - should be parameterized
       reverse_recovery_time=RangeExpr.ALL
     ))
-    self.btn = self.Block(Switch(voltage=0*Volt))  # TODO - actually model switch voltage
+    self.btn = self.Block(Switch(voltage=0*Volt(tol=0)))  # TODO - actually model switch voltage
     self.connect(self.btn.a, self.ctl_diode.cathode, self.btn_diode.cathode)
     self.connect(self.gnd, self.amp_fet.source.as_ground(), self.amp_res.b.as_ground(),
                  self.btn.b.as_ground())

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -1,4 +1,3 @@
-from typing import cast
 import unittest
 
 from electronics_abstract_parts.ESeriesUtil import ESeriesRatioUtil
@@ -27,8 +26,8 @@ class GatedEmitterFollower(Block):
     self.high_en = self.Port(DigitalSink())
     self.low_en = self.Port(DigitalSink())
 
-    self.current = cast(RangeExpr, current)
-    self.rds_on = cast(RangeExpr, rds_on)
+    self.current = self.ArgParameter(current)
+    self.rds_on = self.ArgParameter(rds_on)
 
   def contents(self) -> None:
     super().contents()
@@ -188,8 +187,8 @@ class SourceMeasureControl(Block):
     self.measured_voltage = self.Port(AnalogSource())
     self.measured_current = self.Port(AnalogSource())
 
-    self.current = cast(RangeExpr, current)
-    self.rds_on = cast(RangeExpr, rds_on)
+    self.current = self.ArgParameter(current)
+    self.rds_on = self.ArgParameter(rds_on)
 
     with self.implicit_connect(
             ImplicitConnect(self.pwr_logic, [Power]),


### PR DESCRIPTION
Not the perfect solution, but cleaner than `cast(RangeExpr, initParam)`. This is the current workaround for #98.

Also removes the implicit promotion from float to Range, which while convenient, really probably isn't safe. Still allows range-float operations, eg range minus float.

Also a few additional cleanups in the standard library.