### PR TITLE
Port.empty() refactor

### DIFF
--- a/edg_core/Array.py
+++ b/edg_core/Array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 from typing import *
 
 import edgir
@@ -146,6 +147,9 @@ class DerivedVector(BaseVector, Generic[VectorType]):
     assert base.parent is not None  # to satisfy type checker, though kind of duplicates _is_bound
     self._bind_in_place(base.parent)
 
+  def _type_of(self) -> Hashable:
+    return (self.target._type_of(),)
+
   def _get_elt_sample(self) -> BasePort:
     return self.target
 
@@ -155,8 +159,8 @@ class DerivedVector(BaseVector, Generic[VectorType]):
   def _def_to_proto(self) -> edgir.PortTypes:
     raise RuntimeError()  # this doesn't generate into a library element
 
-  def _type_of(self) -> Hashable:
-    return (self.target._type_of(),)
+  def _get_initializers(self, path_prefix: List[str]) -> List[Tuple[ConstraintExpr, List[str], ConstraintExpr]]:
+    raise RuntimeError()  # should never happen
 
 
 # An 'elastic' array of ports type, with unspecified length at declaration time, and length

--- a/edg_core/Array.py
+++ b/edg_core/Array.py
@@ -199,6 +199,9 @@ class Vector(BaseVector, Generic[VectorType]):
   def _def_to_proto(self) -> edgir.PortTypes:
     raise RuntimeError()  # this doesn't generate into a library element
 
+  def _get_initializers(self, path_prefix: List[str]) -> List[Tuple[ConstraintExpr, List[str], ConstraintExpr]]:
+    raise RuntimeError()  # should never happen
+
   def _get_contained_ref_map(self) -> IdentityDict[Refable, edgir.LocalPath]:
     return self.elt_sample._get_ref_map(edgir.LocalPath())
 

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -311,7 +311,12 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
       # TODO needs to be something like sealed types for match comprehensiveness
 
     for (name, port) in self._ports.items():
-      process_port_inits(port, [name])
+      if port not in ignore_ports:
+        for (param, path, initializer) in port._get_initializers([name]):
+          pb.constraints[f"(init){'.'.join(path)}"].CopyFrom(
+            AssignBinding.make_assign(param, param._to_expr_type(initializer), ref_map)
+          )
+          self._namespace_order.append(f"(init){'.'.join(path)}")
 
     return pb
 

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -272,17 +272,15 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
 
     return pb
 
-  def _populate_def_proto_port_init(self, pb: BaseBlockEdgirType,
-                                    ignore_ports: IdentitySet[BasePort] = IdentitySet()) -> BaseBlockEdgirType:
+  def _populate_def_proto_port_init(self, pb: BaseBlockEdgirType) -> BaseBlockEdgirType:
     ref_map = self._get_ref_map(edgir.LocalPath())  # TODO dedup ref_map
 
     for (name, port) in self._ports.items():
-      if port not in ignore_ports:
-        for (param, path, initializer) in port._get_initializers([name]):
-          pb.constraints[f"(init){'.'.join(path)}"].CopyFrom(
-            AssignBinding.make_assign(param, param._to_expr_type(initializer), ref_map)
-          )
-          self._namespace_order.append(f"(init){'.'.join(path)}")
+      for (param, path, initializer) in port._get_initializers([name]):
+        pb.constraints[f"(init){'.'.join(path)}"].CopyFrom(
+          AssignBinding.make_assign(param, param._to_expr_type(initializer), ref_map)
+        )
+        self._namespace_order.append(f"(init){'.'.join(path)}")
 
     return pb
 

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -75,13 +75,6 @@ class ConstraintExpr(Refable, Generic[WrappedType, CastableType]):
   def _is_bound(self) -> bool:
     return self.binding is not None and self.binding.is_bound()
 
-  def _initializer_to(self, target: ConstraintExpr) -> BoolExpr:
-    assert type(self) == type(target), "target must be of same type"
-    if self.initializer is None:
-      return BoolExpr._to_expr_type(True)
-    else:
-      return target == self.initializer
-
   @abstractmethod
   def _decl_to_proto(self) -> edgir.ValInit:
     """Returns the protobuf for the definition of this parameter. Must have ParamBinding / ParamVariableBinding"""
@@ -159,25 +152,6 @@ class BoolExpr(ConstraintExpr[bool, BoolLike]):
         f"if-then-else results must be of same type, got then={then_val}, else={else_val}"
     assert self._is_bound() and then_val._is_bound() and else_val._is_bound()
     return then_val._new_bind(IfThenElseBinding(self, then_val, else_val))
-
-  def _is_true_lit(self) -> bool:
-    assert self._is_bound()
-    return isinstance(self.binding, BoolLiteralBinding) and self.binding.value == True
-
-  def _is_lit(self) -> bool:
-    assert self._is_bound()
-    return isinstance(self.binding, BoolLiteralBinding)
-
-  @classmethod
-  def _combine_and(cls, sub_exprs: Iterable[BoolExpr]) -> BoolExpr:
-    def combine_exprs(expr1: BoolExpr, expr2: BoolExpr) -> BoolExpr:
-      return expr1 & expr2
-
-    sub_exprs = [sub_expr for sub_expr in sub_exprs if not sub_expr._is_true_lit()]
-    if len(sub_exprs) == 0:
-      return cls._to_expr_type(True)
-    else:
-      return reduce(combine_exprs, sub_exprs)
 
 
 NumLikeSelfType = TypeVar('NumLikeSelfType', bound='NumLikeExpr')

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -316,7 +316,7 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     pb = self._populate_def_proto_param_init(pb)
     for (port) in self._connected_ports():
       if port._block_parent() is self:
-        port_name = self.manager._name_of(port)
+        port_name = self.manager._name_of(port) or "unk"
         assert not port._get_initializers([port_name]), f"connected boundary port {name} has unexpected initializer"
     pb = self._populate_def_proto_port_init(pb)
 

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -176,7 +176,7 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     super().__init__()
 
     # name -> (empty param, default argument (if any)), set in @init_in_parent
-    self._init_params_value: Dict[str, Tuple[ConstraintExpr, ConstraintExpr]]
+    self._init_params_value: Dict[str, Tuple[ConstraintExpr, Optional[ConstraintExpr]]]
     if not hasattr(self, '_init_params_value'):
       self._init_params_value = {}
     for param_name, (param, param_value) in self._init_params_value.items():

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -314,14 +314,14 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     for (name, (param, param_value)) in self._init_params_value.items():
       assert param.initializer is None, f"__init__ argument param {name} has unexpected initializer"
     pb = self._populate_def_proto_param_init(pb)
-    bad_ports = []
+    bad_params = []
     for (port) in self._connected_ports():
       if port._block_parent() is self:
         port_name = self.manager._name_of(port)
         # assert not port._get_initializers([port_name]), f"connected boundary port {name} has unexpected initializer"
-        if port._get_initializers([port_name or "unk"]):
-          bad_ports.append(port_name)
-    assert not bad_ports, f"unexpected initializers in {type(self)}: {bad_ports}"
+        for (param, path, init) in port._get_initializers([port_name or "unk"]):
+          bad_params.append('.'.join(path))
+    assert not bad_params, f"unexpected initializers in {type(self)}: {bad_params}"
     pb = self._populate_def_proto_port_init(pb, self._connected_ports())
 
     return pb
@@ -433,8 +433,17 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     assert port_parent._parent is self, "can only export ports of contained block"
     assert port._is_bound(), "can only export bound type"
 
-    new_port: BasePort = self.Port(type(port)(),  # TODO is dropping args safe in all cases?
-                                   tags, optional=optional)
+    if isinstance(port, BaseVector):  # TODO can the vector and non-vector paths be unified?
+      assert isinstance(port, Vector)
+      assert isinstance(port._tpe, Port)
+      new_port: BasePort = self.Port(Vector(port._tpe.empty()),
+                                     tags, optional=optional)
+    elif isinstance(port, Port):
+      new_port = self.Port(type(port).empty(),  # TODO is dropping args safe in all cases?
+                           tags, optional=optional)
+    else:
+      raise NotImplementedError(f"unknown exported port type {port}")
+
     self.connect(new_port, port)
     return new_port  # type: ignore
 

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -318,7 +318,7 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
       if port._block_parent() is self:
         port_name = self.manager._name_of(port)
         assert not port._get_initializers([port_name]), f"connected boundary port {name} has unexpected initializer"
-    pb = self._populate_def_proto_port_init(pb, self._connected_ports())
+    pb = self._populate_def_proto_port_init(pb)
 
     return pb
 
@@ -429,7 +429,6 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     assert port_parent._parent is self, "can only export ports of contained block"
     assert port._is_bound(), "can only export bound type"
 
-    assert isinstance(port, Port)
     new_port = self.Port(type(port).empty(),  # TODO is dropping args safe in all cases?
                          tags, optional=optional)
 

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -314,9 +314,14 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     for (name, (param, param_value)) in self._init_params_value.items():
       assert param.initializer is None, f"__init__ argument param {name} has unexpected initializer"
     pb = self._populate_def_proto_param_init(pb)
-    # for (port) in self._connected_ports():
-    #   name = self.manager._name_of(port)
-    #   assert not port._get_initializers([name]), f"connected boundary port {name} has unexpected initializer"
+    bad_ports = []
+    for (port) in self._connected_ports():
+      if port._block_parent() is self:
+        port_name = self.manager._name_of(port)
+        # assert not port._get_initializers([port_name]), f"connected boundary port {name} has unexpected initializer"
+        if port._get_initializers([port_name or "unk"]):
+          bad_ports.append(port_name)
+    assert not bad_ports, f"unexpected initializers in {type(self)}: {bad_ports}"
     pb = self._populate_def_proto_port_init(pb, self._connected_ports())
 
     return pb

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -40,8 +40,8 @@ def init_in_parent(fn: InitType) -> InitType:
     builder_prev = builder.get_curr_context()
     builder.push_element(self)
     try:
-      if not hasattr(self, '_init_params'):
-        self._init_params = {}
+      if not hasattr(self, '_init_params_value'):
+        self._init_params_value = {}
 
       for arg_index, (arg_name, arg_param) in enumerate(list(inspect.signature(fn).parameters.items())[1:]):  # discard 0=self
         if arg_param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
@@ -56,9 +56,9 @@ def init_in_parent(fn: InitType) -> InitType:
         else:
           arg_val = None
 
-        if arg_name in self._init_params:  # if previously declared, check it is the prev param and keep as-is
-          prev_val = self._init_params[arg_name]
-          assert prev_val is arg_val, f"in {fn}, redefinition of initializer {arg_name}={arg_val} over prior {prev_val}"
+        if arg_name in self._init_params_value:  # if previously declared, check it is the prev param and keep as-is
+          (prev_param, prev_val) = self._init_params_value[arg_name]
+          assert prev_param is arg_val, f"in {fn}, redefinition of initializer {arg_name}={arg_val} over prior {prev_val}"
         else:  # not previously declared, create a new constructor parameter
           if isinstance(arg_val, ConstraintExpr):
             assert arg_val._is_bound() or arg_val.initializer is None,\
@@ -68,21 +68,31 @@ def init_in_parent(fn: InitType) -> InitType:
 
           param_model: ConstraintExpr
           if arg_param.annotation in (BoolLike, "BoolLike", BoolExpr, "BoolExpr"):
-            param_model = BoolExpr(arg_val)
+            param_model = BoolExpr()
           elif arg_param.annotation in (IntLike, "IntLike", IntExpr, "IntExpr"):
-            param_model = IntExpr(arg_val)
+            param_model = IntExpr()
           elif arg_param.annotation in (FloatLike, "FloatLike", FloatExpr, "FloatExpr"):
-            param_model = FloatExpr(arg_val)
+            param_model = FloatExpr()
           elif arg_param.annotation in (RangeLike, "RangeLike", RangeExpr, "RangeExpr"):
-            param_model = RangeExpr(arg_val)
+            param_model = RangeExpr()
           elif arg_param.annotation in (StringLike, "StringLike", StringExpr, "StringExpr"):
-            param_model = StringExpr(arg_val)
+            param_model = StringExpr()
           else:
             raise ValueError(f"In {fn}, unknown argument type for {arg_name}: {arg_param.annotation}")
 
           # Create new parameter in self, and pass through this one instead of the original
           param_bound = param_model._bind(InitParamBinding(self))
-          self._init_params[arg_name] = param_bound
+
+          # transform value to standaradize form to ConstraintExpr or None as needed
+          if isinstance(arg_val, ConstraintExpr):
+            if not arg_val._is_bound():  # TODO: perhaps deprecate the FloatExpr() form as an empty param?
+              assert arg_val.initializer is None, f"models may not be passed into __init__ {arg_name}={arg_val}"
+              arg_val = None
+          elif not isinstance(arg_val, ConstraintExpr) and arg_val is not None:
+            arg_val = param_model._to_expr_type(arg_val)
+          assert arg_val is None or type(param_model) == type(arg_val)
+
+          self._init_params_value[arg_name] = (param_bound, arg_val)
 
           if arg_name in kwargs:
             kwargs[arg_name] = param_bound
@@ -164,13 +174,13 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
   def __init__(self) -> None:
     super().__init__()
 
-    self._init_params: Dict[str, ConstraintExpr]  # name -> bound param (with initializer set), set in @init_in_parent
-    if hasattr(self, '_init_params'):
-      for param_name, self_param in self._init_params.items():
-        self._parameters.register(self_param)
-        self.manager.add_element(param_name, self_param)
-    else:
-      self._init_params = {}
+    # name -> (empty param, default argument (if any)), set in @init_in_parent
+    self._init_params_value: Dict[str, Tuple[ConstraintExpr, ConstraintExpr]]
+    if not hasattr(self, '_init_params_value'):
+      self._init_params_value = {}
+    for param_name, (param, param_value) in self._init_params_value.items():
+      self._parameters.register(param)
+      self.manager.add_element(param_name, param)
 
     self.parent = None
 
@@ -196,10 +206,10 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     pb = super()._populate_def_proto_block_base(pb)
 
     # generate param defaults
-    for param_name, self_param in self._init_params.items():
-      if self_param.initializer is not None:
+    for param_name, (param, param_value) in self._init_params_value.items():
+      if param_value is not None:
         # default values can't depend on anything so the ref_map is empty
-        pb.param_defaults[param_name].CopyFrom(self_param.initializer._expr_to_proto(IdentityDict()))
+        pb.param_defaults[param_name].CopyFrom(param_value._expr_to_proto(IdentityDict()))
 
     return pb
 
@@ -270,10 +280,10 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
 
     # generate block initializers
     for (block_name, block) in self._blocks.items():
-      for (block_param_name, block_param) in block._init_params.items():
-        if block_param.initializer is not None:
+      for (block_param_name, (block_param, block_param_value)) in block._init_params_value.items():
+        if block_param_value is not None:
           pb.constraints[f'(init){block_name}.{block_param_name}'].CopyFrom(  # TODO better name
-            AssignBinding.make_assign(block_param, block_param._to_expr_type(block_param.initializer), ref_map)
+            AssignBinding.make_assign(block_param, block_param._to_expr_type(block_param_value), ref_map)
           )
           self._namespace_order.append(f'(init){block_name}.{block_param_name}')
 
@@ -300,7 +310,12 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     pb = self._populate_def_proto_hierarchy(pb)  # specifically generate connect statements first
     pb = self._populate_def_proto_block_base(pb)
     pb = self._populate_def_proto_block_contents(pb)
-    pb = self._populate_def_proto_param_init(pb, IdentitySet(*self._init_params.values()))
+    for (name, (param, param_value)) in self._init_params_value.items():
+      assert param.initializer is None, f"__init__ argument param {name} has unexpected initializer"
+    pb = self._populate_def_proto_param_init(pb)
+    # for (port) in self._connected_ports():
+    #   name = self.manager._name_of(port)
+    #   assert not port._get_initializers([name]), f"connected boundary port {name} has unexpected initializer"
     pb = self._populate_def_proto_port_init(pb, self._connected_ports())
 
     return pb

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -90,7 +90,8 @@ def init_in_parent(fn: InitType) -> InitType:
               arg_val = None
           elif not isinstance(arg_val, ConstraintExpr) and arg_val is not None:
             arg_val = param_model._to_expr_type(arg_val)
-          assert arg_val is None or type(param_model) == type(arg_val)
+          assert arg_val is None or type(param_model) == type(arg_val), \
+            f"type mismatch for {arg_name}: argument type {type(param_model)}, argument value {type(arg_val)}"
 
           self._init_params_value[arg_name] = (param_bound, arg_val)
 

--- a/edg_core/Ports.py
+++ b/edg_core/Ports.py
@@ -246,6 +246,14 @@ class Bundle(Port[PortLinkType], BaseContainerPort, Generic[PortLinkType]):
       *[field._get_ref_map(edgir.localpath_concat(prefix, name)) for (name, field) in self._ports.items()]
     )
 
+  PortSelfType = TypeVar('PortSelfType', bound='Port')
+  def _model_update_initializers(self: PortSelfType, initializers: PortSelfType) -> None:
+    ...
+
+  def model_with_elt_initializers(self: PortSelfType, initializers: dict[str, Port]) -> PortSelfType:
+    """Clones model-typed self, except adding initializers to elements from the input dict."""
+    pass
+
   T = TypeVar('T', bound=Port)
   def Port(self, tpe: T, *, desc: Optional[str] = None) -> T:
     """Registers a field for this Bundle"""

--- a/edg_core/Ports.py
+++ b/edg_core/Ports.py
@@ -158,6 +158,11 @@ class Port(BasePort, Generic[PortLinkType]):
       assert isinstance(other_param, type(param))
       param.initializer = other_param.initializer
 
+  def init_from(self: SelfType, other: SelfType):
+    assert self.parent is not None, "may only init_from on an bound port"
+    assert not self._get_initializers([]), "may only init_from an empty model"
+    self._cloned_from(other)
+
   def _bridge(self) -> Optional[PortBridge]:
     """Creates a (unbound) bridge and returns it."""
     if self.bridge_type is None:

--- a/edg_core/Ports.py
+++ b/edg_core/Ports.py
@@ -240,11 +240,6 @@ class Port(BasePort, Generic[PortLinkType]):
     return [(param, path_prefix + [name], param.initializer) for (name, param) in self._parameters.items()
             if param.initializer is not None]
 
-  def _model_update_initializers(self: SelfType, initializers: SelfType) -> None:
-    """INTERNAL API - IN PLACE MODIFICATION.
-    Asserts this is a model type with all initializers, then updates my initializers (in-place) with the input."""
-    ...
-
   def is_connected(self) -> BoolExpr:
     return self._is_connected
 
@@ -328,13 +323,6 @@ class Bundle(Port[PortLinkType], BaseContainerPort, Generic[PortLinkType]):
       self_initializers,
       *[port._get_initializers(path_prefix + [name]) for (name, port) in self._ports.items()]
     ))
-
-  def _model_update_initializers(self: SelfType, initializers: SelfType) -> None:
-    ...
-
-  def model_with_elt_initializers(self: SelfType, initializers: dict[str, Port]) -> SelfType:
-    """Clones model-typed self, except adding initializers to elements from the input dict."""
-    ...
 
   T = TypeVar('T', bound=Port)
   def Port(self, tpe: T, *, desc: Optional[str] = None) -> T:

--- a/electronics_abstract_parts/AbstractAnalogSwitch.py
+++ b/electronics_abstract_parts/AbstractAnalogSwitch.py
@@ -10,14 +10,14 @@ class AnalogSwitch(Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.control = self.Port(DigitalSink())
+    self.control = self.Port(DigitalSink.empty())
 
-    self.com = self.Port(Passive())
-    self.no = self.Port(Passive())
-    self.nc = self.Port(Passive())
+    self.com = self.Port(Passive.empty())
+    self.no = self.Port(Passive.empty())
+    self.nc = self.Port(Passive.empty())
 
     # TODO: this is a different way of modeling parts - parameters in the part itself
     # instead of on the ports (because this doesn't have typed ports)

--- a/electronics_abstract_parts/AbstractConnector.py
+++ b/electronics_abstract_parts/AbstractConnector.py
@@ -7,7 +7,7 @@ class BananaJack(Connector):
   """Base class for a single terminal 4mm banana jack, such as used on test equipment."""
   def __init__(self) -> None:
     super().__init__()
-    self.port = self.Port(Passive())
+    self.port = self.Port(Passive.empty())
 
 
 @abstract_block

--- a/electronics_abstract_parts/AbstractCrystal.py
+++ b/electronics_abstract_parts/AbstractCrystal.py
@@ -11,6 +11,5 @@ class Crystal(DiscreteComponent):
 
     self.frequency = self.ArgParameter(frequency)
 
-    # actual frequency to be fulled in by subclass
-    self.crystal = self.Port(CrystalPort(frequency=RangeExpr()), [InOut])
-    self.gnd = self.Port(Ground(), [Common])
+    self.crystal = self.Port(CrystalPort.empty(), [InOut])  # set by subclass
+    self.gnd = self.Port(Ground.empty(), [Common])

--- a/electronics_abstract_parts/AbstractDevices.py
+++ b/electronics_abstract_parts/AbstractDevices.py
@@ -10,9 +10,8 @@ class Battery(DiscreteApplication):
                capacity: FloatLike = Default(0.0)):
     super().__init__()
 
-    self.pwr = self.Port(VoltageSource(
-      voltage_out=RangeExpr(), current_limits=RangeExpr()))  # set by subclasses
-    self.gnd = self.Port(GroundSource())
+    self.pwr = self.Port(VoltageSource.empty())  # set by subclasses
+    self.gnd = self.Port(GroundSource.empty())
 
     self.voltage = self.ArgParameter(voltage)
     self.capacity = self.ArgParameter(capacity)

--- a/electronics_abstract_parts/AbstractDiodes.py
+++ b/electronics_abstract_parts/AbstractDiodes.py
@@ -15,8 +15,8 @@ class Diode(DiscreteSemiconductor):
                reverse_recovery_time: RangeLike = Default(Range.all())) -> None:
     super().__init__()
 
-    self.anode = self.Port(Passive())
-    self.cathode = self.Port(Passive())
+    self.anode = self.Port(Passive.empty())
+    self.cathode = self.Port(Passive.empty())
 
     self.reverse_voltage = self.ArgParameter(reverse_voltage)
     self.current = self.ArgParameter(current)
@@ -36,8 +36,8 @@ class ZenerDiode(DiscreteSemiconductor):
                forward_voltage_drop: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()
 
-    self.anode = self.Port(Passive())
-    self.cathode = self.Port(Passive())
+    self.anode = self.Port(Passive.empty())
+    self.cathode = self.Port(Passive.empty())
 
     self.zener_voltage = self.ArgParameter(zener_voltage)
     self.forward_voltage_drop = self.ArgParameter(forward_voltage_drop)
@@ -50,8 +50,8 @@ class ProtectionZenerDiode(DiscreteApplication):
   def __init__(self, voltage: RangeLike):
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power, Input])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power, Input])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.voltage = self.ArgParameter(voltage)
 

--- a/electronics_abstract_parts/AbstractFets.py
+++ b/electronics_abstract_parts/AbstractFets.py
@@ -21,9 +21,9 @@ class Fet(DiscreteSemiconductor):
                gate_charge: RangeLike = Default(Range.all()), power: RangeLike = Default(Range.exact(0))) -> None:
     super().__init__()
 
-    self.source = self.Port(Passive())
-    self.drain = self.Port(Passive())
-    self.gate = self.Port(Passive())
+    self.source = self.Port(Passive.empty())
+    self.drain = self.Port(Passive.empty())
+    self.gate = self.Port(Passive.empty())
 
     self.drain_voltage = self.ArgParameter(drain_voltage)
     self.drain_current = self.ArgParameter(drain_current)

--- a/electronics_abstract_parts/AbstractFuse.py
+++ b/electronics_abstract_parts/AbstractFuse.py
@@ -11,12 +11,8 @@ class Fuse(DiscreteComponent, DiscreteApplication):
 
     self.trip_current = self.ArgParameter(trip_current)
 
-    self.pwr_in = self.Port(VoltageSink(current_draw=RangeExpr(),
-                                        voltage_limits=RangeExpr.ALL),
-                            [Input])  # TODO also allow Power tag?
-    self.pwr_out = self.Port(VoltageSource(voltage_out=RangeExpr(),
-                                           current_limits=RangeExpr.ALL),
-                             [Output])
+    self.pwr_in = self.Port(VoltageSink.empty(), [Input])  # TODO also allow Power tag?
+    self.pwr_out = self.Port(VoltageSource.empty(), [Output])
     # TODO: GND port for voltage rating?
 
     self.assign(self.pwr_in.current_draw, self.pwr_out.link().current_drawn)  # TODO dedup w/ bridge?

--- a/electronics_abstract_parts/AbstractFuse.py
+++ b/electronics_abstract_parts/AbstractFuse.py
@@ -10,6 +10,7 @@ class Fuse(DiscreteComponent, DiscreteApplication):
     super().__init__()
 
     self.trip_current = self.ArgParameter(trip_current)
+    self.actual_trip_current = self.Parameter(RangeExpr())
 
     self.pwr_in = self.Port(VoltageSink.empty(), [Input])  # TODO also allow Power tag?
     self.pwr_out = self.Port(VoltageSource.empty(), [Output])

--- a/electronics_abstract_parts/AbstractFuse.py
+++ b/electronics_abstract_parts/AbstractFuse.py
@@ -12,21 +12,21 @@ class Fuse(DiscreteComponent, DiscreteApplication):
     self.trip_current = self.ArgParameter(trip_current)
     self.actual_trip_current = self.Parameter(RangeExpr())
 
-    self.pwr_in = self.Port(VoltageSink.empty(), [Input])  # TODO also allow Power tag?
-    self.pwr_out = self.Port(VoltageSource.empty(), [Output])
-    # TODO: GND port for voltage rating?
+    self.pwr_in = self.Port(VoltageSink.empty(), [Input])
+    self.pwr_out = self.Port(VoltageSource(
+      voltage_out=self.pwr_in.link().voltage,
+      current_limits=(0, self.actual_trip_current.lower())
+    ), [Output])  # TODO: GND port for voltage rating?
+    self.pwr_in.init_from(VoltageSink(
+      voltage_limits=RangeExpr.ALL,
+      current_draw=self.pwr_out.link().current_drawn
+    ))
 
-    self.assign(self.pwr_in.current_draw, self.pwr_out.link().current_drawn)  # TODO dedup w/ bridge?
-    self.assign(self.pwr_out.voltage_out, self.pwr_in.link().voltage)
-
-    self.require(self.trip_current.upper() > self.pwr_out.link().current_drawn.lower(),
-                   "expected current draw exceeds fuse trip rating")
+    self.require(self.actual_trip_current.within(self.trip_current),
+                 "fuse rating not within specified rating")
 
 
 @abstract_block
 class PptcFuse(Fuse):
   """PPTC fuse that models PPTC-specific parameters.
   TODO: what other parameters?"""
-  @init_in_parent
-  def __init__(self, **kwargs) -> None:
-    super().__init__(**kwargs)

--- a/electronics_abstract_parts/AbstractLed.py
+++ b/electronics_abstract_parts/AbstractLed.py
@@ -7,8 +7,8 @@ class Led(DiscreteSemiconductor):
   def __init__(self):
     super().__init__()
 
-    self.a = self.Port(Passive())
-    self.k = self.Port(Passive())
+    self.a = self.Port(Passive.empty())
+    self.k = self.Port(Passive.empty())
 
 
 @abstract_block
@@ -16,7 +16,7 @@ class RgbLedCommonAnode(DiscreteSemiconductor):
   def __init__(self):
     super().__init__()
 
-    self.a = self.Port(Passive())
-    self.k_red = self.Port(Passive())
-    self.k_green = self.Port(Passive())
-    self.k_blue = self.Port(Passive())
+    self.a = self.Port(Passive.empty())
+    self.k_red = self.Port(Passive.empty())
+    self.k_green = self.Port(Passive.empty())
+    self.k_blue = self.Port(Passive.empty())

--- a/electronics_abstract_parts/AbstractOpamp.py
+++ b/electronics_abstract_parts/AbstractOpamp.py
@@ -13,12 +13,12 @@ class Opamp(Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.inp = self.Port(AnalogSink())
-    self.inn = self.Port(AnalogSink())
-    self.out = self.Port(AnalogSource())
+    self.inp = self.Port(AnalogSink.empty())
+    self.inn = self.Port(AnalogSink.empty())
+    self.out = self.Port(AnalogSource.empty())
 
 
 class OpampFollower(AnalogFilter):
@@ -86,8 +86,8 @@ class Amplifier(AnalogFilter, GeneratorBlock):
 
     self.input = self.Export(self.amp.inp, [Input])
     # self.output = self.Export(self.amp.out, [Output])
-    self.output = self.Port(AnalogSource(), [Output])
-    self.reference = self.Port(AnalogSink())
+    self.output = self.Port(AnalogSource.empty(), [Output])
+    self.reference = self.Port(AnalogSink.empty())
 
     self.generator(self.generate_resistors, amplification, impedance, series, tolerance)
 
@@ -172,10 +172,10 @@ class DifferentialAmplifier(AnalogFilter, GeneratorBlock):
     self.pwr = self.Export(self.amp.pwr, [Power])
     self.gnd = self.Export(self.amp.gnd, [Common])
 
-    self.input_positive = self.Port(AnalogSink())
-    self.input_negative = self.Port(AnalogSink())
-    self.output_reference = self.Port(AnalogSink())
-    self.output = self.Port(AnalogSource())
+    self.input_positive = self.Port(AnalogSink.empty())
+    self.input_negative = self.Port(AnalogSink.empty())
+    self.output_reference = self.Port(AnalogSink.empty())
+    self.output = self.Port(AnalogSource.empty())
 
     self.generator(self.generate_resistors, ratio, input_impedance, series, tolerance)
 
@@ -279,9 +279,9 @@ class IntegratorInverting(AnalogFilter, GeneratorBlock):
     self.pwr = self.Export(self.amp.pwr, [Power])
     self.gnd = self.Export(self.amp.gnd, [Common])
 
-    self.input = self.Port(AnalogSink())
-    self.output = self.Port(AnalogSource())
-    self.reference = self.Port(AnalogSink())  # negative reference for the input and output signals
+    self.input = self.Port(AnalogSink.empty())
+    self.output = self.Port(AnalogSource.empty())
+    self.reference = self.Port(AnalogSink.empty())  # negative reference for the input and output signals
 
     self.generator(self.generate_components, factor, capacitance, series, tolerance)
 

--- a/electronics_abstract_parts/AbstractPassives.py
+++ b/electronics_abstract_parts/AbstractPassives.py
@@ -8,8 +8,8 @@ class Resistor(PassiveComponent):
   def __init__(self, resistance: RangeLike, power: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
 
-    self.a = self.Port(Passive())
-    self.b = self.Port(Passive())
+    self.a = self.Port(Passive.empty())
+    self.b = self.Port(Passive.empty())
 
     self.resistance = self.ArgParameter(resistance)
     self.power = self.ArgParameter(power)  # operating power range
@@ -77,8 +77,8 @@ class CurrentSenseResistor(DiscreteApplication):
     self.pwr_in = self.Export(self.res.pwr_in, [Input])
     self.pwr_out = self.Export(self.res.pwr_out, [Output])
 
-    self.sense_in = self.Port(AnalogSource())
-    self.sense_out = self.Port(AnalogSource())
+    self.sense_in = self.Port(AnalogSource.empty())
+    self.sense_out = self.Port(AnalogSource.empty())
 
   def contents(self):
     super().contents()
@@ -108,8 +108,8 @@ class Capacitor(UnpolarizedCapacitor):
   def __init__(self, *args, **kwargs) -> None:
     super().__init__(*args, **kwargs)
 
-    self.pos = self.Port(Passive())
-    self.neg = self.Port(Passive())
+    self.pos = self.Port(Passive.empty())
+    self.neg = self.Port(Passive.empty())
 
 
 class DecouplingCapacitor(DiscreteApplication):
@@ -134,8 +134,8 @@ class Inductor(PassiveComponent):
                frequency: RangeLike = Default(RangeExpr.EMPTY_ZERO)) -> None:
     super().__init__()
 
-    self.a = self.Port(Passive())
-    self.b = self.Port(Passive())
+    self.a = self.Port(Passive.empty())
+    self.b = self.Port(Passive.empty())
 
     self.inductance = self.ArgParameter(inductance)
     self.current = self.ArgParameter(current)  # defined as operating current range, non-directioned

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -13,15 +13,9 @@ class DcDcConverter(PowerConditioner):
 
     self.output_voltage = self.ArgParameter(output_voltage)
 
-    self.pwr_in = self.Port(VoltageSink(
-      voltage_limits=RangeExpr(),
-      current_draw=RangeExpr()
-    ), [Power, Input])
-    self.pwr_out = self.Port(VoltageSource(
-      voltage_out=RangeExpr(),
-      current_limits=RangeExpr()
-    ), [Output])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr_in = self.Port(VoltageSink.empty(), [Power, Input])
+    self.pwr_out = self.Port(VoltageSource.empty(), [Output])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.require(self.pwr_out.voltage_out.within(self.output_voltage),
                  "Output voltage must be within spec")

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -132,10 +132,10 @@ class BuckConverterPowerPath(GeneratorBlock):
                dutycycle_limit: RangeLike = Default((0.1, 0.9))):  # arbitrary
     super().__init__()
 
-    self.pwr_in = self.Port(VoltageSink(), [Power])  # models the input cap only
-    self.pwr_out = self.Port(VoltageSource())  # models the output cap and inductor power source
-    self.switch = self.Port(VoltageSink())  # current draw defined as average
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr_in = self.Port(VoltageSink.empty(), [Power])  # models the input cap only
+    self.pwr_out = self.Port(VoltageSource.empty())  # models the output cap and inductor power source
+    self.switch = self.Port(VoltageSink.empty())  # current draw defined as average
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.output_voltage = output_voltage
     self.current_limits = current_limits
@@ -235,11 +235,11 @@ class BoostConverterPowerPath(GeneratorBlock):
                dutycycle_limit: RangeLike = Default((0.2, 0.85))):  # arbitrary
     super().__init__()
 
-    self.pwr_in = self.Port(VoltageSink(), [Power])  # models input cap and inductor power draw
-    self.pwr_out = self.Port(VoltageSink())  # only used for the output cap
+    self.pwr_in = self.Port(VoltageSink.empty(), [Power])  # models input cap and inductor power draw
+    self.pwr_out = self.Port(VoltageSink.empty())  # only used for the output cap
     # TODO switch is a sink as far as dataflow directionality, but it's a voltage and current source
-    self.switch = self.Port(VoltageSink())  # current draw defined as average
-    self.gnd = self.Port(Ground(), [Common])
+    self.switch = self.Port(VoltageSink.empty())  # current draw defined as average
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.output_voltage = output_voltage
     self.current_limits = current_limits

--- a/electronics_abstract_parts/AbstractSolidStateRelay.py
+++ b/electronics_abstract_parts/AbstractSolidStateRelay.py
@@ -12,11 +12,11 @@ class SolidStateRelay(Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.leda = self.Port(Passive())
-    self.ledk = self.Port(Passive())
+    self.leda = self.Port(Passive.empty())
+    self.ledk = self.Port(Passive.empty())
 
-    self.feta = self.Port(Passive())
-    self.fetb = self.Port(Passive())
+    self.feta = self.Port(Passive.empty())
+    self.fetb = self.Port(Passive.empty())
 
     # TODO: this is a different way of modeling parts - parameters in the part itself
     # instead of on the ports (because this doesn't have typed ports)
@@ -38,12 +38,12 @@ class DigitalAnalogIsolatedSwitch(Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.signal = self.Port(DigitalSink())
-    self.gnd = self.Port(Ground(), [Common])
+    self.signal = self.Port(DigitalSink.empty())
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.apull = self.Port(AnalogSink())
-    self.ain = self.Port(AnalogSink())
-    self.aout = self.Port(AnalogSource())
+    self.apull = self.Port(AnalogSink.empty())
+    self.ain = self.Port(AnalogSink.empty())
+    self.aout = self.Port(AnalogSource.empty())
 
     self.ic = self.Block(SolidStateRelay())
     self.res = self.Block(Resistor(

--- a/electronics_abstract_parts/AbstractSwitch.py
+++ b/electronics_abstract_parts/AbstractSwitch.py
@@ -8,8 +8,8 @@ class Switch(DiscreteComponent):
   def __init__(self, voltage: RangeLike, current: RangeLike = Default(0*Amp(tol=0))) -> None:
     super().__init__()
 
-    self.a = self.Port(Passive())
-    self.b = self.Port(Passive())
+    self.a = self.Port(Passive.empty())
+    self.b = self.Port(Passive.empty())
 
     self.current = self.ArgParameter(current)
     self.voltage = self.ArgParameter(voltage)
@@ -19,13 +19,17 @@ class DigitalSwitch(DiscreteApplication):
   def __init__(self) -> None:
     super().__init__()
 
-    self.gnd = self.Port(Ground(), [Common])
-    self.out = self.Port(DigitalSingleSource.low_from_supply(self.gnd), [Output])
+    self.gnd = self.Port(Ground.empty(), [Common])
+    self.out = self.Port(DigitalSingleSource.empty(), [Output])
 
   def contents(self):
     super().contents()
     self.package = self.Block(Switch(current=self.out.link().current_limits,
                                      voltage=self.out.link().voltage))
 
-    self.connect(self.out, self.package.a.as_digital_single_source())
+    self.connect(self.out, self.package.a.as_digital_single_source(
+      voltage_out=self.gnd.link().voltage,
+      output_thresholds=(self.gnd.link().voltage.upper(), float('inf')),
+      pulldown_capable=False, low_signal_driver=True
+    ))
     self.connect(self.gnd, self.package.b.as_ground())

--- a/electronics_abstract_parts/CanTransceiver.py
+++ b/electronics_abstract_parts/CanTransceiver.py
@@ -8,11 +8,11 @@ class CanTransceiver(IntegratedCircuit, Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])  # for isolated converters, this is the logic side supply
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])  # for isolated converters, this is the logic side supply
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.controller = self.Port(CanTransceiverPort(), [Input])
-    self.can = self.Port(CanDiffPort(), [Output])
+    self.controller = self.Port(CanTransceiverPort.empty(), [Input])
+    self.can = self.Port(CanDiffPort.empty(), [Output])
 
 
 @abstract_block
@@ -20,5 +20,5 @@ class IsolatedCanTransceiver(CanTransceiver):
   def __init__(self) -> None:
     super().__init__()
 
-    self.can_pwr = self.Port(VoltageSink())  # no implicit connect tags for isolated side
-    self.can_gnd = self.Port(Ground())
+    self.can_pwr = self.Port(VoltageSink.empty())  # no implicit connect tags for isolated side
+    self.can_gnd = self.Port(Ground.empty())

--- a/electronics_abstract_parts/DigitalAmplifiers.py
+++ b/electronics_abstract_parts/DigitalAmplifiers.py
@@ -84,7 +84,7 @@ class HalfBridgeNFet(Block):
     self.gate_high = self.Port(DigitalSink.empty())
     self.gate_low = self.Port(DigitalSink.empty())
 
-    self.output = self.Port(DigitalSource.from_supply(self.gnd, self.pwr))  # current limits from supply
+    self.output = self.Port(DigitalSource.empty())  # current limits from supply
 
     self.max_rds = self.ArgParameter(max_rds)
     self.frequency = self.ArgParameter(frequency)

--- a/electronics_abstract_parts/DigitalAmplifiers.py
+++ b/electronics_abstract_parts/DigitalAmplifiers.py
@@ -9,8 +9,8 @@ class HighSideSwitch(Block):
                frequency: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])  # amplifier voltage
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])  # amplifier voltage
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.control = self.Port(DigitalSink(  # logic voltage
       current_draw=(0, 0) * Amp  # TODO model pullup resistor current
@@ -78,11 +78,11 @@ class HalfBridgeNFet(Block):
   @init_in_parent
   def __init__(self, max_rds: FloatLike = Default(1*Ohm), frequency: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()  # TODO MODEL ALL THESE
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.gate_high = self.Port(DigitalSink())
-    self.gate_low = self.Port(DigitalSink())
+    self.gate_high = self.Port(DigitalSink.empty())
+    self.gate_low = self.Port(DigitalSink.empty())
 
     self.output = self.Port(DigitalSource.from_supply(self.gnd, self.pwr))  # current limits from supply
 

--- a/electronics_abstract_parts/I2cPullup.py
+++ b/electronics_abstract_parts/I2cPullup.py
@@ -8,10 +8,8 @@ class I2cPullup(DiscreteApplication):
     super().__init__()
 
     # TODO restrictions on I2C voltage, current draw modeling
-    self.pwr = self.Port(VoltageSink(current_draw=Default(RangeExpr.ZERO),
-                                     voltage_limits=RangeExpr.ALL),
-                         [Power])
-    self.i2c = self.Port(I2cPullupPort(), [InOut])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.i2c = self.Port(I2cPullupPort.empty(), [InOut])
 
 
   def contents(self) -> None:

--- a/electronics_abstract_parts/PassiveFilters.py
+++ b/electronics_abstract_parts/PassiveFilters.py
@@ -15,9 +15,9 @@ class LowPassRc(AnalogFilter, GeneratorBlock):
     self.cutoff_freq = self.ArgParameter(cutoff_freq)
     self.voltage = self.ArgParameter(voltage)
 
-    self.input = self.Port(Passive())
-    self.output = self.Port(Passive())
-    self.gnd = self.Port(Passive())
+    self.input = self.Port(Passive.empty())
+    self.output = self.Port(Passive.empty())
+    self.gnd = self.Port(Passive.empty())
 
     self.generator(self.generate_rc, self.cutoff_freq, self.impedance)
 
@@ -39,8 +39,8 @@ class DigitalLowPassRc(DigitalFilter, Block):
   @init_in_parent
   def __init__(self, impedance: RangeLike, cutoff_freq: RangeLike):
     super().__init__()
-    self.input = self.Port(DigitalSink(), [Input])
-    self.output = self.Port(DigitalSource(), [Output])
+    self.input = self.Port(DigitalSink.empty(), [Input])
+    self.output = self.Port(DigitalSource.empty(), [Output])
 
     self.rc = self.Block(LowPassRc(impedance=impedance, cutoff_freq=cutoff_freq,
                                    voltage=self.input.link().voltage))
@@ -67,8 +67,8 @@ class LowPassRcDac(AnalogFilter, Block):
   @init_in_parent
   def __init__(self, impedance: RangeLike, cutoff_freq: RangeLike):
     super().__init__()
-    self.input = self.Port(DigitalSink(), [Input])
-    self.output = self.Port(AnalogSource(), [Output])
+    self.input = self.Port(DigitalSink.empty(), [Input])
+    self.output = self.Port(AnalogSource.empty(), [Output])
 
     self.rc = self.Block(LowPassRc(impedance=impedance, cutoff_freq=cutoff_freq,
                                    voltage=self.input.link().voltage))

--- a/electronics_abstract_parts/ResistiveDivider.py
+++ b/electronics_abstract_parts/ResistiveDivider.py
@@ -70,9 +70,9 @@ class ResistiveDivider(DiscreteApplication, GeneratorBlock):
     self.actual_impedance = self.Parameter(RangeExpr())
     self.actual_series_impedance = self.Parameter(RangeExpr())
 
-    self.top = self.Port(Passive())
-    self.center = self.Port(Passive())
-    self.bottom = self.Port(Passive())
+    self.top = self.Port(Passive.empty())
+    self.center = self.Port(Passive.empty())
+    self.bottom = self.Port(Passive.empty())
 
     self.generator(self.generate_divider, self.ratio, self.impedance, series, tolerance)
 

--- a/electronics_abstract_parts/test_opamp.py
+++ b/electronics_abstract_parts/test_opamp.py
@@ -25,7 +25,12 @@ class VoltageDummy(Block):
 
 
 class TestOpamp(Opamp):
-  pass
+  def contents(self):
+    self.pwr.init_from(VoltageSink())
+    self.gnd.init_from(Ground())
+    self.inp.init_from(AnalogSink())
+    self.inn.init_from(AnalogSink())
+    self.out.init_from(AnalogSource())
 
 
 class TestResistor(Resistor):

--- a/electronics_lib/Batteries.py
+++ b/electronics_lib/Batteries.py
@@ -5,13 +5,15 @@ class Cr2032(Battery, FootprintBlock):
   def __init__(self, voltage: RangeLike = Default((2.0, 3.0)*Volt), *args,
                actual_voltage: RangeLike = Default((2.0, 3.0)*Volt), **kwargs):
     super().__init__(voltage, *args, **kwargs)
-    self.assign(self.pwr.voltage_out, actual_voltage)
+    self.pwr.init_from(VoltageSource(
+      voltage_out=actual_voltage,  # arbitrary from https://www.mouser.com/catalog/additional/Adafruit_3262.pdf
+      current_limits=(0, 10)*mAmp,
+    ))
+    self.gnd.init_from(GroundSource())
 
   def contents(self):
     super().contents()
 
-    # TODO can this be assigned self.pwr == VoltageSource(...) directly?
-    self.assign(self.pwr.current_limits, (0, 10)*mAmp)  # arbitrary from https://www.mouser.com/catalog/additional/Adafruit_3262.pdf
     self.assign(self.actual_capacity, (210, 210)*mAmp)  # TODO bounds of a few CR2032 cells; should be A*h
 
     self.footprint(
@@ -29,12 +31,15 @@ class Li18650(Battery, FootprintBlock):
   def __init__(self, voltage: RangeLike = Default((2.5, 4.2)*Volt), *args,
                actual_voltage: RangeLike = Default((2.5, 4.2)*Volt), **kwargs):
     super().__init__(voltage, *args, **kwargs)
-    self.assign(self.pwr.voltage_out, actual_voltage)
+    self.pwr.init_from(VoltageSource(
+      voltage_out=actual_voltage,  # arbitrary from https://www.mouser.com/catalog/additional/Adafruit_3262.pdf
+      current_limits=(0, 2)*Amp,  # arbitrary assuming low capacity, 1 C discharge
+    ))
+    self.gnd.init_from(GroundSource())
 
   def contents(self):
     super().contents()
 
-    self.assign(self.pwr.current_limits, (0, 2)*Amp)  # arbitrary assuming low capacity, 1 C discharge
     self.assign(self.actual_capacity, (2, 3.6)*Amp)  # TODO should be A*h
 
     self.footprint(
@@ -52,12 +57,15 @@ class AABattery(Battery, FootprintBlock):
   def __init__(self, voltage: RangeLike = Default((1.3, 1.7)*Volt), *args,
                actual_voltage: RangeLike = Default((1.3, 1.7)*Volt), **kwargs):
     super().__init__(voltage, *args, **kwargs)
-    self.assign(self.pwr.voltage_out, actual_voltage)
+    self.pwr.init_from(VoltageSource(
+      voltage_out=actual_voltage,  # arbitrary from https://www.mouser.com/catalog/additional/Adafruit_3262.pdf
+      current_limits=(0, 1)*Amp,
+    ))
+    self.gnd.init_from(GroundSource())
 
   def contents(self):
     super().contents()
 
-    self.assign(self.pwr.current_limits, (0, 1)*Amp)
     self.assign(self.actual_capacity, (2, 3)*Amp)  # TODO should be A*h
 
     self.footprint(

--- a/electronics_lib/BatteryProtector_S8200A.py
+++ b/electronics_lib/BatteryProtector_S8200A.py
@@ -39,9 +39,9 @@ class BatteryProtector_S8200A(Block):
 
     self.ic = self.Block(BatteryProtector_S8200A_Device())
 
-    self.pwr_out = self.Port(VoltageSource())
-    self.gnd_out = self.Port(GroundSource())
-    self.pwr_in = self.Port(VoltageSink())
+    self.pwr_out = self.Port(VoltageSource.empty())
+    self.gnd_out = self.Port(GroundSource.empty())
+    self.pwr_in = self.Port(VoltageSink.empty())
     self.gnd_in = self.Export(self.ic.vss)
 
     self.do_fet = self.Block(NFet(

--- a/electronics_lib/CalSolBlocks.py
+++ b/electronics_lib/CalSolBlocks.py
@@ -52,8 +52,8 @@ class CalSolCanBlock(CalSolSubcircuit):
 
 
 class CanFuse(PptcFuse, FootprintBlock):
-  def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
+  def __init__(self, trip_current=(100, 200)*mAmp):
+    super().__init__(trip_current=trip_current)
     self.assign(self.actual_trip_current, 150*mAmp(tol=0))
 
   def contents(self):

--- a/electronics_lib/CalSolBlocks.py
+++ b/electronics_lib/CalSolBlocks.py
@@ -12,14 +12,14 @@ class CalSolCanBlock(CalSolSubcircuit):
   def __init__(self) -> None:
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.can_pwr = self.Port(VoltageSource(), optional=True)
-    self.can_gnd = self.Port(GroundSource(), optional=True)
+    self.can_pwr = self.Port(VoltageSource.empty(), optional=True)
+    self.can_gnd = self.Port(GroundSource.empty(), optional=True)
 
-    self.controller = self.Port(CanTransceiverPort(), [Input])
-    self.can = self.Port(CanDiffPort(), optional=True)
+    self.controller = self.Port(CanTransceiverPort.empty(), [Input])
+    self.can = self.Port(CanDiffPort.empty(), optional=True)
 
   def contents(self):
     super().contents()
@@ -52,8 +52,9 @@ class CalSolCanBlock(CalSolSubcircuit):
 
 
 class CanFuse(PptcFuse, FootprintBlock):
-  def __init__(self):
-    super().__init__(trip_current=150*mAmp(tol=0))
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.assign(self.actual_trip_current, 150*mAmp(tol=0))
 
   def contents(self):
     super().contents()

--- a/electronics_lib/Crystals.py
+++ b/electronics_lib/Crystals.py
@@ -59,10 +59,9 @@ class SmdCrystal(Crystal, FootprintBlock, GeneratorBlock):
       row[CrystalTable.FREQUENCY] in frequency
     )).first(f"no crystal matching f={frequency} Hz")
 
-    self.assign(self.actual_capacitance, part[CrystalTable.CAPACITANCE])
-
     self.crystal.init_from(CrystalPort(part[CrystalTable.FREQUENCY]))
     self.gnd.init_from(Ground())
+    self.assign(self.actual_capacitance, part[CrystalTable.CAPACITANCE])
 
     self.footprint(
       'X', 'Oscillator:Oscillator_SMD_Abracon_ASE-4Pin_3.2x2.5mm',

--- a/electronics_lib/Crystals.py
+++ b/electronics_lib/Crystals.py
@@ -60,7 +60,9 @@ class SmdCrystal(Crystal, FootprintBlock, GeneratorBlock):
     )).first(f"no crystal matching f={frequency} Hz")
 
     self.assign(self.actual_capacitance, part[CrystalTable.CAPACITANCE])
-    self.assign(self.crystal.frequency, part[CrystalTable.FREQUENCY])
+
+    self.crystal.init_from(CrystalPort(part[CrystalTable.FREQUENCY]))
+    self.gnd.init_from(Ground())
 
     self.footprint(
       'X', 'Oscillator:Oscillator_SMD_Abracon_ASE-4Pin_3.2x2.5mm',

--- a/electronics_lib/Lcd_Qt096t_if09.py
+++ b/electronics_lib/Lcd_Qt096t_if09.py
@@ -62,18 +62,18 @@ class Qt096t_if09(Lcd, Block):
     self.reset = self.Export(self.device.reset)
     self.rs = self.Export(self.device.rs)
     self.cs = self.Export(self.device.cs)
-    self.spi = self.Port(SpiSlave())
-    self.led = self.Port(DigitalSink(
-      # no voltage limits, since the resistor is autogen'd
-      input_thresholds=(3, 3),  # TODO more accurate model
-      current_draw=(16, 20) * mAmp  # TODO user-configurable?
-    ))
+    self.spi = self.Port(SpiSlave(DigitalBidir.empty()))
+    self.led = self.Port(DigitalSink().empty())
 
   def contents(self):
     super().contents()
 
     self.led_res = self.Block(Resistor(resistance=100*Ohm(tol=0.05)))  # TODO dynamic sizing, power
-    self.connect(self.led_res.a.as_digital_sink(), self.led)
+    self.connect(self.led_res.a.as_digital_sink(
+      # no voltage limits, since the resistor is autogen'd
+      input_thresholds=(3, 3),  # TODO more accurate model
+      current_draw=(16, 20) * mAmp  # TODO user-configurable?
+    ), self.led)
     self.connect(self.led_res.b, self.device.leda)
     self.connect(self.spi.sck, self.device.scl)
     self.connect(self.spi.mosi, self.device.sda)

--- a/electronics_lib/Leds.py
+++ b/electronics_lib/Leds.py
@@ -42,8 +42,8 @@ class IndicatorLed(Light):
 
     self.target_current_draw = self.Parameter(RangeExpr(current_draw))
 
-    self.signal = self.Port(DigitalSink(), [InOut])
-    self.gnd = self.Port(Ground(), [Common])
+    self.signal = self.Port(DigitalSink.empty(), [InOut])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.require(self.signal.current_draw.within((0, self.target_current_draw.upper())))
 
@@ -72,8 +72,8 @@ class VoltageIndicatorLed(Light):
 
     self.target_current_draw = self.Parameter(RangeExpr(current_draw))
 
-    self.signal = self.Port(VoltageSink(), [Power, InOut])
-    self.gnd = self.Port(Ground(), [Common])
+    self.signal = self.Port(VoltageSink.empty(), [Power, InOut])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.require(self.signal.current_draw.within(current_draw))
 
@@ -129,10 +129,10 @@ class IndicatorSinkRgbLed(Light):
     # TODO: support brightness
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.red = self.Port(DigitalSink())
-    self.green = self.Port(DigitalSink())
-    self.blue = self.Port(DigitalSink())
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.red = self.Port(DigitalSink.empty())
+    self.green = self.Port(DigitalSink.empty())
+    self.blue = self.Port(DigitalSink.empty())
 
     self.target_current_draw = self.Parameter(RangeExpr(current_draw))
     self.require(self.red.current_draw.within((-1 * self.target_current_draw.upper(), 0)))

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -329,7 +329,7 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
 
     self.pwr = self.Export(self.ic.vdd, [Power])
     self.gnd = self.Export(self.ic.vss, [Common])
-    self.swd = self.Port(SwdTargetPort())  # TODO
+    self.swd = self.Port(SwdTargetPort(DigitalBidir.empty()))
 
     self.xtal = self.Export(self.ic.xtal, optional=True)
     self.xtal_rtc = self.Export(self.ic.xtal_rtc, optional=True)
@@ -338,37 +338,37 @@ class Lpc1549Base(Microcontroller, AssignablePinBlock):  # TODO refactor with _D
     # TODO model current flows from digital ports
     self.digital = ElementDict[DigitalBidir]()
     for i in range(20):
-      self.digital[i] = self.Port(DigitalBidir(), optional=True)
+      self.digital[i] = self.Port(DigitalBidir.empty(), optional=True)
       self._add_assignable_io(self.digital[i])
 
     self.adc = ElementDict[AnalogSink]()
     for i in range(10):
-      self.adc[i] = self.Port(AnalogSink(), optional=True)
+      self.adc[i] = self.Port(AnalogSink.empty(), optional=True)
       self._add_assignable_io(self.adc[i])
 
     self.dac = ElementDict[AnalogSource]()
     for i in range(1):
-      self.dac[i] = self.Port(AnalogSource(), optional=True)
+      self.dac[i] = self.Port(AnalogSource.empty(), optional=True)
       self._add_assignable_io(self.dac[i])
 
     self.uart = ElementDict[UartPort]()
     for i in range(3):
-      self.uart[i] = self.Port(UartPort(), optional=True)
+      self.uart[i] = self.Port(UartPort.empty(), optional=True)
       self._add_assignable_io(self.uart[i])
 
     self.spi = ElementDict[SpiMaster]()
     for i in range(2):
-      self.spi[i] = self.Port(SpiMaster(), optional=True)
+      self.spi[i] = self.Port(SpiMaster.empty(), optional=True)
       self._add_assignable_io(self.spi[i])
 
-    self.can_0 = self.Port(CanControllerPort(), optional=True)
+    self.can_0 = self.Port(CanControllerPort.empty(), optional=True)
     self._add_assignable_io(self.can_0)
 
-    self.i2c_0 = self.Port(I2cMaster(), optional=True)
+    self.i2c_0 = self.Port(I2cMaster.empty(), optional=True)
     self.connect(self.i2c_0, self.ic.i2c_0)
     # self._add_assignable_io(self.i2c_0)  # TODO conflicts with pin assign
 
-    self.usb_0 = self.Port(UsbDevicePort(), optional=True)
+    self.usb_0 = self.Port(UsbDevicePort.empty(), optional=True)
     self.connect(self.usb_0, self.ic.usb_0)
     # self._add_assignable_io(self.usb_0)  # TODO conflicts with pin assign
 

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -138,8 +138,8 @@ class Stm32f103_48(Microcontroller, AssignablePinBlock, GeneratorBlock):
     super().__init__()
     self.ic = self.Block(Stm32f103_48_Device())
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
     self.swd = self.Export(self.ic.swd)
     # self.rst = self.Export(self.ic.nrst)  # TODO separate from SWD
 
@@ -148,24 +148,24 @@ class Stm32f103_48(Microcontroller, AssignablePinBlock, GeneratorBlock):
 
     self.digital = ElementDict[DigitalBidir]()
     for i in range(len(self.ic.io_pins)):
-      self.digital[i] = self.Port(DigitalBidir(), optional=True)
+      self.digital[i] = self.Port(DigitalBidir.empty(), optional=True)
       self._add_assignable_io(self.digital[i])
 
     self.adc = ElementDict[AnalogSink]()
     for i in range(10):
-      self.adc[i] = self.Port(AnalogSink(), optional=True)
+      self.adc[i] = self.Port(AnalogSink.empty(), optional=True)
       self._add_assignable_io(self.adc[i])
 
-    self.uart_0 = self.Port(UartPort(), optional=True)
+    self.uart_0 = self.Port(UartPort.empty(), optional=True)
     self._add_assignable_io(self.uart_0)
 
-    self.spi_0 = self.Port(SpiMaster(), optional=True)
+    self.spi_0 = self.Port(SpiMaster.empty(), optional=True)
     self._add_assignable_io(self.spi_0)
 
-    self.can_0 = self.Port(CanControllerPort(), optional=True)
+    self.can_0 = self.Port(CanControllerPort.empty(), optional=True)
     self._add_assignable_io(self.can_0)
 
-    self.usb_0 = self.Port(UsbDevicePort(), optional=True)
+    self.usb_0 = self.Port(UsbDevicePort.empty(), optional=True)
     # self._add_assignable_io(self.usb_0)  # TODO incompatible with builtin USB circuit
 
     self.generator(self.pin_assign, self.pin_assigns,

--- a/electronics_lib/Oled_Nhd_312_25664uc.py
+++ b/electronics_lib/Oled_Nhd_312_25664uc.py
@@ -71,7 +71,7 @@ class Nhd_312_25664uc(Oled, Block):
     self.reset = self.Export(self.device.nres)
     self.dc = self.Export(self.device.dc)
     self.cs = self.Export(self.device.ncs)
-    self.spi = self.Port(SpiSlave())
+    self.spi = self.Port(SpiSlave(DigitalBidir.empty()))
 
   def contents(self):
     super().contents()

--- a/electronics_lib/PowerConditioning.py
+++ b/electronics_lib/PowerConditioning.py
@@ -35,13 +35,13 @@ class BufferedSupply(PowerConditioner):
     self.sense_resistance = self.ArgParameter(sense_resistance)
     self.voltage_drop = self.ArgParameter(voltage_drop)
 
-    self.pwr = self.Port(VoltageSink(), [Power, Input])
-    self.pwr_out = self.Port(VoltageSource(), [Output])
+    self.pwr = self.Port(VoltageSink.empty(), [Power, Input])
+    self.pwr_out = self.Port(VoltageSource.empty(), [Output])
     self.require(self.pwr.current_draw.within(self.pwr_out.link().current_drawn +
                                               (0, self.charging_current.upper()) +
                                               (0, 0.05)))  # TODO nonhacky bounds on opamp/sense resistor current draw
-    self.sc_out = self.Port(VoltageSource(), optional=True)
-    self.gnd = self.Port(Ground(), [Common])
+    self.sc_out = self.Port(VoltageSource.empty(), optional=True)
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     max_in_voltage = self.pwr.link().voltage.upper()
     max_charge_current = self.charging_current.upper()
@@ -113,9 +113,9 @@ class SingleDiodePowerMerge(PowerConditioner, Block):
   def __init__(self, voltage_drop: RangeLike, reverse_recovery_time: RangeLike = Default((0, float('inf')))) -> None:
     super().__init__()
 
-    self.pwr_in = self.Port(VoltageSink())  # high-priority source
-    self.pwr_in_diode = self.Port(VoltageSink())  # low-priority source
-    self.pwr_out = self.Port(VoltageSource())
+    self.pwr_in = self.Port(VoltageSink.empty())  # high-priority source
+    self.pwr_in_diode = self.Port(VoltageSink.empty())  # low-priority source
+    self.pwr_out = self.Port(VoltageSource.empty())
 
     self.diode = self.Block(Diode(
       reverse_voltage=(0, self.pwr_in.link().voltage.upper() - self.pwr_in_diode.link().voltage.lower()),
@@ -148,9 +148,9 @@ class DiodePowerMerge(PowerConditioner, Block):
   def __init__(self, voltage_drop: RangeLike, reverse_recovery_time: RangeLike = Default((0, float('inf')))) -> None:
     super().__init__()
 
-    self.pwr_in1 = self.Port(VoltageSink())
-    self.pwr_in2 = self.Port(VoltageSink())
-    self.pwr_out = self.Port(VoltageSource())
+    self.pwr_in1 = self.Port(VoltageSink.empty())
+    self.pwr_in2 = self.Port(VoltageSink.empty())
+    self.pwr_out = self.Port(VoltageSource.empty())
 
     output_lower = self.pwr_in1.link().voltage.lower().min(self.pwr_in2.link().voltage.lower()) - RangeExpr._to_expr_type(voltage_drop).upper()
     self.diode1 = self.Block(Diode(

--- a/electronics_lib/Rtc_Pcf2129.py
+++ b/electronics_lib/Rtc_Pcf2129.py
@@ -66,7 +66,7 @@ class Pcf2129(RealtimeClock, Block):
     super().__init__()
 
     self.ic = self.Block(Pcf2129_Device())
-    self.pwr = self.Port(VoltageSink(), [Power])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
     self.pwr_bat = self.Export(self.ic.pwr_bat)
     self.gnd = self.Export(self.ic.gnd, [Common])
 

--- a/electronics_lib/Speakers.py
+++ b/electronics_lib/Speakers.py
@@ -51,12 +51,8 @@ class Lm4871(IntegratedCircuit):
     self.pwr = self.Export(self.ic.pwr, [Power])
     self.gnd = self.Export(self.ic.gnd, [Common])
 
-    self.sig = self.Port(AnalogSink(  # TODO these aren't actually documented
-      # voltage_limits= ,
-      # current_draw=(0, 0) * Amp,
-      # impedance=,
-    ), [Input])
-    self.spk = self.Port(SpeakerDriverPort(), [Output])
+    self.sig = self.Port(AnalogSink.empty(), [Input])
+    self.spk = self.Port(SpeakerDriverPort(AnalogSource.empty()), [Output])
 
 
   def contents(self):
@@ -99,7 +95,7 @@ class Speaker(DiscreteApplication, FootprintBlock):
     super().__init__()
 
     self.input = self.Port(SpeakerPort(
-      impedance=8*Ohm(tol=0)
+      AnalogSink(impedance=8*Ohm(tol=0))
     ), [Input])
 
   def contents(self):

--- a/electronics_lib/UsbPorts.py
+++ b/electronics_lib/UsbPorts.py
@@ -101,9 +101,13 @@ class UsbMicroBReceptacle(UsbDeviceConnector, FootprintBlock):
 
   def contents(self):
     super().contents()
-    self.assign(self.pwr.voltage_out, self.USB2_VOLTAGE_RANGE)
-    self.assign(self.pwr.current_limits, self.USB2_CURRENT_LIMITS)
-    # TODO set GND and USB port initializers
+    self.pwr.init_from(VoltageSource(
+      voltage_out=self.USB2_VOLTAGE_RANGE,
+      current_limits=self.USB2_CURRENT_LIMITS
+    ))
+    self.gnd.init_from(Ground())
+    self.usb.init_from(UsbHostPort())
+
     self.footprint(
       'J', 'Connector_USB:USB_Micro-B_Molex-105017-0001',
       {

--- a/electronics_lib/UsbPorts.py
+++ b/electronics_lib/UsbPorts.py
@@ -89,13 +89,10 @@ class UsbDeviceConnector(UsbConnector):
   """Abstract base class for a USB 2.0 device-side port connector"""
   def __init__(self) -> None:
     super().__init__()
-    self.pwr = self.Port(VoltageSource(
-      voltage_out=self.USB2_VOLTAGE_RANGE,
-      current_limits=self.USB2_CURRENT_LIMITS
-    ), optional=True)
-    self.gnd = self.Port(GroundSource())
+    self.pwr = self.Port(VoltageSource.empty(), optional=True)
+    self.gnd = self.Port(GroundSource.empty())
 
-    self.usb = self.Port(UsbHostPort(), optional=True)
+    self.usb = self.Port(UsbHostPort.empty(), optional=True)
 
 
 class UsbMicroBReceptacle(UsbDeviceConnector, FootprintBlock):
@@ -104,6 +101,9 @@ class UsbMicroBReceptacle(UsbDeviceConnector, FootprintBlock):
 
   def contents(self):
     super().contents()
+    self.assign(self.pwr.voltage_out, self.USB2_VOLTAGE_RANGE)
+    self.assign(self.pwr.current_limits, self.USB2_CURRENT_LIMITS)
+    # TODO set GND and USB port initializers
     self.footprint(
       'J', 'Connector_USB:USB_Micro-B_Molex-105017-0001',
       {
@@ -144,8 +144,8 @@ class UsbCcPulldownResistor(Block):
   without needing a USB PD IC."""
   def __init__(self) -> None:
     super().__init__()
-    self.cc = self.Port(UsbCcPort(), [Input])
-    self.gnd = self.Port(Ground(), [Common])
+    self.cc = self.Port(UsbCcPort.empty(), [Input])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
   def contents(self) -> None:
     super().contents()

--- a/electronics_lib/UsbPorts.py
+++ b/electronics_lib/UsbPorts.py
@@ -105,7 +105,7 @@ class UsbMicroBReceptacle(UsbDeviceConnector, FootprintBlock):
       voltage_out=self.USB2_VOLTAGE_RANGE,
       current_limits=self.USB2_CURRENT_LIMITS
     ))
-    self.gnd.init_from(Ground())
+    self.gnd.init_from(GroundSource())
     self.usb.init_from(UsbHostPort())
 
     self.footprint(

--- a/electronics_model/AnalogPort.py
+++ b/electronics_model/AnalogPort.py
@@ -94,13 +94,6 @@ class AnalogSourceBridge(CircuitPortBridge):  # basic passthrough port, sources 
 
 
 class AnalogSink(AnalogBase):
-  @staticmethod
-  def empty() -> AnalogSink:
-    """Returns a new port with no parameters defined (instead of unmodeled defaults),
- such as if the port is to be exported, including as part of a bundle"""
-    return AnalogSink(voltage_limits=RangeExpr(), current_draw=RangeExpr(),
-                      impedance=RangeExpr())
-
   def __init__(self, voltage_limits: RangeLike = Default(RangeExpr.ALL),
                current_draw: RangeLike = Default(RangeExpr.ZERO),
                impedance: RangeLike = Default(RangeExpr.INF)) -> None:
@@ -114,13 +107,6 @@ class AnalogSink(AnalogBase):
 
 
 class AnalogSource(AnalogBase):
-  @staticmethod
-  def empty() -> AnalogSource:
-    """Returns a new port with no parameters defined (instead of unmodeled defaults),
-  such as if the port is to be exported, including as part of a bundle"""
-    return AnalogSource(voltage_out=RangeExpr(), current_limits=RangeExpr(),
-                        impedance=RangeExpr())
-
   def __init__(self, voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),
                current_limits: RangeLike = Default(RangeExpr.ALL),
                impedance: RangeLike = Default(RangeExpr.ZERO)) -> None:

--- a/electronics_model/CrystalPort.py
+++ b/electronics_model/CrystalPort.py
@@ -1,8 +1,5 @@
-from typing import *
-
 from edg_core import *
 from .PassivePort import Passive
-from .VoltagePorts import VoltageSink, VoltageSource
 
 
 class CrystalLink(Link):

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -273,15 +273,6 @@ class DigitalBidir(DigitalBase, NotConnectablePort):
       pullup_capable=pullup_capable, pulldown_capable=pulldown_capable
     )
 
-  @staticmethod
-  def empty() -> DigitalBidir:
-    """Returns a new port with no parameters defined (instead of unmodeled defaults),
-     such as if the port is to be exported, including as part of a bundle"""
-    return DigitalBidir(voltage_limits=RangeExpr(), current_draw=RangeExpr(),
-                        voltage_out=RangeExpr(), current_limits=RangeExpr(),
-                        input_thresholds=RangeExpr(), output_thresholds=RangeExpr(),
-                        pullup_capable=BoolExpr(), pulldown_capable=BoolExpr())
-
   def __init__(self, *, voltage_limits: RangeLike = Default(RangeExpr.ALL),
                current_draw: RangeLike = Default(RangeExpr.ZERO),
                voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),

--- a/electronics_model/Ground.py
+++ b/electronics_model/Ground.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from edg_core import *
+from .Units import Volt, Amp
+from .VoltagePorts import VoltageSink, VoltageSource
+
+
+class GroundWrapper:  # a wrapper around VoltageSink to have it behave as Ground
+  def __call__(self, current_draw: RangeLike = RangeExpr.ZERO * Amp) -> VoltageSink:
+    return VoltageSink(voltage_limits=RangeExpr.ZERO * Volt, current_draw=current_draw)
+
+  def empty(self) -> VoltageSink:
+    return VoltageSink.empty()
+
+
+class GroundSourceWrapper:
+  def __call__(self) -> VoltageSource:
+    return VoltageSource(voltage_out=RangeExpr.ZERO * Volt, current_limits=RangeExpr.ZERO * Amp)
+
+  def empty(self) -> VoltageSource:
+    return VoltageSource.empty()
+
+
+# type checker doesn't recognize it if we use a @staticmethod __call__ and have this directly be Ground
+# so it's explicitly instantiated
+Ground = GroundWrapper()
+GroundSource = GroundSourceWrapper()
+
+
+# Standard port tags for implicit connection scopes / auto-connecting power supplies
+Common = PortTag(VoltageSink)  # Common ground (0v) port

--- a/electronics_model/SpeakerPort.py
+++ b/electronics_model/SpeakerPort.py
@@ -18,21 +18,22 @@ class SpeakerLink(Link):
 
 
 class SpeakerDriverPort(Bundle[SpeakerLink]):
-  def __init__(self,
-               voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),  # TODO dedup w/ AnalogSource?
-               current_limits: RangeLike = Default(RangeExpr.ALL),
-               impedance: RangeLike = Default(RangeExpr.ZERO)) -> None:
+  def __init__(self, model: Optional[AnalogSource] = None) -> None:
     super().__init__()
     self.link_type = SpeakerLink
 
-    self.a = self.Port(AnalogSource(voltage_out=voltage_out, current_limits=current_limits, impedance=impedance))
-    self.b = self.Port(AnalogSource(voltage_out=voltage_out, current_limits=current_limits, impedance=impedance))
+    if model is None:
+      model = AnalogSource()  # ideal by default
+    self.a = self.Port(model)
+    self.b = self.Port(model)
 
 
 class SpeakerPort(Bundle[SpeakerLink]):
-  def __init__(self, impedance: RangeLike = Default(RangeExpr.INF)) -> None:
+  def __init__(self, model: Optional[AnalogSink] = None) -> None:
     super().__init__()
     self.link_type = SpeakerLink
 
-    self.a = self.Port(AnalogSink(impedance=impedance))  # TODO how to model max power?
-    self.b = self.Port(AnalogSink(impedance=impedance))
+    if model is None:
+      model = AnalogSink()  # ideal by default
+    self.a = self.Port(model)  # TODO how to model max power?
+    self.b = self.Port(model)

--- a/electronics_model/VoltagePorts.py
+++ b/electronics_model/VoltagePorts.py
@@ -96,16 +96,14 @@ class VoltageBase(CircuitPort[VoltageLink]):
 
 
 class VoltageSink(VoltageBase):
-  def __init__(self, model: Optional[VoltageSink] = None,
-               voltage_limits: RangeLike = Default(RangeExpr.ALL),
+  @staticmethod
+  def empty():
+    return VoltageSink(voltage_limits=RangeExpr(), current_draw=RangeExpr())
+
+  def __init__(self, voltage_limits: RangeLike = Default(RangeExpr.ALL),
                current_draw: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
     self.bridge_type = VoltageSinkBridge
-
-    if model is not None:
-      # TODO check that both model and individual parameters aren't overdefined
-      voltage_limits = model.voltage_limits
-      current_draw = model.current_draw
 
     self.voltage_limits: RangeExpr = self.Parameter(RangeExpr(voltage_limits))
     self.current_draw: RangeExpr = self.Parameter(RangeExpr(current_draw))
@@ -150,17 +148,15 @@ class VoltageSinkAdapterAnalogSource(CircuitPortAdapter['AnalogSource']):
 
 
 class VoltageSource(VoltageBase):
-  def __init__(self, model: Optional[VoltageSource] = None,
-               voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),
+  @staticmethod
+  def empty():
+    return VoltageSource(voltage_out=RangeExpr(), current_limits=RangeExpr())
+
+  def __init__(self, voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),
                current_limits: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()
     self.bridge_type = VoltageSourceBridge
     self.adapter_types = [VoltageSinkAdapterDigitalSource, VoltageSinkAdapterAnalogSource]
-
-    if model is not None:
-      # TODO check that both model and individual parameters aren't overdefined
-      voltage_out = model.voltage_out
-      current_limits = model.current_limits
 
     self.voltage_out: RangeExpr = self.Parameter(RangeExpr(voltage_out))
     self.current_limits: RangeExpr = self.Parameter(RangeExpr(current_limits))
@@ -172,16 +168,8 @@ class VoltageSource(VoltageBase):
     return self._convert(VoltageSinkAdapterAnalogSource())
 
 
-def Ground(current_draw: RangeLike = RangeExpr.ZERO * Amp) -> VoltageSink:
-  return VoltageSink(voltage_limits=RangeExpr.ZERO * Volt, current_draw=current_draw)
-
-def GroundSource() -> VoltageSource:
-  return VoltageSource(voltage_out=RangeExpr.ZERO * Volt, current_limits=RangeExpr.ZERO * Amp)
-
-# Standard port tags for implicit connection scopes / auto-connecting power supplies
-Common = PortTag(VoltageSink)  # Common ground (0v) port
-
 Power = PortTag(VoltageSink)  # General positive voltage port, should only be mutually exclusive with the below
+
 
 # Note: in the current model, no explicit "power tag" is equivalent to digital / noisy supply
 # TODO bring these back, on an optional basis

--- a/electronics_model/VoltagePorts.py
+++ b/electronics_model/VoltagePorts.py
@@ -96,10 +96,6 @@ class VoltageBase(CircuitPort[VoltageLink]):
 
 
 class VoltageSink(VoltageBase):
-  @staticmethod
-  def empty():
-    return VoltageSink(voltage_limits=RangeExpr(), current_draw=RangeExpr())
-
   def __init__(self, voltage_limits: RangeLike = Default(RangeExpr.ALL),
                current_draw: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
@@ -148,10 +144,6 @@ class VoltageSinkAdapterAnalogSource(CircuitPortAdapter['AnalogSource']):
 
 
 class VoltageSource(VoltageBase):
-  @staticmethod
-  def empty():
-    return VoltageSource(voltage_out=RangeExpr(), current_limits=RangeExpr())
-
   def __init__(self, voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),
                current_limits: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()

--- a/electronics_model/__init__.py
+++ b/electronics_model/__init__.py
@@ -10,8 +10,8 @@ from .Units import UnitUtils
 
 # Need to export link and bridge types for library auto-detection
 from .PassivePort import Passive
-from .VoltagePorts import VoltageSource, VoltageSink, GroundSource, Ground, Common
-from .VoltagePorts import Power, Ground
+from .VoltagePorts import VoltageSource, VoltageSink, Power
+from .Ground import Ground, GroundSource, Common
 from .DigitalPorts import DigitalSource, DigitalSink, DigitalBidir, DigitalSingleSource
 from .AnalogPort import AnalogSource, AnalogSink
 from .UartPort import UartPort

--- a/electronics_model/test_netlist.py
+++ b/electronics_model/test_netlist.py
@@ -107,8 +107,8 @@ class TestFakeSinkHierarchy(Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.pos = self.Port(VoltageSink())
-    self.neg = self.Port(VoltageSink())
+    self.pos = self.Port(VoltageSink.empty())
+    self.neg = self.Port(VoltageSink.empty())
 
   def contents(self) -> None:
     super().contents()
@@ -134,8 +134,8 @@ class TestFakeDualSinkHierarchy(Block):
   def __init__(self) -> None:
     super().__init__()
 
-    self.pos = self.Port(VoltageSink())
-    self.neg = self.Port(VoltageSink())
+    self.pos = self.Port(VoltageSink.empty())
+    self.neg = self.Port(VoltageSink.empty())
 
   def contents(self) -> None:
     super().contents()

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -80,7 +80,7 @@ class Ref_Lf21215tmr_Device(FootprintBlock):
       [Power])
 
     self.gnd = self.Port(
-      VoltageSink(model=None, voltage_limits=Default(RangeExpr.ALL), current_draw=Default(RangeExpr.ZERO)),
+      VoltageSink(voltage_limits=Default(RangeExpr.ALL), current_draw=Default(RangeExpr.ZERO)),
       [Common])
 
     self.vout = self.Port(DigitalSource.from_supply(

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -6,13 +6,13 @@ from edg import *
 class SwdSourceBitBang(Block):
   def __init__(self) -> None:
     super().__init__()
-    self.reset_in = self.Port(DigitalSink())
-    self.swclk_in = self.Port(DigitalSink())
-    self.swdio_in = self.Port(DigitalSink())
-    self.swdio_out = self.Port(DigitalSource())
-    self.swo_out = self.Port(DigitalSource())  # TODO is this directionality coreect?
+    self.reset_in = self.Port(DigitalSink.empty())
+    self.swclk_in = self.Port(DigitalSink.empty())
+    self.swdio_in = self.Port(DigitalSink.empty())
+    self.swdio_out = self.Port(DigitalSource.empty())
+    self.swo_out = self.Port(DigitalSource.empty())  # TODO is this directionality coreect?
 
-    self.swd = self.Port(SwdHostPort(), [Output])
+    self.swd = self.Port(SwdHostPort.empty(), [Output])
 
   def contents(self) -> None:
     super().contents()

--- a/examples/test_high_switch.py
+++ b/examples/test_high_switch.py
@@ -8,7 +8,7 @@ class LightsConnector(Connector, FootprintBlock):
   def __init__(self, current_draw: RangeLike = RangeExpr()) -> None:
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
+    self.pwr = self.Port(VoltageSink(), [Power])  # unused, doesn't draw anything
     self.gnd = self.Port(Ground(), [Common])
     self.out = ElementDict[DigitalSink]()
     for i in range(2):
@@ -36,13 +36,13 @@ class LightsDriver(Block):
 
     self.current_draw = current_draw
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.control = ElementDict[DigitalSink]()
 
     for i in range(2):
-      self.control[i] = self.Port(DigitalSink())
+      self.control[i] = self.Port(DigitalSink.empty())
 
   def contents(self) -> None:
     super().contents()

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -37,7 +37,7 @@ class MultimeterAnalog(Block):
     self.connect(self.res.b.as_analog_source(
       voltage_out=(self.gnd.link().voltage.lower(), self.pwr.link().voltage.upper()),
       current_limits=(-10, 10)*mAmp,
-      impedance=1*mOhm
+      impedance=1*mOhm(tol=0)
     ), self.range.input, self.output)
     self.rdiv = self.Block(Resistor(100*Ohm(tol=0.01)))
     self.connect(self.rdiv.a.as_analog_sink(), self.range.out0)

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -15,13 +15,13 @@ class MultimeterAnalog(Block):
     super().__init__()
 
     # TODO: separate Vref?
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.input_positive = self.Port(AnalogSink())
-    self.output = self.Port(AnalogSource())
+    self.input_positive = self.Port(AnalogSink.empty())
+    self.output = self.Port(AnalogSource.empty())
 
-    self.select = self.Port(DigitalSink())  # divider or not
+    self.select = self.Port(DigitalSink.empty())  # divider or not
 
   def contents(self):
     super().contents()
@@ -59,13 +59,13 @@ class MultimeterCurrentDriver(Block):
     super().__init__()
 
     # TODO: separate Vref?
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.output = self.Port(AnalogSink())  # TBD this should be some kind of AnalogBidirectional
+    self.output = self.Port(AnalogSink.empty())  # TBD this should be some kind of AnalogBidirectional
 
-    self.control = self.Port(AnalogSink())
-    self.enable = self.Port(DigitalSink())
+    self.control = self.Port(AnalogSink.empty())
+    self.enable = self.Port(DigitalSink.empty())
 
     self.resistance = self.ArgParameter(resistance)
     self.voltage_rating = self.ArgParameter(voltage_rating)
@@ -122,20 +122,14 @@ class FetPowerGate(Block):
   """
   def __init__(self):
     super().__init__()
-    self.pwr_in = self.Port(VoltageSink(
-      current_draw=RangeExpr(),
-      voltage_limits=RangeExpr.ALL
-    ), [Input])
-    self.pwr_out = self.Port(VoltageSource(
-      voltage_out=self.pwr_in.link().voltage,
-      current_limits=RangeExpr.ALL
-    ), [Output])
-    self.gnd = self.Port(Ground(), [Common])
+    self.pwr_in = self.Port(VoltageSink.empty(), [Input])
+    self.pwr_out = self.Port(VoltageSource.empty(), [Output])
+    self.gnd = self.Port(Ground.empty(), [Common])
 
     self.assign(self.pwr_in.current_draw, self.pwr_out.link().current_drawn)
 
-    self.btn_out = self.Port(DigitalSingleSource())
-    self.control = self.Port(DigitalSink())  # digital level control - gnd-referenced NFET gate
+    self.btn_out = self.Port(DigitalSingleSource.empty())
+    self.control = self.Port(DigitalSink.empty())  # digital level control - gnd-referenced NFET gate
 
   def contents(self):
     super().contents()

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -18,13 +18,13 @@ class GatedEmitterFollower(Block):
   def __init__(self, current: RangeLike, rds_on: RangeLike):
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.gnd = self.Port(Ground(), [Common])
-    self.out = self.Port(VoltageSource())
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.gnd = self.Port(Ground.empty(), [Common])
+    self.out = self.Port(VoltageSource.empty())
 
-    self.control = self.Port(AnalogSink())
-    self.high_en = self.Port(DigitalSink())
-    self.low_en = self.Port(DigitalSink())
+    self.control = self.Port(AnalogSink.empty())
+    self.high_en = self.Port(DigitalSink.empty())
+    self.low_en = self.Port(DigitalSink.empty())
 
     self.current = self.ArgParameter(current)
     self.rds_on = self.ArgParameter(rds_on)
@@ -104,9 +104,9 @@ class ErrorAmplifier(GeneratorBlock):
     self.pwr = self.Export(self.amp.pwr, [Power])
     self.gnd = self.Export(self.amp.gnd, [Common])
 
-    self.target = self.Port(AnalogSink())
-    self.actual = self.Port(AnalogSink())
-    self.output = self.Port(AnalogSource())
+    self.target = self.Port(AnalogSink.empty())
+    self.actual = self.Port(AnalogSink.empty())
+    self.output = self.Port(AnalogSource.empty())
 
     self.generator(self.generate_amp, output_resistance, input_resistance, diode_spec,
                    series, tolerance)
@@ -177,15 +177,15 @@ class SourceMeasureControl(Block):
   def __init__(self, current: RangeLike, rds_on: RangeLike):
     super().__init__()
 
-    self.pwr = self.Port(VoltageSink(), [Power])
-    self.pwr_logic = self.Port(VoltageSink())
-    self.gnd = self.Port(Ground(), [Common])
-    self.ref_center = self.Port(AnalogSink())
+    self.pwr = self.Port(VoltageSink.empty(), [Power])
+    self.pwr_logic = self.Port(VoltageSink.empty())
+    self.gnd = self.Port(Ground.empty(), [Common])
+    self.ref_center = self.Port(AnalogSink.empty())
 
-    self.out = self.Port(VoltageSource())
+    self.out = self.Port(VoltageSource.empty())
 
-    self.measured_voltage = self.Port(AnalogSource())
-    self.measured_current = self.Port(AnalogSource())
+    self.measured_voltage = self.Port(AnalogSource.empty())
+    self.measured_current = self.Port(AnalogSource.empty())
 
     self.current = self.ArgParameter(current)
     self.rds_on = self.ArgParameter(rds_on)


### PR DESCRIPTION
Resolves #103 , forcing Port.empty() to be used for intermediate ports, and refactors existing code to push this through. Defines Port.empty() in infrastructure (structured as clearing all initializers)

Also:
- Refactor the port initializer code to be centralized in Port, in preparation for IO arrays.
- Clean up a bunch of cruft
- Get rid of the ignore_* in the creation of proto - this silently drops data
- Internally, initializers are treated as mutable (in infrastructure only) and copied on a clone operation. Previously, all state must have been captured in the __init__ arguments, which is too limiting for heterogeneous IO (eg, a SPI port consisting of micro pins with different digital characteristics). This enables that.
- Refactor the Ground() not-a-port port so it can also support Ground.empty()
- Refactor this through all the examples and libraries