### PR TITLE
Link Array Support

### DIFF
--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -28,13 +28,15 @@ object EdgirUtils {
         (fn.isDefinedAt(connected.getBlockPort), fn.isDefinedAt(connected.getLinkPort)) match {
           case (true, false) => fn(connected.getBlockPort)
           case (false, true) => fn(connected.getLinkPort)
-          case _ => throw new IllegalArgumentException("block xor link did not match")
+          case (true, true) => throw new IllegalArgumentException("block and link both matched")
+          case (false, false) => throw new IllegalArgumentException("neither block nor link matched")
         }
       case expr.ValueExpr.Expr.Exported(exported) =>
         (fn.isDefinedAt(exported.getExteriorPort), fn.isDefinedAt(exported.getInternalBlockPort)) match {
           case (true, false) => fn(exported.getExteriorPort)
           case (false, true) => fn(exported.getInternalBlockPort)
-          case _ => throw new IllegalArgumentException("exterior xor interior did not match")
+          case (true, true) => throw new IllegalArgumentException("exterior and interior both matched")
+          case (false, false) => throw new IllegalArgumentException("neither interior nor exterior matched")
         }
       case _ => throw new IllegalArgumentException
     }
@@ -45,13 +47,15 @@ object EdgirUtils {
         (fn.isDefinedAt(connected.getBlockPort), fn.isDefinedAt(connected.getLinkPort)) match {
           case (true, false) => connection.update(_.connected.blockPort := fn(connected.getBlockPort))
           case (false, true) => connection.update(_.connected.linkPort := fn(connected.getLinkPort))
-          case _ => throw new IllegalArgumentException("block xor link did not match")
+          case (true, true) => throw new IllegalArgumentException("block and link both matched")
+          case (false, false) => throw new IllegalArgumentException("neither block nor link matched")
         }
       case expr.ValueExpr.Expr.Exported(exported) =>
         (fn.isDefinedAt(exported.getExteriorPort), fn.isDefinedAt(exported.getInternalBlockPort)) match {
           case (true, false) => connection.update(_.exported.exteriorPort := fn(exported.getExteriorPort))
           case (false, true) => connection.update(_.exported.internalBlockPort := fn(exported.getInternalBlockPort))
-          case _ => throw new IllegalArgumentException("exterior xor interior did not match")
+          case (true, true) => throw new IllegalArgumentException("exterior and interior both matched")
+          case (false, false) => throw new IllegalArgumentException("neither interior nor exterior matched")
         }
       case _ => throw new IllegalArgumentException
     }

--- a/compiler/src/main/scala/edg/ElemBuilder.scala
+++ b/compiler/src/main/scala/edg/ElemBuilder.scala
@@ -151,12 +151,12 @@ object ElemBuilder {
     )))
 
     // Fully elaborated (known length) PortArray
-    def Array(selfClass: String, count: Int, port: elem.PortLike): elem.PortLike =
+    def Array(selfClass: String, elements: Seq[String], port: elem.PortLike): elem.PortLike =
       elem.PortLike(`is`=elem.PortLike.Is.Array(elem.PortArray(
         selfClass=Some(LibraryPath(selfClass)),
         contains=elem.PortArray.Contains.Ports(elem.PortArray.Ports(
-          (0 until count).map { i =>
-            i.toString -> port
+          elements.map { element =>
+            element -> port
           }.toMap
         ))
       )))

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -790,7 +790,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
 
               case connects => throw new IllegalArgumentException(s"invalid connections to array $connects")
             }
-          case _ =>
+          case _ =>  // non-array, eg Port or Bundle
             connectedConstraints.connectionsByLinkPort(portPostfix, false) match {
               case PortConnections.ArrayConnect(constrName, constr) => constr.expr match {
                 case expr.ValueExpr.Expr.ConnectedArray(connected) =>
@@ -807,8 +807,8 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
                 case connects => throw new IllegalArgumentException(s"invalid connections to array $connects")
               }
 
-              case PortConnections.NotConnected =>  // TODO what are NC semantics for link array?
-                resolvePortConnectivity(path, portPostfix, None)
+              case PortConnections.NotConnected =>
+                // ignored - not-connected-ness will be forwarded
 
               case connects => throw new IllegalArgumentException(s"invalid connections to element $connects")
             }

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -577,6 +577,13 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
     }
     array.createFrom(model)
 
+    // For all arrays, size ELEMENTS directly from ALLOCATED
+    model.getPorts.collect { case (portName, port: wir.PortArray) =>
+      constProp.addDirectedEquality(
+        path.asIndirect + portName + IndirectStep.Elements, path.asIndirect + portName + IndirectStep.Allocated,
+        path, s"$path.$portName (link array-from-connects)")
+    }
+
     val arrayPortDeps = model.getPorts.collect { case (portName, port: wir.PortArray) =>
       ElaborateRecord.ParamValue(path.asIndirect + portName + IndirectStep.Elements)
     }.toSeq
@@ -936,7 +943,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
           path, s"$path.$portName (link array")
     }
 
-    elaborateLink(path)
+//    elaborateLink(path)
   }
 
   def elaboratePortArray(path: DesignPath): Unit = {

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -920,6 +920,9 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
     import edg.ExprBuilder.{Ref, ValueExpr}
     val link = resolve(path).asInstanceOf[wir.LinkArray]
 
+    val linkElements = ArrayValue.ExtractText(
+      constProp.getValue(path.asIndirect + IndirectStep.Elements).get)
+
     val linkPortArrayCounts = link.getModelPorts.collect {
       case (portName, port: wir.PortArray) =>
         val portElements = ArrayValue.ExtractText(
@@ -954,6 +957,10 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
     }
 
     // Create internal links
+    link.initLinks(linkElements).foreach { case (createdLinkName, createdLink) =>
+      val innerLinkElaborated = expandLink(path + createdLinkName, createdLink)
+      link.elaborate(createdLinkName, innerLinkElaborated)
+    }
 
     // Create internal connects
 

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -1077,8 +1077,10 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
 
     import edg.ExprBuilder.ValueExpr
     val allocatedIndexToConstraint = combinedConstrNames.map { constrName =>
+        println(parentBlock.getConstraints(constrName))
       parentBlock.getConstraints(constrName).connectMapRef {
         case ValueExpr.Ref(record.portPath :+ index) => (index, constrName)
+        case ValueExpr.Ref(record.portPath :+ index :+ interior) => (index, constrName)  // for link arrays
       }
     }.toMap
 

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -170,7 +170,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
   }
 
   // Working design tree data structure
-  private var root = new wir.Block(inputDesignPb.getContents, None)  // TODO refactor to unify root / non-root cases
+  private val root = new wir.Block(inputDesignPb.getContents, None)  // TODO refactor to unify root / non-root cases
   def resolve(path: DesignPath): wir.Pathable = root.resolve(path.steps)
   def resolveBlock(path: DesignPath): wir.BlockLike = root.resolve(path.steps).asInstanceOf[wir.BlockLike]
   def resolveLink(path: DesignPath): wir.LinkLike = root.resolve(path.steps).asInstanceOf[wir.LinkLike]
@@ -1066,7 +1066,6 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
         case ValueExpr.RefAllocate(record.portPath, index) => index
       }
     }
-    println(record.portPath)
     val arrayIndices = record.arrayConstraintNames.map { constrName =>
       parentBlock.getConstraints(constrName).expr
     }.flatMap {

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -49,30 +49,34 @@ object ElaborateRecord {
   // Defines the ALLOCATED for the port array, by aggregating all the connected ports.
   // Requires: ELEMENTS of all incoming connections defined.
   case class ResolveArrayAllocated(parent: DesignPath, portPath: Seq[String], constraintNames: Seq[String],
-                                   arrayConstraintNames: Seq[String], portIsLink: Boolean) extends ElaborateTask
+                                   arrayConstraintNames: Seq[String], portIsLink: Boolean)
+      extends ElaborateTask with ElaborateDependency
 
   // For array connections (to link arrays) only, rewrites constraints to replace the ALLOCATE with a concrete
   // port name, automatically allocated.
   // Requires: array-connections expanded, port's ELEMENTS defined.
   case class RewriteArrayAllocate(parent: DesignPath, portPath: Seq[String], constraintNames: Seq[String],
-                                  arrayConstraintNames: Seq[String], portIsLink: Boolean) extends ElaborateTask
+                                  arrayConstraintNames: Seq[String], portIsLink: Boolean)
+      extends ElaborateTask with ElaborateDependency
 
   // Expands ArrayConnect and ArrayExport connections to individual Connect and Export operations.
   // ALLOCATEs are preserved as-is, meaning those will be allocated on an individual (instead of array) basis.
   // Requires: port's ELEMENTS defined.
-  case class ExpandArrayConnections(parent: DesignPath, constraintName: String) extends ElaborateTask
-      with ElaborateDependency
+  case class ExpandArrayConnections(parent: DesignPath, constraintName: String)
+      extends ElaborateTask with ElaborateDependency
 
   // Once lowered to single connects, rewrites constraints to replace the ALLOCATE with a concrete port name,
   // allocated from the port's ELEMENTS.
   // Requires: array-connections expanded, port's ELEMENTS defined.
   case class RewriteConnectAllocate(parent: DesignPath, portPath: Seq[String], constraintNames: Seq[String],
-                                    arrayConstraintNames: Seq[String], portIsLink: Boolean) extends ElaborateTask
+                                    arrayConstraintNames: Seq[String], portIsLink: Boolean)
+      extends ElaborateTask with ElaborateDependency
 
   // Sets a PortArray's IS_CONNECTED based off all the connected constraints.
   // Requires: array-connections expanded, ALLOCATE replaced with concrete indices
   case class ResolveArrayIsConnected(parent: DesignPath, portPath: Seq[String], constraintNames: Seq[String],
-                                     arrayConstraintNames: Seq[String], portIsLink: Boolean) extends ElaborateTask
+                                     arrayConstraintNames: Seq[String], portIsLink: Boolean)
+      extends ElaborateTask
 }
 
 
@@ -1101,6 +1105,8 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
             case Some(suggestedName) => elts.map { elt => Some(s"$suggestedName.$elt") }
             case None => Seq.fill(elts.length)(None)
           }
+
+        case _ => throw new IllegalArgumentException
       }
       case _ => throw new IllegalArgumentException
     }

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -300,7 +300,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
         case _: wir.Block =>
           connectedLink.put(portPath, DesignPath())
           elaboratePending.setValue(ElaborateRecord.ConnectedLink(portPath), None)
-        case _: wir.Link =>  // links set these on all ports, so this is ignored here. TODO: unify code paths?
+        case _: wir.Link | _: wir.LinkArray =>  // links set these on all ports, so this is ignored here. TODO: unify code paths?
       }
       port match {
         case port: wir.Bundle =>
@@ -808,7 +808,9 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
               }
 
               case PortConnections.NotConnected =>
-                // ignored - not-connected-ness will be forwarded
+                val resolveConnectedTask = ElaborateRecord.ResolveArrayIsConnected(path, portPostfix, Seq(), Seq(), false)
+                elaboratePending.addNode(resolveConnectedTask, Seq(
+                  ElaborateRecord.ElaboratePortArray(path ++ portPostfix)))
 
               case connects => throw new IllegalArgumentException(s"invalid connections to element $connects")
             }

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -924,6 +924,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
       case (portName, port: wir.PortArray) =>
         val portElements = ArrayValue.ExtractText(
           constProp.getValue(path.asIndirect + portName + IndirectStep.Elements).get)
+        constProp.setValue(path.asIndirect + portName + IndirectStep.Length, IntValue(portElements.size))
         elaboratePending.setValue(ElaborateRecord.ElaboratePortArray(path + portName), None)  // resolved in initPortsFromModel
         portName -> portElements.size
     }

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -952,7 +952,11 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
       elaboratePending.setValue(ElaborateRecord.ElaboratePortArray(path ++ createdPortPostfix), None)
     }
 
-//    elaborateLink(path)
+    // Create internal links
+
+    // Create internal connects
+
+    // Resolve connections
   }
 
   def elaboratePortArray(path: DesignPath): Unit = {

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -1084,8 +1084,9 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
       }
     }.toMap
 
-    val portArray = resolve(record.parent ++ record.portPath).asInstanceOf[wir.PortArray]
-    portArray.getPorts.foreach { case (index, innerPort) =>
+    val portArrayElts = ArrayValue.ExtractText(
+      constProp.getValue(record.parent.asIndirect ++ record.portPath + IndirectStep.Elements).get)
+    portArrayElts.foreach { index =>
       val constraintOption = allocatedIndexToConstraint.get(index).map { constrName =>
         (constrName, parentBlock.getConstraints(constrName))
       }

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -932,7 +932,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
         portName -> portElements
     }
 
-    // Expand port arrays based on ELEMENTS - first propagate ELEMENTS
+    // Propagate link-wide ELEMENTS to port ELEMENTS and inner-link ALLOCATED
     link.getModelPorts.foreach {
       case (portName, port: wir.PortArray) =>
         linkPortArrayElements(portName).foreach { index =>
@@ -940,6 +940,12 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
             path.asIndirect + portName + index + IndirectStep.Elements,
             path.asIndirect + IndirectStep.Elements,
             path, s"$portName.$index (link-array ports-from-elts)")
+        }
+        linkElements.foreach { elementIndex =>
+          constProp.addDirectedEquality(
+            path.asIndirect + elementIndex + portName + IndirectStep.Allocated,
+            path.asIndirect + portName + IndirectStep.Elements,
+            path, s"$elementIndex.$portName (link-array inner-port-array from outer-elts)")
         }
       case (portName, port) =>
         constProp.addDirectedEquality(

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -645,7 +645,6 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
                   // Note: actual expansion task set on the link side
                   val resolveConnectedTask = ElaborateRecord.ResolveArrayIsConnected(path, blockPortPostfix, Seq(), Seq(constrName), false)
                   elaboratePending.addNode(resolveConnectedTask, Seq(
-                    ElaborateRecord.ElaboratePortArray(path ++ portPostfix),
                     expandArrayTask
                   ))
 
@@ -661,7 +660,6 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
                   val expandArrayTask = ElaborateRecord.ExpandArrayConnections(path, constrName)
                   elaboratePending.addNode(expandArrayTask,
                     Seq(
-                      ElaborateRecord.ElaboratePortArray(path ++ intPostfix),  // port must be defined
                       ElaborateRecord.ParamValue(path.asIndirect ++ intPostfix + IndirectStep.Elements),
                       // allocated must run first, it depends on constraints not being lowered
                       ElaborateRecord.ParamValue(path.asIndirect ++ intPostfix + IndirectStep.Allocated)
@@ -1077,7 +1075,6 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
 
     import edg.ExprBuilder.ValueExpr
     val allocatedIndexToConstraint = combinedConstrNames.map { constrName =>
-        println(parentBlock.getConstraints(constrName))
       parentBlock.getConstraints(constrName).connectMapRef {
         case ValueExpr.Ref(record.portPath :+ index) => (index, constrName)
         case ValueExpr.Ref(record.portPath :+ index :+ interior) => (index, constrName)  // for link arrays

--- a/compiler/src/main/scala/edg/compiler/DesignRefsValidate.scala
+++ b/compiler/src/main/scala/edg/compiler/DesignRefsValidate.scala
@@ -123,10 +123,14 @@ class DesignRefsValidate extends DesignMap[Unit, Unit, Unit] {
     // do nothing
   }
 
-  override def mapLink(path: DesignPath, block: elem.Link,
-              ports: SeqMap[String, Unit], links: SeqMap[String, Unit]): Unit = {
-    block.params.foreach { case (name, _) => paramDefs.add(path + name) }
-    block.constraints.foreach { case (name, constr) => mapConstraint(path, name, constr) }
+  override def mapLink(path: DesignPath, link: elem.Link,
+                       ports: SeqMap[String, Unit], links: SeqMap[String, Unit]): Unit = {
+    link.params.foreach { case (name, _) => paramDefs.add(path + name) }
+    link.constraints.foreach { case (name, constr) => mapConstraint(path, name, constr) }
+  }
+  override def mapLinkArray(path: DesignPath, link: elem.LinkArray,
+                            ports: SeqMap[String, Unit], links: SeqMap[String, Unit]): Unit = {
+    link.constraints.foreach { case (name, constr) => mapConstraint(path, name, constr) }
   }
   override def mapLinkLibrary(path: DesignPath, link: ref.LibraryPath): Unit = {
     // do nothing

--- a/compiler/src/main/scala/edg/compiler/DesignStructuralValidate.scala
+++ b/compiler/src/main/scala/edg/compiler/DesignStructuralValidate.scala
@@ -47,9 +47,20 @@ class DesignStructuralValidate extends DesignMap[Seq[CompilerError], Seq[Compile
     Seq(CompilerError.LibraryElement(path, block))
   }
 
-  override def mapLink(path: DesignPath, block: elem.Link,
-              ports: SeqMap[String, Seq[CompilerError]], links: SeqMap[String, Seq[CompilerError]]): Seq[CompilerError] = {
+  override def mapLink(path: DesignPath, link: elem.Link,
+                       ports: SeqMap[String, Seq[CompilerError]], links: SeqMap[String, Seq[CompilerError]]):
+      Seq[CompilerError] = {
     (ports.values.flatten ++ links.values.flatten).toSeq
+  }
+  override def mapLinkArray(path: DesignPath, link: elem.LinkArray,
+                            ports: SeqMap[String, Seq[CompilerError]], links: SeqMap[String, Seq[CompilerError]]):
+      Seq[CompilerError] = {
+    val undefinedError = if (link.ports.isEmpty || link.links.isEmpty) {
+      Seq(CompilerError.AbstractBlock(path, link.getSelfClass))
+    } else {
+      Seq()
+    }
+    undefinedError ++ (ports.values.flatten ++ links.values.flatten).toSeq
   }
   override def mapLinkLibrary(path: DesignPath, link: ref.LibraryPath): Seq[CompilerError] = {
     Seq(CompilerError.LibraryElement(path, link))

--- a/compiler/src/main/scala/edg/wir/BlockLike.scala
+++ b/compiler/src/main/scala/edg/wir/BlockLike.scala
@@ -1,5 +1,6 @@
 package edg.wir
 
+import edg.EdgirUtils.SimpleLibraryPath
 import edgir.common.common
 import edgir.elem.elem
 import edgir.expr.expr
@@ -45,7 +46,7 @@ class Block(pb: elem.HierarchyBlock, unrefinedType: Option[ref.LibraryPath]) ext
       } else if (links.contains(subname)) {
         links(subname).resolve(tail)
       } else {
-        throw new InvalidPathException(s"No element $subname in Block")
+        throw new InvalidPathException(s"No element $subname (of $suffix) in Block ${pb.getSelfClass.toSimpleString}")
       }
   }
 
@@ -134,7 +135,7 @@ class Generator(basePb: elem.HierarchyBlock, unrefinedType: Option[ref.LibraryPa
 case class BlockLibrary(target: ref.LibraryPath) extends BlockLike {
   def resolve(suffix: Seq[String]): Pathable = suffix match {
     case Seq() => this
-    case _ => throw new InvalidPathException(s"Can't resolve into library $target")
+    case _ => throw new InvalidPathException(s"Can't resolve $suffix into library ${target.toSimpleString}")
   }
   def toPb: elem.BlockLike = elem.BlockLike(elem.BlockLike.Type.LibElem(target))
   override def isElaborated: Boolean = false

--- a/compiler/src/main/scala/edg/wir/LinkLike.scala
+++ b/compiler/src/main/scala/edg/wir/LinkLike.scala
@@ -1,5 +1,6 @@
 package edg.wir
 
+import edg.EdgirUtils.SimpleLibraryPath
 import edgir.init.init
 import edgir.elem.elem
 import edgir.expr.expr
@@ -34,7 +35,7 @@ class Link(pb: elem.Link) extends LinkLike
       } else if (links.contains(subname)) {
         links(subname).resolve(tail)
       } else {
-        throw new InvalidPathException(s"No element $subname in Link")
+        throw new InvalidPathException(s"No element $subname (of $suffix} in Link ${pb.getSelfClass.toSimpleString}")
       }
   }
 
@@ -136,7 +137,7 @@ class LinkArray(pb: elem.LinkArray) extends LinkLike
       } else if (links.contains(subname)) {
         links(subname).resolve(tail)
       } else {
-        throw new InvalidPathException(s"No element $subname in Link")
+        throw new InvalidPathException(s"No element $subname (of $suffix) in Link ${pb.getSelfClass.toSimpleString}")
       }
   }
 
@@ -156,7 +157,7 @@ class LinkArray(pb: elem.LinkArray) extends LinkLike
 case class LinkLibrary(target: ref.LibraryPath) extends LinkLike {
   def resolve(suffix: Seq[String]): Pathable = suffix match {
     case Seq() => this
-    case _ => throw new InvalidPathException(s"Can't resolve into library $target")
+    case _ => throw new InvalidPathException(s"Can't resolve $suffix into library ${target.toSimpleString}")
   }
   def toPb: elem.LinkLike = elem.LinkLike(elem.LinkLike.Type.LibElem(target))
   override def isElaborated: Boolean = false

--- a/compiler/src/main/scala/edg/wir/LinkLike.scala
+++ b/compiler/src/main/scala/edg/wir/LinkLike.scala
@@ -92,6 +92,16 @@ class LinkArray(pb: elem.LinkArray) extends LinkLike
     }
   }
 
+  // Creates the specified amount of internal links, returning the name and created link.
+  def initLinks(elements: Seq[String]): Map[String, LinkLibrary] = {
+    require(links.isEmpty)
+    elements.map { index =>
+      val created = new LinkLibrary(getModelLibrary)
+      links.update(index, created)
+      (index, created)
+    }.toMap
+  }
+
   // TODO explicit isElaborated flag? instead of inferring?
   override def isElaborated: Boolean = !(pb.ports.isEmpty && pb.links.isEmpty && pb.constraints.isEmpty)
 

--- a/compiler/src/main/scala/edg/wir/LinkLike.scala
+++ b/compiler/src/main/scala/edg/wir/LinkLike.scala
@@ -58,6 +58,17 @@ class LinkArray(pb: elem.LinkArray) extends LinkLike
   override protected val links = mutable.SeqMap[String, LinkLike]()
   override protected val constraints = mutable.SeqMap[String, expr.ValueExpr]()
 
+  var model: Option[Link] = None
+
+  def getModelLibrary: ref.LibraryPath = pb.getSelfClass
+
+  def createFrom(linkDef: Link): Unit = {
+    require(model.isEmpty)
+    model = Some(linkDef)
+  }
+
+  def getModelPorts: Map[String, PortLike] = model.get.getPorts
+
 
   // TODO explicit isElaborated flag? instead of inferring?
   override def isElaborated: Boolean = !(pb.ports.isEmpty && pb.links.isEmpty && pb.constraints.isEmpty)

--- a/compiler/src/main/scala/edg/wir/PortLike.scala
+++ b/compiler/src/main/scala/edg/wir/PortLike.scala
@@ -1,5 +1,7 @@
 package edg.wir
 
+import edg.EdgirUtils.SimpleLibraryPath
+
 import scala.collection.{SeqMap, mutable}
 import edgir.init.init
 import edgir.elem.elem
@@ -33,7 +35,7 @@ class Port(pb: elem.Port) extends PortLike
 
   override def resolve(suffix: Seq[String]): Pathable = suffix match {
     case Seq() => this
-    case suffix => throw new InvalidPathException(s"No suffix $suffix in Port")
+    case suffix => throw new InvalidPathException(s"No elements (of $suffix) in Port")
   }
 
   def toEltPb: elem.Port = {
@@ -60,7 +62,7 @@ class Bundle(pb: elem.Bundle) extends PortLike
       if (ports.contains(subname)) {
         ports(subname).resolve(tail)
       } else {
-        throw new InvalidPathException(s"No element $subname in Block")
+        throw new InvalidPathException(s"No elements $subname (of $suffix) in Bundle ${pb.getSelfClass.toSimpleString}")
       }
   }
 
@@ -94,7 +96,7 @@ class PortArray(pb: elem.PortArray) extends PortLike with HasMutablePorts {
       if (ports.contains(subname)) {
         ports(subname).resolve(tail)
       } else {
-        throw new InvalidPathException(s"No element $subname in Block")
+        throw new InvalidPathException(s"No element $subname (of $suffix) in PortArray ${pb.getSelfClass.toSimpleString}")
       }
   }
 
@@ -126,7 +128,7 @@ class PortArray(pb: elem.PortArray) extends PortLike with HasMutablePorts {
 case class PortLibrary(target: ref.LibraryPath) extends PortLike {
   def resolve(suffix: Seq[String]): Pathable = suffix match {
     case Seq() => this
-    case _ => throw new InvalidPathException(s"Can't resolve into library $target")
+    case _ => throw new InvalidPathException(s"Can't resolve $suffix into library ${target.toSimpleString}")
   }
   def toPb: elem.PortLike = elem.PortLike(elem.PortLike.Is.LibElem(target))
   override def isElaborated: Boolean = false

--- a/compiler/src/test/scala/edg/compiler/CompilerBlockPortArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerBlockPortArrayExpansionTest.scala
@@ -32,13 +32,13 @@ class CompilerBlockPortArrayExpansionTest extends AnyFlatSpec with CompilerTestU
       Block.Block("concreteSinksBlock",
         superclasses = Seq("baseSinksBlock"),
         ports = Map(
-          "port" -> Port.Array("sinkPort", 2, Port.Library("sinkPort")),
+          "port" -> Port.Array("sinkPort", Seq("0", "1"), Port.Library("sinkPort")),
         )
       ),
       Block.Block("emptySinksBlock",
         superclasses = Seq("baseSinksBlock"),
         ports = Map(
-          "port" -> Port.Array("sinkPort", 0, Port.Library("sinkPort")),
+          "port" -> Port.Array("sinkPort", Seq(), Port.Library("sinkPort")),
         )
       ),
       Block.Block("concreteWrapperBlock",

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -51,27 +51,27 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       ),
       constraints = Map(
         "sourceConnect" -> Constraint.ConnectedArray(Ref("source", "port"), Ref("link", "source")),
-        "sink0Connect" -> Constraint.ConnectedArray(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
-        "sink1Connect" -> Constraint.ConnectedArray(Ref("sink1", "port"), Ref.Allocate(Ref("link", "sinks"))),
+//        "sink0Connect" -> Constraint.ConnectedArray(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
+//        "sink1Connect" -> Constraint.ConnectedArray(Ref("sink1", "port"), Ref.Allocate(Ref("link", "sinks"))),
       )
     ))
     val referenceConstraints = Map(  // expected constraints in the top-level design
       "sourceConnect.0" -> Constraint.Connected(Ref("source", "port", "0"), Ref("link", "source", "0")),
       "sourceConnect.1" -> Constraint.Connected(Ref("source", "port", "1"), Ref("link", "source", "1")),
 
-      "sink0Connect.0" -> Constraint.Connected(Ref("sink0", "port", "0"), Ref("link", "sinks", "0", "0")),
-      "sink0Connect.1" -> Constraint.Connected(Ref("sink0", "port", "1"), Ref("link", "sinks", "0", "1")),
-      "sink1Connect.0" -> Constraint.Connected(Ref("sink1", "port", "0"), Ref("link", "sinks", "1", "0")),
-      "sink1Connect.1" -> Constraint.Connected(Ref("sink1", "port", "1"), Ref("link", "sinks", "1", "1")),
+//      "sink0Connect.0" -> Constraint.Connected(Ref("sink0", "port", "0"), Ref("link", "sinks", "0", "0")),
+//      "sink0Connect.1" -> Constraint.Connected(Ref("sink0", "port", "1"), Ref("link", "sinks", "0", "1")),
+//      "sink1Connect.0" -> Constraint.Connected(Ref("sink1", "port", "0"), Ref("link", "sinks", "1", "0")),
+//      "sink1Connect.1" -> Constraint.Connected(Ref("sink1", "port", "1"), Ref("link", "sinks", "1", "1")),
     )
     val referenceLinkArrayConstraints = Map(  // expected constraints in the link array
       "source.0" -> Constraint.Exported(Ref("source", "0"), Ref("0", "source")),
       "source.1" -> Constraint.Exported(Ref("source", "1"), Ref("1", "source")),
 
-      "sink.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
-      "sink.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
-      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
-      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
+//      "sink.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
+//      "sink.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
+//      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
+//      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
     )
 
     val (compiler, compiled) = testCompile(inputDesign, library)

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -86,18 +86,41 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(library), Refinements())
     val compiled = compiler.compile()
 
-
-    // TEMPORARILY HERE REMOVE ME
-    compiled.contents.get.constraints should equal(referenceConstraints)
-
-
-
-    val dsv = new DesignStructuralValidate()
-    dsv.map(Design(compiled.contents.get)) should equal(Seq())
-
-    val drv = new DesignRefsValidate()
-    drv.validate(Design(compiled.contents.get)) should equal(Seq())
+//    val dsv = new DesignStructuralValidate()
+//    dsv.map(Design(compiled.contents.get)) should equal(Seq())
+//
+//    val drv = new DesignRefsValidate()
+//    drv.validate(Design(compiled.contents.get)) should equal(Seq())
 
     compiled.contents.get.constraints should equal(referenceConstraints)
+
+    compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+
+    compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+    compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Length) should
+        equal(Some(IntValue(3)))
+
+    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1")))))
+    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + IndirectStep.Length) should
+        equal(Some(IntValue(2)))
+    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "0" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "0" + IndirectStep.Length) should
+        equal(Some(IntValue(3)))
+    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "1" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "1" + IndirectStep.Length) should
+        equal(Some(IntValue(3)))
+
+
+        // TEMPORARILY HERE TO MAKE A INCOMPLETE TEST FAILURE
+        val dsv = new DesignStructuralValidate()
+        dsv.map(Design(compiled.contents.get)) should equal(Seq())
+
+        val drv = new DesignRefsValidate()
+        drv.validate(Design(compiled.contents.get)) should equal(Seq())
   }
 }

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -20,7 +20,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     blocks = Seq(
       Block.Block("sourceBlock",  // array elements source
         ports = Map(
-          "port" -> Port.Array("sourcePort", Seq("a", "b", "c"), Port.Library("sinkPort")),
+          "port" -> Port.Array("sourcePort", Seq("a", "b", "c"), Port.Library("sourcePort")),
         ),
         constraints = Map(
           "port.a" -> Constraint.Assign(Ref("port", "a", "param"), ValueExpr.Literal(1)),
@@ -30,7 +30,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       ),
       Block.Block("sinkBlock",  // array elements sink
         ports = Map(
-          "port" -> Port.Array("sinkPort"),
+          "port" -> Port.Array("sinkPort", Seq("a", "b", "c"), Port.Library("sinkPort")),
         ),
         constraints = Map(
           "port.a" -> Constraint.Assign(Ref("port", "a", "param"), ValueExpr.Literal(11)),

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -39,7 +39,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     )
   )
 
-  "Compiler on design with abstract source and array sink" should "expand blocks" ignore {
+  "Compiler on design with abstract source and array sink" should "expand blocks" in {
     val inputDesign = Design(Block.Block("topDesign",
       blocks = Map(
         "source" -> Block.Library("sourceBlock"),

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -20,7 +20,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     blocks = Seq(
       Block.Block("sourceBlock",  // array elements source
         ports = Map(
-          "port" -> Port.Array("sourcePort", 3, Port.Library("sinkPort")),
+          "port" -> Port.Array("sourcePort", Seq("a", "b", "c"), Port.Library("sinkPort")),
         )
       ),
       Block.Block("sinkBlock",  // array elements sink
@@ -56,28 +56,28 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       )
     ))
     val referenceConstraints = Map(  // expected constraints in the top-level design
-      "sourceConnect.0" -> Constraint.Connected(Ref("source", "port", "0"), Ref("link", "source", "0")),
-      "sourceConnect.1" -> Constraint.Connected(Ref("source", "port", "1"), Ref("link", "source", "1")),
-      "sourceConnect.2" -> Constraint.Connected(Ref("source", "port", "2"), Ref("link", "source", "2")),
+      "sourceConnect.a" -> Constraint.Connected(Ref("source", "port", "a"), Ref("link", "source", "a")),
+      "sourceConnect.b" -> Constraint.Connected(Ref("source", "port", "b"), Ref("link", "source", "b")),
+      "sourceConnect.c" -> Constraint.Connected(Ref("source", "port", "c"), Ref("link", "source", "c")),
 
-      "sink0Connect.0" -> Constraint.Connected(Ref("sink0", "port", "0"), Ref("link", "sinks", "0", "0")),
-      "sink0Connect.1" -> Constraint.Connected(Ref("sink0", "port", "1"), Ref("link", "sinks", "0", "1")),
-      "sink0Connect.2" -> Constraint.Connected(Ref("sink0", "port", "2"), Ref("link", "sinks", "0", "2")),
-      "sink1Connect.0" -> Constraint.Connected(Ref("sink1", "port", "0"), Ref("link", "sinks", "1", "0")),
-      "sink1Connect.1" -> Constraint.Connected(Ref("sink1", "port", "1"), Ref("link", "sinks", "1", "1")),
-      "sink1Connect.2" -> Constraint.Connected(Ref("sink1", "port", "2"), Ref("link", "sinks", "1", "2")),
+      "sink0Connect.a" -> Constraint.Connected(Ref("sink0", "port", "a"), Ref("link", "sinks", "0", "a")),
+      "sink0Connect.b" -> Constraint.Connected(Ref("sink0", "port", "b"), Ref("link", "sinks", "0", "b")),
+      "sink0Connect.c" -> Constraint.Connected(Ref("sink0", "port", "c"), Ref("link", "sinks", "0", "c")),
+      "sink1Connect.a" -> Constraint.Connected(Ref("sink1", "port", "a"), Ref("link", "sinks", "1", "a")),
+      "sink1Connect.b" -> Constraint.Connected(Ref("sink1", "port", "b"), Ref("link", "sinks", "1", "b")),
+      "sink1Connect.c" -> Constraint.Connected(Ref("sink1", "port", "c"), Ref("link", "sinks", "1", "c")),
     )
     val referenceLinkArrayConstraints = Map(  // expected constraints in the link array
-      "source.0" -> Constraint.Exported(Ref("source", "0"), Ref("0", "source")),
-      "source.1" -> Constraint.Exported(Ref("source", "1"), Ref("1", "source")),
-      "source.2" -> Constraint.Exported(Ref("source", "2"), Ref("2", "source")),
+      "source.a" -> Constraint.Exported(Ref("source", "a"), Ref("a", "source")),
+      "source.b" -> Constraint.Exported(Ref("source", "b"), Ref("b", "source")),
+      "source.c" -> Constraint.Exported(Ref("source", "c"), Ref("c", "source")),
 
-      "sinks.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
-      "sinks.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
-      "sinks.0.2" -> Constraint.Exported(Ref("sinks", "0", "2"), Ref("2", "sinks", "0")),
-      "sinks.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
-      "sinks.1.1" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
-      "sinks.1.2" -> Constraint.Exported(Ref("sinks", "1", "2"), Ref("2", "sinks", "1")),
+      "sinks.0.a" -> Constraint.Exported(Ref("sinks", "0", "a"), Ref("a", "sinks", "0")),
+      "sinks.0.b" -> Constraint.Exported(Ref("sinks", "0", "b"), Ref("b", "sinks", "0")),
+      "sinks.0.c" -> Constraint.Exported(Ref("sinks", "0", "c"), Ref("c", "sinks", "0")),
+      "sinks.1.a" -> Constraint.Exported(Ref("sinks", "1", "a"), Ref("a", "sinks", "1")),
+      "sinks.1.b" -> Constraint.Exported(Ref("sinks", "1", "b"), Ref("b", "sinks", "1")),
+      "sinks.1.c" -> Constraint.Exported(Ref("sinks", "1", "c"), Ref("c", "sinks", "1")),
     )
 
     val (compiler, compiled) = testCompile(inputDesign, library)
@@ -85,7 +85,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     compiled.getContents.constraints should equal(referenceConstraints)
 
     compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
     compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Length) should
         equal(Some(IntValue(3)))
 
@@ -95,23 +95,23 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
         equal(Some(IntValue(2)))
     (0 until 2).foreach { sinkIndex =>
       compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex.toString + IndirectStep.Elements) should
-          equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+          equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
       compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex.toString + IndirectStep.Length) should
           equal(Some(IntValue(3)))
     }
 
     compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
 
     val linkPb = compiled.getContents.links("link").getArray
     linkPb.constraints should equal(referenceLinkArrayConstraints)
 
-    linkPb.links.keySet should equal(Set("0", "1", "2"))
-    (0 until 3).foreach { elementIndex =>
-      linkPb.links(elementIndex.toString).getLink.getSelfClass should equal(LibraryPath("link"))
-      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Elements) should
+    linkPb.links.keySet should equal(Set("a", "b", "c"))
+    Seq("a", "b", "c").foreach { elementIndex =>
+      linkPb.links(elementIndex).getLink.getSelfClass should equal(LibraryPath("link"))
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + IndirectStep.Elements) should
           equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1")))))
-      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Length) should
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + IndirectStep.Length) should
           equal(Some(IntValue(2)))
     }
   }
@@ -129,14 +129,14 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       )
     ))
     val referenceConstraints = Map(  // expected constraints in the top-level design
-      "sourceConnect.0" -> Constraint.Connected(Ref("source", "port", "0"), Ref("link", "source", "0")),
-      "sourceConnect.1" -> Constraint.Connected(Ref("source", "port", "1"), Ref("link", "source", "1")),
-      "sourceConnect.2" -> Constraint.Connected(Ref("source", "port", "2"), Ref("link", "source", "2")),
+      "sourceConnect.a" -> Constraint.Connected(Ref("source", "port", "a"), Ref("link", "source", "a")),
+      "sourceConnect.b" -> Constraint.Connected(Ref("source", "port", "b"), Ref("link", "source", "b")),
+      "sourceConnect.c" -> Constraint.Connected(Ref("source", "port", "c"), Ref("link", "source", "c")),
     )
     val referenceLinkArrayConstraints = Map(  // expected constraints in the link array
-      "source.0" -> Constraint.Exported(Ref("source", "0"), Ref("0", "source")),
-      "source.1" -> Constraint.Exported(Ref("source", "1"), Ref("1", "source")),
-      "source.2" -> Constraint.Exported(Ref("source", "2"), Ref("2", "source")),
+      "source.a" -> Constraint.Exported(Ref("source", "a"), Ref("a", "source")),
+      "source.b" -> Constraint.Exported(Ref("source", "b"), Ref("b", "source")),
+      "source.c" -> Constraint.Exported(Ref("source", "c"), Ref("c", "source")),
     )
 
     val (compiler, compiled) = testCompile(inputDesign, library)
@@ -144,7 +144,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     compiled.getContents.constraints should equal(referenceConstraints)
 
     compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
     compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Length) should
         equal(Some(IntValue(3)))
 
@@ -154,17 +154,17 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
         equal(Some(IntValue(0)))
 
     compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
 
     val linkPb = compiled.getContents.links("link").getArray
     linkPb.constraints should equal(referenceLinkArrayConstraints)
 
-    linkPb.links.keySet should equal(Set("0", "1", "2"))
-    (0 until 3).foreach { elementIndex =>
-      linkPb.links(elementIndex.toString).getLink.getSelfClass should equal(LibraryPath("link"))
-      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Elements) should
+    linkPb.links.keySet should equal(Set("a", "b", "c"))
+    Seq("a", "b", "c").foreach { elementIndex =>
+      linkPb.links(elementIndex).getLink.getSelfClass should equal(LibraryPath("link"))
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + IndirectStep.Elements) should
           equal(Some(ArrayValue(Seq())))
-      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Length) should
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + IndirectStep.Length) should
           equal(Some(IntValue(0)))
     }
   }

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -93,14 +93,12 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1")))))
     compiler.getValue(IndirectDesignPath() + "link" + "sinks" + IndirectStep.Length) should
         equal(Some(IntValue(2)))
-    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "0" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
-    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "0" + IndirectStep.Length) should
-        equal(Some(IntValue(3)))
-    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "1" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
-    compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "1" + IndirectStep.Length) should
-        equal(Some(IntValue(3)))
+    (0 until 2).foreach { sinkIndex =>
+      compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex.toString + IndirectStep.Elements) should
+          equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
+      compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex.toString + IndirectStep.Length) should
+          equal(Some(IntValue(3)))
+    }
 
     compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
@@ -112,6 +110,13 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     linkPb.links("2").getLink.getSelfClass should equal(LibraryPath("link"))
 
     linkPb.constraints should equal(referenceLinkArrayConstraints)
+
+    (0 until 3).foreach { elementIndex =>
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Elements) should
+          equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1")))))
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Length) should
+          equal(Some(IntValue(2)))
+    }
   }
 
   "Compiler on design with partially-connected link-arrays" should "work" in {
@@ -161,5 +166,12 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     linkPb.links("2").getLink.getSelfClass should equal(LibraryPath("link"))
 
     linkPb.constraints should equal(referenceLinkArrayConstraints)
+
+    (0 until 3).foreach { elementIndex =>
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Elements) should
+          equal(Some(ArrayValue(Seq())))
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Length) should
+          equal(Some(IntValue(0)))
+    }
   }
 }

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -149,6 +149,8 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     Map("a" -> 1, "b" -> 2, "c" -> 3).foreach { case (elementIndex, paramValue) =>
       compiler.getValue(IndirectDesignPath() + "link" + "source" + elementIndex + "param") should
           equal(Some(IntValue(paramValue)))
+      compiler.getValue(IndirectDesignPath() + "link" + "source" + elementIndex + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(true)))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + "param") should
           equal(Some(IntValue(paramValue)))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + IndirectStep.IsConnected) should
@@ -159,6 +161,8 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       Map("a" -> 11, "b" -> 12, "c" -> 13).foreach { case (elementIndex, paramValue) =>
         compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex + elementIndex + "param") should
             equal(Some(IntValue(paramValue)))
+        compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex + elementIndex + IndirectStep.IsConnected) should
+            equal(Some(BooleanValue(true)))
         compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + sinkIndex + "param") should
             equal(Some(IntValue(paramValue)))
         compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + sinkIndex + IndirectStep.IsConnected) should
@@ -238,6 +242,8 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     Map("a" -> 1, "b" -> 2, "c" -> 3).foreach { case (elementIndex, paramValue) =>
       compiler.getValue(IndirectDesignPath() + "link" + "source" + elementIndex + "param") should
           equal(Some(IntValue(paramValue)))
+      compiler.getValue(IndirectDesignPath() + "link" + "source" + elementIndex + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(true)))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + "param") should
           equal(Some(IntValue(paramValue)))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + IndirectStep.IsConnected) should
@@ -309,11 +315,21 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
           equal(Some(IntValue(1)))
     }
 
+    // Check disconnected-ness
+    Seq("a", "b", "c").foreach { elementIndex =>
+      compiler.getValue(IndirectDesignPath() + "link" + "source" + elementIndex + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(false)))
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(false)))
+    }
+
     // Check parameter propagation
     Seq("0").foreach { sinkIndex =>
       Map("a" -> 11, "b" -> 12, "c" -> 13).foreach { case (elementIndex, paramValue) =>
         compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex + elementIndex + "param") should
             equal(Some(IntValue(paramValue)))
+        compiler.getValue(IndirectDesignPath() + "link" + "sinks" + sinkIndex + elementIndex + IndirectStep.IsConnected) should
+            equal(Some(BooleanValue(true)))
         compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + sinkIndex + "param") should
             equal(Some(IntValue(paramValue)))
         compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + sinkIndex + IndirectStep.IsConnected) should
@@ -326,14 +342,6 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
           equal(Some(IntValue(-1)))
       compiler.getValue(IndirectDesignPath() + "sink" + "port" + elementIndex + IndirectStep.IsConnected) should
           equal(Some(BooleanValue(true)))
-    }
-
-    // Check disconnected-ness
-    Seq("a", "b", "c").foreach { elementIndex =>
-      compiler.getValue(IndirectDesignPath() + "link" + "source" + elementIndex + IndirectStep.IsConnected) should
-          equal(Some(BooleanValue(false)))
-      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + IndirectStep.IsConnected) should
-          equal(Some(BooleanValue(false)))
     }
   }
 

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -58,23 +58,39 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     val referenceConstraints = Map(  // expected constraints in the top-level design
       "sourceConnect.0" -> Constraint.Connected(Ref("source", "port", "0"), Ref("link", "source", "0")),
       "sourceConnect.1" -> Constraint.Connected(Ref("source", "port", "1"), Ref("link", "source", "1")),
+      "sourceConnect.2" -> Constraint.Connected(Ref("source", "port", "2"), Ref("link", "source", "2")),
 
       "sink0Connect.0" -> Constraint.Connected(Ref("sink0", "port", "0"), Ref("link", "sinks", "0", "0")),
       "sink0Connect.1" -> Constraint.Connected(Ref("sink0", "port", "1"), Ref("link", "sinks", "0", "1")),
+      "sink0Connect.2" -> Constraint.Connected(Ref("sink0", "port", "2"), Ref("link", "sinks", "0", "2")),
       "sink1Connect.0" -> Constraint.Connected(Ref("sink1", "port", "0"), Ref("link", "sinks", "1", "0")),
       "sink1Connect.1" -> Constraint.Connected(Ref("sink1", "port", "1"), Ref("link", "sinks", "1", "1")),
+      "sink1Connect.2" -> Constraint.Connected(Ref("sink1", "port", "2"), Ref("link", "sinks", "1", "2")),
     )
     val referenceLinkArrayConstraints = Map(  // expected constraints in the link array
       "source.0" -> Constraint.Exported(Ref("source", "0"), Ref("0", "source")),
       "source.1" -> Constraint.Exported(Ref("source", "1"), Ref("1", "source")),
+      "source.2" -> Constraint.Exported(Ref("source", "2"), Ref("2", "source")),
 
       "sink.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
       "sink.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
+      "sink.0.2" -> Constraint.Exported(Ref("sinks", "0", "2"), Ref("2", "sinks", "0")),
       "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
       "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
+      "sink.2.0" -> Constraint.Exported(Ref("sinks", "1", "2"), Ref("2", "sinks", "1")),
     )
 
-    val (compiler, compiled) = testCompile(inputDesign, library)
+//    val (compiler, compiled) = testCompile(inputDesign, library)
+    // TODO remove with above once things fully work
+    import edg.wir.{EdgirLibrary, Refinements}
+    val compiler = new Compiler(inputDesign, new EdgirLibrary(library), Refinements())
+    val compiled = compiler.compile()
+
+
+    // TEMPORARILY HERE REMOVE ME
+    compiled.contents.get.constraints should equal(referenceConstraints)
+
+
 
     val dsv = new DesignStructuralValidate()
     dsv.map(Design(compiled.contents.get)) should equal(Seq())

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -94,9 +94,6 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
 
     compiled.getContents.constraints should equal(referenceConstraints)
 
-    compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
-        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
-
     compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Elements) should
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
     compiler.getValue(IndirectDesignPath() + "link" + "source" + IndirectStep.Length) should
@@ -115,9 +112,16 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "1" + IndirectStep.Length) should
         equal(Some(IntValue(3)))
 
-    compiled.getContents.links("link").getArray.constraints should equal(referenceLinkArrayConstraints)
+    compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
 
+    val linkPb = compiled.getContents.links("link").getArray
+    linkPb.links.keySet should equal(Set("0", "1", "2"))
+    linkPb.links("0").getLink.getSelfClass should equal(LibraryPath("link"))
+    linkPb.links("1").getLink.getSelfClass should equal(LibraryPath("link"))
+    linkPb.links("2").getLink.getSelfClass should equal(LibraryPath("link"))
 
+    linkPb.constraints should equal(referenceLinkArrayConstraints)
 
         // TEMPORARILY HERE TO MAKE A INCOMPLETE TEST FAILURE
         val dsv = new DesignStructuralValidate()

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -240,11 +240,15 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
           equal(Some(IntValue(paramValue)))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + "param") should
           equal(Some(IntValue(paramValue)))
+      compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "source" + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(true)))
     }
 
     Seq("a", "b", "c").foreach { elementIndex =>
       compiler.getValue(IndirectDesignPath() + "source" + "port" + elementIndex + IndirectStep.ConnectedLink + "param") should
           equal(Some(IntValue(-1)))
+      compiler.getValue(IndirectDesignPath() + "source" + "port" + elementIndex + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(true)))
     }
   }
 
@@ -312,12 +316,16 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
             equal(Some(IntValue(paramValue)))
         compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + sinkIndex + "param") should
             equal(Some(IntValue(paramValue)))
+        compiler.getValue(IndirectDesignPath() + "link" + elementIndex + "sinks" + sinkIndex + IndirectStep.IsConnected) should
+            equal(Some(BooleanValue(true)))
       }
     }
 
     Seq("a", "b", "c").foreach { elementIndex =>
       compiler.getValue(IndirectDesignPath() + "sink" + "port" + elementIndex + IndirectStep.ConnectedLink + "param") should
           equal(Some(IntValue(-1)))
+      compiler.getValue(IndirectDesignPath() + "sink" + "port" + elementIndex + IndirectStep.IsConnected) should
+          equal(Some(BooleanValue(true)))
     }
 
     // Check disconnected-ness

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -80,17 +80,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       "sinks.1.2" -> Constraint.Exported(Ref("sinks", "1", "2"), Ref("2", "sinks", "1")),
     )
 
-//    val (compiler, compiled) = testCompile(inputDesign, library)
-    // TODO remove with above once things fully work
-    import edg.wir.{EdgirLibrary, Refinements}
-    val compiler = new Compiler(inputDesign, new EdgirLibrary(library), Refinements())
-    val compiled = compiler.compile()
-
-//    val dsv = new DesignStructuralValidate()
-//    dsv.map(Design(compiled.contents.get)) should equal(Seq())
-//
-//    val drv = new DesignRefsValidate()
-//    drv.validate(Design(compiled.contents.get)) should equal(Seq())
+    val (compiler, compiled) = testCompile(inputDesign, library)
 
     compiled.getContents.constraints should equal(referenceConstraints)
 
@@ -122,12 +112,5 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     linkPb.links("2").getLink.getSelfClass should equal(LibraryPath("link"))
 
     linkPb.constraints should equal(referenceLinkArrayConstraints)
-
-        // TEMPORARILY HERE TO MAKE A INCOMPLETE TEST FAILURE
-        val dsv = new DesignStructuralValidate()
-        dsv.map(Design(compiled.contents.get)) should equal(Seq())
-
-        val drv = new DesignRefsValidate()
-        drv.validate(Design(compiled.contents.get)) should equal(Seq())
   }
 }

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -3,7 +3,7 @@ package edg.compiler
 import edg.CompilerTestUtil
 import edg.ElemBuilder._
 import edg.ExprBuilder.Ref
-import edg.wir.{DesignPath, IndirectDesignPath, IndirectStep}
+import edg.wir.{IndirectDesignPath, IndirectStep}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -104,14 +104,11 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
 
     val linkPb = compiled.getContents.links("link").getArray
-    linkPb.links.keySet should equal(Set("0", "1", "2"))
-    linkPb.links("0").getLink.getSelfClass should equal(LibraryPath("link"))
-    linkPb.links("1").getLink.getSelfClass should equal(LibraryPath("link"))
-    linkPb.links("2").getLink.getSelfClass should equal(LibraryPath("link"))
-
     linkPb.constraints should equal(referenceLinkArrayConstraints)
 
+    linkPb.links.keySet should equal(Set("0", "1", "2"))
     (0 until 3).foreach { elementIndex =>
+      linkPb.links(elementIndex.toString).getLink.getSelfClass should equal(LibraryPath("link"))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Elements) should
           equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1")))))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Length) should
@@ -160,14 +157,11 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
 
     val linkPb = compiled.getContents.links("link").getArray
-    linkPb.links.keySet should equal(Set("0", "1", "2"))
-    linkPb.links("0").getLink.getSelfClass should equal(LibraryPath("link"))
-    linkPb.links("1").getLink.getSelfClass should equal(LibraryPath("link"))
-    linkPb.links("2").getLink.getSelfClass should equal(LibraryPath("link"))
-
     linkPb.constraints should equal(referenceLinkArrayConstraints)
 
+    linkPb.links.keySet should equal(Set("0", "1", "2"))
     (0 until 3).foreach { elementIndex =>
+      linkPb.links(elementIndex.toString).getLink.getSelfClass should equal(LibraryPath("link"))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Elements) should
           equal(Some(ArrayValue(Seq())))
       compiler.getValue(IndirectDesignPath() + "link" + elementIndex.toString + "sinks" + IndirectStep.Length) should

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -92,7 +92,7 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
 //    val drv = new DesignRefsValidate()
 //    drv.validate(Design(compiled.contents.get)) should equal(Seq())
 
-    compiled.contents.get.constraints should equal(referenceConstraints)
+    compiled.getContents.constraints should equal(referenceConstraints)
 
     compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
@@ -114,6 +114,9 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
         equal(Some(ArrayValue(Seq(TextValue("0"), TextValue("1"), TextValue("2")))))
     compiler.getValue(IndirectDesignPath() + "link" + "sinks" + "1" + IndirectStep.Length) should
         equal(Some(IntValue(3)))
+
+    compiled.getContents.links("link").getArray.constraints should equal(referenceLinkArrayConstraints)
+
 
 
         // TEMPORARILY HERE TO MAKE A INCOMPLETE TEST FAILURE

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -320,12 +320,12 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       "source1Connect.a" -> Constraint.Connected(Ref("source1", "port", "a"), Ref("link1", "source", "a")),
       "source1Connect.b" -> Constraint.Connected(Ref("source1", "port", "b"), Ref("link1", "source", "b")),
       "source1Connect.c" -> Constraint.Connected(Ref("source1", "port", "c"), Ref("link1", "source", "c")),
-      "sinkConnect0.a" -> Constraint.Connected(Ref("sink", "port", "n0.a"), Ref("link0", "sinks", "0", "a")),
-      "sinkConnect0.b" -> Constraint.Connected(Ref("sink", "port", "n0.b"), Ref("link0", "sinks", "0", "b")),
-      "sinkConnect0.c" -> Constraint.Connected(Ref("sink", "port", "n0.c"), Ref("link0", "sinks", "0", "c")),
-      "sinkConnect1.a" -> Constraint.Connected(Ref("sink", "port", "n1.a"), Ref("link1", "sinks", "0", "a")),
-      "sinkConnect1.b" -> Constraint.Connected(Ref("sink", "port", "n1.b"), Ref("link1", "sinks", "0", "b")),
-      "sinkConnect1.c" -> Constraint.Connected(Ref("sink", "port", "n1.c"), Ref("link1", "sinks", "0", "c")),
+      "sinkConnect0.a" -> Constraint.Connected(Ref("sink", "port", "n0_a"), Ref("link0", "sinks", "0", "a")),
+      "sinkConnect0.b" -> Constraint.Connected(Ref("sink", "port", "n0_b"), Ref("link0", "sinks", "0", "b")),
+      "sinkConnect0.c" -> Constraint.Connected(Ref("sink", "port", "n0_c"), Ref("link0", "sinks", "0", "c")),
+      "sinkConnect1.a" -> Constraint.Connected(Ref("sink", "port", "n1_a"), Ref("link1", "sinks", "0", "a")),
+      "sinkConnect1.b" -> Constraint.Connected(Ref("sink", "port", "n1_b"), Ref("link1", "sinks", "0", "b")),
+      "sinkConnect1.c" -> Constraint.Connected(Ref("sink", "port", "n1_c"), Ref("link1", "sinks", "0", "c")),
     )
 
     val (compiler, compiled) = testCompile(inputDesign, library)
@@ -340,11 +340,13 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
     // Don't need to test ELEMENTS, that is out of scope - typically would be handled by a generator
     compiler.getValue(IndirectDesignPath() + "sink" + "port" + IndirectStep.Allocated) should
         equal(Some(ArrayValue(Seq(
-          TextValue("n0.a"), TextValue("n0.b"), TextValue("n0.c"),
-          TextValue("n1.a"), TextValue("n1.b"), TextValue("n1.c")
+          TextValue("n0_a"), TextValue("n0_b"), TextValue("n0_c"),
+          TextValue("n1_a"), TextValue("n1_b"), TextValue("n1_c")
         ))))
+    compiled.getContents.blocks("sink").getHierarchy.ports("port").getArray.getPorts.ports.keySet should equal(
+      Set("n0_a", "n0_b", "n0_c", "n1_a", "n1_b", "n1_c"))
 
-    Seq("n0.a", "n0.b", "n0.c", "n1.a", "n1.b", "n1.c").foreach { elementIndex =>
+    Seq("n0_a", "n0_b", "n0_c", "n1_a", "n1_b", "n1_c").foreach { elementIndex =>
       compiler.getValue(IndirectDesignPath() + "sink" + "port" + elementIndex + IndirectStep.ConnectedLink + "param") should
           equal(Some(IntValue(-1)))
     }

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -72,12 +72,12 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       "source.1" -> Constraint.Exported(Ref("source", "1"), Ref("1", "source")),
       "source.2" -> Constraint.Exported(Ref("source", "2"), Ref("2", "source")),
 
-      "sink.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
-      "sink.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
-      "sink.0.2" -> Constraint.Exported(Ref("sinks", "0", "2"), Ref("2", "sinks", "0")),
-      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
-      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
-      "sink.2.0" -> Constraint.Exported(Ref("sinks", "1", "2"), Ref("2", "sinks", "1")),
+      "sinks.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
+      "sinks.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
+      "sinks.0.2" -> Constraint.Exported(Ref("sinks", "0", "2"), Ref("2", "sinks", "0")),
+      "sinks.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
+      "sinks.1.1" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
+      "sinks.1.2" -> Constraint.Exported(Ref("sinks", "1", "2"), Ref("2", "sinks", "1")),
     )
 
 //    val (compiler, compiled) = testCompile(inputDesign, library)

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -254,8 +254,8 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       constraints = Map(
         "source0Connect" -> Constraint.ConnectedArray(Ref("source0", "port"), Ref("link0", "source")),
         "source1Connect" -> Constraint.ConnectedArray(Ref("source1", "port"), Ref("link1", "source")),
-        "sinkConnect0" -> Constraint.ConnectedArray(Ref.Allocate(Ref("sink", "port"), None), Ref.Allocate(Ref("link0", "sinks"))),
-        "sinkConnect1" -> Constraint.ConnectedArray(Ref.Allocate(Ref("sink", "port"), None), Ref.Allocate(Ref("link1", "sinks"))),
+        "sinkConnect0" -> Constraint.ConnectedArray(Ref.Allocate(Ref("sink", "port")), Ref.Allocate(Ref("link0", "sinks"))),
+        "sinkConnect1" -> Constraint.ConnectedArray(Ref.Allocate(Ref("sink", "port")), Ref.Allocate(Ref("link1", "sinks"))),
       )
     ))
     val referenceConstraints = Map(  // expected constraints in the top-level design
@@ -277,10 +277,76 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
 
     compiled.getContents.constraints should equal(referenceConstraints)
 
-    compiler.getValue(IndirectDesignPath() + "link" + IndirectStep.Elements) should
+    compiler.getValue(IndirectDesignPath() + "link0" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
+    compiler.getValue(IndirectDesignPath() + "link1" + IndirectStep.Elements) should
         equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
 
+    // Don't need to test ELEMENTS, that is out of scope
+    compiler.getValue(IndirectDesignPath() + "sink" + "port" + IndirectStep.Allocated) should
+        equal(Some(ArrayValue(Seq(
+          TextValue("0"), TextValue("1"), TextValue("2"),
+          TextValue("3"), TextValue("4"), TextValue("5")
+        ))))
 
+    Seq("0", "1", "2", "3", "4", "5").foreach { elementIndex =>
+      compiler.getValue(IndirectDesignPath() + "sink" + "port" + elementIndex + IndirectStep.ConnectedLink + "param") should
+          equal(Some(IntValue(-1)))
+    }
+  }
 
+  "Compiler on design with block-side-named-allocated link-arrays" should "work" in {
+    val inputDesign = Design(Block.Block("topDesign",
+      blocks = Map(
+        "source0" -> Block.Library("sourceBlock"),
+        "source1" -> Block.Library("sourceBlock"),
+        "sink" -> Block.Library("elasticSinkBlock"),
+      ),
+      links = Map(
+        "link0" -> Link.Array("link"),
+        "link1" -> Link.Array("link"),
+      ),
+      constraints = Map(
+        "source0Connect" -> Constraint.ConnectedArray(Ref("source0", "port"), Ref("link0", "source")),
+        "source1Connect" -> Constraint.ConnectedArray(Ref("source1", "port"), Ref("link1", "source")),
+        "sinkConnect0" -> Constraint.ConnectedArray(Ref.Allocate(Ref("sink", "port"), Some("n0")), Ref.Allocate(Ref("link0", "sinks"))),
+        "sinkConnect1" -> Constraint.ConnectedArray(Ref.Allocate(Ref("sink", "port"), Some("n1")), Ref.Allocate(Ref("link1", "sinks"))),
+      )
+    ))
+    val referenceConstraints = Map(  // expected constraints in the top-level design
+      "source0Connect.a" -> Constraint.Connected(Ref("source0", "port", "a"), Ref("link0", "source", "a")),
+      "source0Connect.b" -> Constraint.Connected(Ref("source0", "port", "b"), Ref("link0", "source", "b")),
+      "source0Connect.c" -> Constraint.Connected(Ref("source0", "port", "c"), Ref("link0", "source", "c")),
+      "source1Connect.a" -> Constraint.Connected(Ref("source1", "port", "a"), Ref("link1", "source", "a")),
+      "source1Connect.b" -> Constraint.Connected(Ref("source1", "port", "b"), Ref("link1", "source", "b")),
+      "source1Connect.c" -> Constraint.Connected(Ref("source1", "port", "c"), Ref("link1", "source", "c")),
+      "sinkConnect0.a" -> Constraint.Connected(Ref("sink", "port", "n0.a"), Ref("link0", "sinks", "0", "a")),
+      "sinkConnect0.b" -> Constraint.Connected(Ref("sink", "port", "n0.b"), Ref("link0", "sinks", "0", "b")),
+      "sinkConnect0.c" -> Constraint.Connected(Ref("sink", "port", "n0.c"), Ref("link0", "sinks", "0", "c")),
+      "sinkConnect1.a" -> Constraint.Connected(Ref("sink", "port", "n1.a"), Ref("link1", "sinks", "0", "a")),
+      "sinkConnect1.b" -> Constraint.Connected(Ref("sink", "port", "n1.b"), Ref("link1", "sinks", "0", "b")),
+      "sinkConnect1.c" -> Constraint.Connected(Ref("sink", "port", "n1.c"), Ref("link1", "sinks", "0", "c")),
+    )
+
+    val (compiler, compiled) = testCompile(inputDesign, library)
+
+    compiled.getContents.constraints should equal(referenceConstraints)
+
+    compiler.getValue(IndirectDesignPath() + "link0" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
+    compiler.getValue(IndirectDesignPath() + "link1" + IndirectStep.Elements) should
+        equal(Some(ArrayValue(Seq(TextValue("a"), TextValue("b"), TextValue("c")))))
+
+    // Don't need to test ELEMENTS, that is out of scope - typically would be handled by a generator
+    compiler.getValue(IndirectDesignPath() + "sink" + "port" + IndirectStep.Allocated) should
+        equal(Some(ArrayValue(Seq(
+          TextValue("n0.a"), TextValue("n0.b"), TextValue("n0.c"),
+          TextValue("n1.a"), TextValue("n1.b"), TextValue("n1.c")
+        ))))
+
+    Seq("n0.a", "n0.b", "n0.c", "n1.a", "n1.b", "n1.c").foreach { elementIndex =>
+      compiler.getValue(IndirectDesignPath() + "sink" + "port" + elementIndex + IndirectStep.ConnectedLink + "param") should
+          equal(Some(IntValue(-1)))
+    }
   }
 }

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkArrayExpansionTest.scala
@@ -51,27 +51,27 @@ class CompilerLinkArrayExpansionTest extends AnyFlatSpec with CompilerTestUtil {
       ),
       constraints = Map(
         "sourceConnect" -> Constraint.ConnectedArray(Ref("source", "port"), Ref("link", "source")),
-//        "sink0Connect" -> Constraint.ConnectedArray(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
-//        "sink1Connect" -> Constraint.ConnectedArray(Ref("sink1", "port"), Ref.Allocate(Ref("link", "sinks"))),
+        "sink0Connect" -> Constraint.ConnectedArray(Ref("sink0", "port"), Ref.Allocate(Ref("link", "sinks"))),
+        "sink1Connect" -> Constraint.ConnectedArray(Ref("sink1", "port"), Ref.Allocate(Ref("link", "sinks"))),
       )
     ))
     val referenceConstraints = Map(  // expected constraints in the top-level design
       "sourceConnect.0" -> Constraint.Connected(Ref("source", "port", "0"), Ref("link", "source", "0")),
       "sourceConnect.1" -> Constraint.Connected(Ref("source", "port", "1"), Ref("link", "source", "1")),
 
-//      "sink0Connect.0" -> Constraint.Connected(Ref("sink0", "port", "0"), Ref("link", "sinks", "0", "0")),
-//      "sink0Connect.1" -> Constraint.Connected(Ref("sink0", "port", "1"), Ref("link", "sinks", "0", "1")),
-//      "sink1Connect.0" -> Constraint.Connected(Ref("sink1", "port", "0"), Ref("link", "sinks", "1", "0")),
-//      "sink1Connect.1" -> Constraint.Connected(Ref("sink1", "port", "1"), Ref("link", "sinks", "1", "1")),
+      "sink0Connect.0" -> Constraint.Connected(Ref("sink0", "port", "0"), Ref("link", "sinks", "0", "0")),
+      "sink0Connect.1" -> Constraint.Connected(Ref("sink0", "port", "1"), Ref("link", "sinks", "0", "1")),
+      "sink1Connect.0" -> Constraint.Connected(Ref("sink1", "port", "0"), Ref("link", "sinks", "1", "0")),
+      "sink1Connect.1" -> Constraint.Connected(Ref("sink1", "port", "1"), Ref("link", "sinks", "1", "1")),
     )
     val referenceLinkArrayConstraints = Map(  // expected constraints in the link array
       "source.0" -> Constraint.Exported(Ref("source", "0"), Ref("0", "source")),
       "source.1" -> Constraint.Exported(Ref("source", "1"), Ref("1", "source")),
 
-//      "sink.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
-//      "sink.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
-//      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
-//      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
+      "sink.0.0" -> Constraint.Exported(Ref("sinks", "0", "0"), Ref("0", "sinks", "0")),
+      "sink.0.1" -> Constraint.Exported(Ref("sinks", "0", "1"), Ref("1", "sinks", "0")),
+      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "0"), Ref("0", "sinks", "1")),
+      "sink.1.0" -> Constraint.Exported(Ref("sinks", "1", "1"), Ref("1", "sinks", "1")),
     )
 
     val (compiler, compiled) = testCompile(inputDesign, library)

--- a/compiler/src/test/scala/edg/compiler/CompilerLinkPortArrayExpansionTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerLinkPortArrayExpansionTest.scala
@@ -138,7 +138,7 @@ class CompilerLinkPortArrayExpansionTest extends AnyFlatSpec with CompilerTestUt
         "link" -> Link.Link(selfClass="link",
           ports = Map(
             "source" -> Port.Port(selfClass="sourcePort"),
-            "sinks" -> Port.Array(selfClass="sinkPort", 3, Port.Port(selfClass="sinkPort")),
+            "sinks" -> Port.Array(selfClass="sinkPort", Seq("0", "1", "2"), Port.Port(selfClass="sinkPort")),
           )
         )
       ),
@@ -196,7 +196,7 @@ class CompilerLinkPortArrayExpansionTest extends AnyFlatSpec with CompilerTestUt
         "link" -> Link.Link(selfClass="link",
           ports = Map(
             "source" -> Port.Port(selfClass="sourcePort"),
-            "sinks" -> Port.Array(selfClass="sinkPort", 0, Port.Port(selfClass="sinkPort")),
+            "sinks" -> Port.Array(selfClass="sinkPort", Seq(), Port.Port(selfClass="sinkPort")),
           )
         )
       ),

--- a/edg_core/Array.py
+++ b/edg_core/Array.py
@@ -277,7 +277,8 @@ class Vector(BaseVector, Generic[VectorType]):
     assert self._is_bound(), "not bound, can't allocate array elements"
     block_parent = self._block_parent()
     assert isinstance(block_parent, Block), "can only allocate from ports of a Block"
-    assert builder.get_enclosing_block() is block_parent._parent, "can only allocate ports of internal blocks"
+    assert builder.get_enclosing_block() is block_parent._parent or builder.get_enclosing_block() is None, \
+      "can only allocate ports of internal blocks"  # None case is to allow elaborating in unit tests
     # self._elts is ignored, since that defines the inner-facing behavior, which this is outer-facing behavior
     allocated = type(self._tpe).empty()._bind(self)
     self._allocates.append((suggested_name, allocated))

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -118,7 +118,7 @@ class NewConnectedPorts():
       elif is_vectors == {True}:  # vector connect case
         is_link_array = True
       else:
-        raise UnconnectableError(f"Can't connect vector and non-vector types without flattening")
+        raise UnconnectableError(f"Can't connect array and non-array types without flattening")
 
       link_facing_ports_by_type: Dict[Type[Port], List[BasePort]] = {}
       for port in link_facing_ports:
@@ -133,7 +133,7 @@ class NewConnectedPorts():
           for port in port_type_ports:
             link_facing_connections.append((port, link_ref_map[link_port]))
         else:  # single port, can only connect one thing
-          if len(port_type_ports) > 1 or (not is_link_array and isinstance(port_type_ports[0], Vector)):
+          if len(port_type_ports) > 1 or (not is_link_array and not self.flatten and isinstance(port_type_ports[0], Vector)):
               raise UnconnectableError(f"Multiple connect {port_type_ports} to non-array {link_port}")
           link_facing_connections.append((port_type_ports[0], link_ref_map[link_port]))
       link_facing_connections_dict = IdentityDict(link_facing_connections)

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -110,7 +110,7 @@ class NewConnectedPorts():
         link = link_type()
       else:
         raise UnconnectableError(f"Ambiguous link {link_types} for connection between {ports}")
-      link_ports_by_type: Dict[Port, List[BasePort]] = {}  # sorted by port order; mutable and consumed as allocated
+      link_ports_by_type: Dict[Type[Port], List[BasePort]] = {}  # sorted by port order; mutable and consumed as allocated
       for name, port in link._ports.items():
         link_ports_by_type.setdefault(type(self._baseport_leaf_type(port)), []).append(port)
       link_ref_map = link._get_ref_map_allocate(edgir.LocalPath())

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -73,7 +73,7 @@ class NewConnectedPorts():
       ports_vectors = set([isinstance(port, BaseVector) for port in ports])
       ports_link_types = set([self._baseport_leaf_type(port).link_type for port in ports])
       if len(ports_link_types) == 1:
-        port_link_type = ports_link_types.pop()
+        link = ports_link_types.pop()()
       else:
         raise ValueError(f"Ambiguous link {ports_link_types} for connection between {ports}")
 
@@ -84,9 +84,13 @@ class NewConnectedPorts():
       else:
         raise ValueError(f"Can't connect vector and non-vector types without flattening")
 
+      # TODO HANDLE BRIDGING
+
       ports_by_type: Dict[Type[Port], List[BasePort]] = {}
       for port in ports:
         ports_by_type.setdefault(type(self._baseport_leaf_type(port)), []).append(port)
+
+      for (port_type, port_type_ports) in ports_by_type.items():  # assign to link ports
 
 
 

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -387,6 +387,10 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
 
     return ImplicitScope(self, implicits)
 
+  def connect(self, *connects: Union[BasePort, Connection], flatten=False) -> Connection:
+    assert not flatten, "flatten only allowed in links"
+    return super().connect(*connects, flatten=flatten)
+
   CastableType = TypeVar('CastableType')
   from .ConstraintExpr import BoolLike, BoolExpr, FloatLike, FloatExpr, RangeLike, RangeExpr
   # type ignore is needed because IntLike overlaps BoolLike

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -5,7 +5,7 @@ from typing import *
 import edgir
 from .Array import BaseVector, Vector
 from .Binding import InitParamBinding, AssignBinding
-from .Blocks import BaseBlock, ConnectedPorts, NewConnectedPorts
+from .Blocks import BaseBlock, NewConnectedPorts
 from .ConstraintExpr import BoolLike, FloatLike, IntLike, RangeLike, StringLike
 from .ConstraintExpr import ConstraintExpr, BoolExpr, FloatExpr, IntExpr, RangeExpr, StringExpr
 from .Core import Refable, non_library

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -113,7 +113,7 @@ def init_in_parent(fn: InitType) -> InitType:
 class ImplicitConnect:
   """Implicit connect definition. a port and all the implicit connect tags it supports.
   To implicitly connect to a sub-block's port, this tags list must be a superset of the sub-block port's tag list."""
-  def __init__(self, port: Port, tags: List[PortTag]) -> None:
+  def __init__(self, port: Union[Port, Connection], tags: List[PortTag]) -> None:
     self.port = port
     self.tags = set(tags)
 
@@ -328,13 +328,13 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
 
     return pb
 
-  def chain(self, *elts: Union[BasePort, Block]) -> ChainConnect:
+  def chain(self, *elts: Union[Connection, BasePort, Block]) -> ChainConnect:
     if not elts:
       return self._chains.register(ChainConnect([], []))
     chain_blocks = []
     chain_links = []
 
-    if isinstance(elts[0], BasePort):
+    if isinstance(elts[0], (BasePort, Connection)):
       current_port = elts[0]
     elif isinstance(elts[0], Block):
       outable_ports = elts[0]._get_ports_by_tag({Output}) + elts[0]._get_ports_by_tag({InOut})

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -249,7 +249,11 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
 
       elif isinstance(connect_elts, NewConnectedPorts.Connection):  # generate link
         link_path = edgir.localpath_concat(edgir.LocalPath(), name)
-        pb.links[name].lib_elem.target.name = connect_elts.link_type._static_def_name()
+
+        if connect_elts.is_link_array:
+          pb.links[name].array.self_class.target.name = connect_elts.link_type._static_def_name()
+        else:
+          pb.links[name].lib_elem.target.name = connect_elts.link_type._static_def_name()
         self._namespace_order.append(f"{name}")
 
         for idx, (self_port, link_port_path) in enumerate(connect_elts.bridged_connects):

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -4,7 +4,7 @@ from typing import *
 
 import edgir
 from .Array import BaseVector, DerivedVector
-from .Blocks import BaseBlock, NewConnectedPorts
+from .Blocks import BaseBlock, Connection
 from .Core import Refable, non_library
 from .Exceptions import *
 from .IdentityDict import IdentityDict
@@ -48,7 +48,7 @@ class Link(BaseBlock[edgir.Link]):
       self._links_order[str(len(self._links_order))] = f"{name}"
 
       connect_elts = connect.make_connection(self, True)
-      assert isinstance(connect_elts, NewConnectedPorts.Connection)
+      assert isinstance(connect_elts, Connection.ConnectedLink)
 
       link_path = edgir.localpath_concat(edgir.LocalPath(), name)
       pb.links[name].lib_elem.target.name = connect_elts.link_type._static_def_name()

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -54,8 +54,8 @@ class Link(BaseBlock[edgir.Link]):
       pb.links[name].lib_elem.target.name = connect_elts.link_type._static_def_name()
 
       assert not connect_elts.is_link_array
-
-      for idx, (self_port, link_port_path) in enumerate(connect_elts.bridged_connects):
+      assert not connect_elts.bridged_connects
+      for idx, (self_port, link_port_path) in enumerate(connect_elts.link_connects):
         if isinstance(self_port, BaseVector):
           assert isinstance(self_port, DerivedVector)
           pb.constraints[f"(export){name}_{idx}"].exportedArray.exterior_port.map_extract.container.ref.CopyFrom(ref_map[self_port.base])

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -47,7 +47,7 @@ class Link(BaseBlock[edgir.Link]):
     for name, connect in self._connects.items_ordered():
       self._links_order[str(len(self._links_order))] = f"{name}"
 
-      connect_elts = connect.make_connection(self, True)
+      connect_elts = connect.make_connection(self)
       assert isinstance(connect_elts, Connection.ConnectedLink)
 
       link_path = edgir.localpath_concat(edgir.LocalPath(), name)

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -47,7 +47,7 @@ class Link(BaseBlock[edgir.Link]):
     for name, connect in self._connects.items_ordered():
       self._links_order[str(len(self._links_order))] = f"{name}"
 
-      connect_elts = connect.generate_connections()
+      connect_elts = connect.make_connection(self, True)
       assert connect_elts is not None and connect_elts.link_type is not None, "bad connect definition in link"
 
       link_path = edgir.localpath_concat(edgir.LocalPath(), name)

--- a/edg_core/ScalaCompilerInterface.py
+++ b/edg_core/ScalaCompilerInterface.py
@@ -80,7 +80,8 @@ class ScalaCompilerInstance:
     self.request_serializer.write(request)
     result = self.response_deserializer.read()
     assert result is not None
-    assert result.HasField('design'), f"no compiled result, with error {result.error}"
+    if not result.HasField('design'):
+      raise CompilerCheckError(f"no compiled result, with error {result.error}")
     if result.error and errors_fatal:
       raise CompilerCheckError(f"error during compilation: \n{result.error}")
     return CompiledDesign(result)

--- a/edg_core/TransformUtil.py
+++ b/edg_core/TransformUtil.py
@@ -76,12 +76,9 @@ class Path(NamedTuple):  # internal helper type
       return None, (self, curr)
     elif steps[0].HasField('name'):
       name = steps[0].name
-      if (isinstance(curr, edgir.Port) or isinstance(curr, edgir.Bundle) or
-          isinstance(curr, edgir.HierarchyBlock) or isinstance(curr, edgir.Link)) \
-          and name in curr.params:
+      if isinstance(curr, (edgir.Port, edgir.Bundle, edgir.HierarchyBlock, edgir.Link)) and name in curr.params:
         return self.append_param(name)._follow_partial_steps(steps[1:], curr.params[name])
-      elif (isinstance(curr, edgir.Bundle) or isinstance(curr, edgir.Link) or
-            isinstance(curr, edgir.HierarchyBlock)) and name in curr.ports:
+      elif isinstance(curr, (edgir.Bundle, edgir.Link, edgir.HierarchyBlock, edgir.LinkArray)) and name in curr.ports:
         path = self.append_port(name)
         port = edgir.resolve_portlike(curr.ports[name])
         return path._follow_partial_steps(steps[1:], port)
@@ -91,7 +88,7 @@ class Path(NamedTuple):  # internal helper type
         return path._follow_partial_steps(steps[1:], port)
       elif isinstance(curr, edgir.HierarchyBlock) and name in curr.blocks:
         return self.append_block(name)._follow_partial_steps(steps[1:], edgir.resolve_blocklike(curr.blocks[name]))
-      elif (isinstance(curr, edgir.HierarchyBlock) or isinstance(curr, edgir.Link)) and name in curr.links.keys():
+      elif isinstance(curr, (edgir.HierarchyBlock, edgir.Link, edgir.LinkArray)) and name in curr.links.keys():
         return self.append_link(name)._follow_partial_steps(steps[1:], edgir.resolve_linklike(curr.links[name]))
       else:
         return steps, (self, curr)

--- a/edg_core/TransformUtil.py
+++ b/edg_core/TransformUtil.py
@@ -149,6 +149,9 @@ class Transform():
   def visit_link(self, context: TransformContext, link: edgir.Link) -> None:
     pass
 
+  def visit_linkarray(self, context: TransformContext, link: edgir.LinkArray) -> None:
+    pass
+
   # The visit_*like allows changing the "type", eg lib -> instantiated h-block
   def visit_blocklike(self, context: TransformContext, block: edgir.BlockLike) -> None:
     pass
@@ -230,6 +233,18 @@ class Transform():
         self._traverse_portlike(context.append_port(name), port)
 
       for name, link in elt.link.links.items():
+        self._traverse_linklike(context.append_link(name), link)
+    elif elt.HasField('array'):
+      try:
+        self.visit_linkarray(context, elt.array)
+      except Exception as e:
+        raise type(e)(f"(while visiting LinkArray at {context}) " + str(e)) \
+          .with_traceback(sys.exc_info()[2])
+
+      for name, port in elt.array.ports.items():
+        self._traverse_portlike(context.append_port(name), port)
+
+      for name, link in elt.array.links.items():
         self._traverse_linklike(context.append_link(name), link)
     else:
       raise ValueError(f"_traverse_linklike encountered unknown type {elt} at {context}")

--- a/edg_core/test_connect_array.py
+++ b/edg_core/test_connect_array.py
@@ -1,0 +1,74 @@
+import unittest
+
+import edgir
+from . import *
+from .test_common import TestBlockSource, TestBlockSink, TestPortSource, TestPortSink, List
+
+
+class TestBlockSourceArray(Block):
+  def __init__(self) -> None:
+    super().__init__()
+    self.sources = self.Port(Vector(TestPortSource()))
+    self.sources.append_elt(TestPortSource(), "a")
+    self.sources.append_elt(TestPortSource(), "b")
+
+
+class TestBlockSinkArray(GeneratorBlock):
+  def __init__(self) -> None:
+    super().__init__()
+    self.sinks = self.Port(Vector(TestPortSink()))
+    self.generator(self.generate, self.sinks.allocated())
+
+  def generate(self, allocateds: List[str]):
+    for allocated in allocateds:
+      self.sinks.append_elt(TestPortSink(), allocated)
+
+
+class ArrayConnectBlock(Block):
+  def contents(self):
+    super().contents()
+
+    self.source = self.Block(TestBlockSourceArray())
+    self.sink1 = self.Block(TestBlockSinkArray())
+    self.sink2 = self.Block(TestBlockSinkArray())
+    self.test_net = self.connect(self.source.sources, self.sink1.sinks, self.sink2.sinks)
+
+
+class ArrayConnectProtoTestCase(unittest.TestCase):
+  def setUp(self) -> None:
+    self.pb = ArrayConnectBlock()._elaborated_def_to_proto()
+
+  def test_subblock_def(self) -> None:
+    self.assertEqual(self.pb.blocks['source'].lib_elem.target.name, "edg_core.test_connect_array.TestBlockSourceArray")
+    self.assertEqual(self.pb.blocks['sink1'].lib_elem.target.name, "edg_core.test_connect_array.TestBlockSinkArray")
+    self.assertEqual(self.pb.blocks['sink2'].lib_elem.target.name, "edg_core.test_connect_array.TestBlockSinkArray")
+
+  def test_link_inference(self) -> None:
+    self.assertEqual(len(self.pb.links), 1)
+    self.assertEqual(self.pb.links['test_net'].array.self_class.target.name, "edg_core.test_common.TestLink")
+
+  def test_connectivity(self) -> None:
+    self.assertEqual(len(self.pb.constraints), 3)  # TODO: maybe filter by connection types in future for robustness
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connectedArray.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connectedArray.link_port.ref.steps.add().name = 'source'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'source'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'source'
+    self.assertIn(expected_conn, self.pb.constraints.values())
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connectedArray.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connectedArray.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink1'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, self.pb.constraints.values())
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connectedArray.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connectedArray.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink2'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, self.pb.constraints.values())

--- a/edg_core/test_connect_array.py
+++ b/edg_core/test_connect_array.py
@@ -2,7 +2,7 @@ import unittest
 
 import edgir
 from . import *
-from .test_common import TestBlockSource, TestBlockSink, TestPortSource, TestPortSink, List
+from .test_common import TestPortSource, TestPortSink, List
 
 
 class TestBlockSourceFixedArray(Block):
@@ -82,15 +82,13 @@ class ArrayAllocatedConnectBlock(Block):
 
 class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):
   def setUp(self) -> None:
-    self.pb = ArrayConnectBlock()._elaborated_def_to_proto()
+    self.pb = ArrayAllocatedConnectBlock()._elaborated_def_to_proto()
 
   def test_link_inference(self) -> None:
     self.assertEqual(len(self.pb.links), 1)
     self.assertEqual(self.pb.links['test_net'].array.self_class.target.name, "edg_core.test_common.TestLink")
 
   def test_connectivity(self) -> None:
-    self.assertEqual(len(self.pb.constraints), 4)
-
     expected_conn = edgir.ValueExpr()
     expected_conn.connectedArray.link_port.ref.steps.add().name = 'test_net1'
     expected_conn.connectedArray.link_port.ref.steps.add().name = 'source'
@@ -122,3 +120,5 @@ class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sinks'
     expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
     self.assertIn(expected_conn, self.pb.constraints.values())
+
+    self.assertEqual(len(self.pb.constraints), 4)

--- a/edg_core/test_connect_array.py
+++ b/edg_core/test_connect_array.py
@@ -54,7 +54,7 @@ class ArrayConnectProtoTestCase(unittest.TestCase):
     expected_conn.connectedArray.link_port.ref.steps.add().name = 'test_net'
     expected_conn.connectedArray.link_port.ref.steps.add().name = 'source'
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'source'
-    expected_conn.connectedArray.block_port.ref.steps.add().name = 'source'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sources'
     self.assertIn(expected_conn, self.pb.constraints.values())
 
     expected_conn = edgir.ValueExpr()
@@ -62,7 +62,7 @@ class ArrayConnectProtoTestCase(unittest.TestCase):
     expected_conn.connectedArray.link_port.ref.steps.add().name = 'sinks'
     expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink1'
-    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sinks'
     self.assertIn(expected_conn, self.pb.constraints.values())
 
     expected_conn = edgir.ValueExpr()
@@ -70,5 +70,5 @@ class ArrayConnectProtoTestCase(unittest.TestCase):
     expected_conn.connectedArray.link_port.ref.steps.add().name = 'sinks'
     expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink2'
-    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink'
+    expected_conn.connectedArray.block_port.ref.steps.add().name = 'sinks'
     self.assertIn(expected_conn, self.pb.constraints.values())

--- a/edg_core/test_connect_array.py
+++ b/edg_core/test_connect_array.py
@@ -76,8 +76,8 @@ class ArrayAllocatedConnectBlock(Block):
     self.source1 = self.Block(TestBlockSourceFixedArray())
     self.source2 = self.Block(TestBlockSourceFixedArray())
     self.sink = self.Block(TestBlockSinkElasticArray())
-    self.test_net1 = self.connect(self.source1.sources, self.sink.sinks.allocate())
-    self.test_net2 = self.connect(self.source2.sources, self.sink.sinks.allocate())
+    self.test_net1 = self.connect(self.source1.sources, self.sink.sinks.allocate_vector())
+    self.test_net2 = self.connect(self.source2.sources, self.sink.sinks.allocate_vector())
 
 
 class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):
@@ -85,8 +85,9 @@ class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):
     self.pb = ArrayAllocatedConnectBlock()._elaborated_def_to_proto()
 
   def test_link_inference(self) -> None:
-    self.assertEqual(len(self.pb.links), 1)
-    self.assertEqual(self.pb.links['test_net'].array.self_class.target.name, "edg_core.test_common.TestLink")
+    self.assertEqual(len(self.pb.links), 2)
+    self.assertEqual(self.pb.links['test_net1'].array.self_class.target.name, "edg_core.test_common.TestLink")
+    self.assertEqual(self.pb.links['test_net2'].array.self_class.target.name, "edg_core.test_common.TestLink")
 
   def test_connectivity(self) -> None:
     expected_conn = edgir.ValueExpr()
@@ -102,7 +103,7 @@ class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):
     expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink'
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sinks'
-    expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
+    expected_conn.connectedArray.block_port.ref.steps.add().allocate = ''
     self.assertIn(expected_conn, self.pb.constraints.values())
 
     expected_conn = edgir.ValueExpr()
@@ -118,7 +119,7 @@ class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):
     expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sink'
     expected_conn.connectedArray.block_port.ref.steps.add().name = 'sinks'
-    expected_conn.connectedArray.link_port.ref.steps.add().allocate = ''
+    expected_conn.connectedArray.block_port.ref.steps.add().allocate = ''
     self.assertIn(expected_conn, self.pb.constraints.values())
 
     self.assertEqual(len(self.pb.constraints), 4)

--- a/edg_core/test_hierarchy_block.py
+++ b/edg_core/test_hierarchy_block.py
@@ -66,9 +66,11 @@ class MultiConnectBlock(Block):
     self.source = self.Block(TestBlockSource())
     self.sink1 = self.Block(TestBlockSink())
     self.sink2 = self.Block(TestBlockSink())
+    self.sink3 = self.Block(TestBlockSink())
 
     self.test_net = self.connect(self.source.source, self.sink1.sink)
     self.connect(self.source.source, self.sink2.sink)  # not named, to not conflict with the first
+    self.connect(self.test_net, self.sink3.sink)
 
 
 class MultiConnectBlockProtoTestCase(unittest.TestCase):
@@ -76,7 +78,7 @@ class MultiConnectBlockProtoTestCase(unittest.TestCase):
     self.pb = MultiConnectBlock()._elaborated_def_to_proto()
 
   def test_connectivity(self) -> None:
-    self.assertEqual(len(self.pb.constraints), 3)
+    self.assertEqual(len(self.pb.constraints), 4)
 
     expected_conn = edgir.ValueExpr()
     expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
@@ -98,6 +100,14 @@ class MultiConnectBlockProtoTestCase(unittest.TestCase):
     expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
     expected_conn.connected.link_port.ref.steps.add().allocate = ''
     expected_conn.connected.block_port.ref.steps.add().name = 'sink2'
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, self.pb.constraints.values())
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink3'
     expected_conn.connected.block_port.ref.steps.add().name = 'sink'
     self.assertIn(expected_conn, self.pb.constraints.values())
 

--- a/edg_core/test_inner_link.py
+++ b/edg_core/test_inner_link.py
@@ -13,8 +13,10 @@ class TestBundleLink(Link):
     self.source = self.Port(TestBundleSource())
     self.sinks = self.Port(Vector(TestBundleSink()))
 
-    self.a_net = self.connect(self.source.a, self.sinks.map_extract(lambda x: x.a))
-    self.b_net = self.connect(self.source.b, self.sinks.map_extract(lambda x: x.b))
+    self.a_net = self.connect(self.source.a, self.sinks.map_extract(lambda x: x.a),
+                              flatten=True)
+    self.b_net = self.connect(self.source.b, self.sinks.map_extract(lambda x: x.b),
+                              flatten=True)
 
 
 class TestBundleSource(Bundle[TestBundleLink]):

--- a/edgir/__init__.py
+++ b/edgir/__init__.py
@@ -5,7 +5,7 @@ from .init_pb2 import ValInit
 from .name_pb2 import *
 from .impl_pb2 import *
 from .ref_pb2 import LibraryPath, LocalPath, LocalStep, CONNECTED_LINK, IS_CONNECTED, LENGTH, ALLOCATED, NAME
-from .elem_pb2 import Port, PortArray, PortLike, Bundle, HierarchyBlock, BlockLike, Link, LinkLike
+from .elem_pb2 import Port, PortArray, PortLike, Bundle, HierarchyBlock, BlockLike, Link, LinkArray, LinkLike
 from .schema_pb2 import Library, Design
 from .expr_pb2 import ConnectedExpr, ExportedExpr, ValueExpr, BinaryExpr, \
   BinarySetExpr, UnaryExpr, UnarySetExpr, MapExtractExpr
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
 PortTypes = Union[Port, PortArray, Bundle]
 BlockTypes = HierarchyBlock
 BlockLikeTypes = Union[BlockTypes, Link]
-EltTypes = Union[PortTypes, BlockLikeTypes, ValInit]
+LinkTypes = Union[Link, LinkArray]  # LinkArray is not block-like b/c it doesn't have a class and params
+EltTypes = Union[PortTypes, BlockLikeTypes, LinkArray, ValInit]
 
 
 def resolve_blocklike(block: BlockLike) -> BlockTypes:
@@ -31,9 +32,11 @@ def resolve_blocklike(block: BlockLike) -> BlockTypes:
     raise ValueError(f"bad blocklike {block}")
 
 
-def resolve_linklike(link: LinkLike) -> Link:
+def resolve_linklike(link: LinkLike) -> LinkTypes:
   if link.HasField('link'):
     return link.link
+  if link.HasField('array'):
+    return link.array
   else:
     raise ValueError(f"bad linklike {link}")
 

--- a/electronics_lib/Leds.py
+++ b/electronics_lib/Leds.py
@@ -130,44 +130,45 @@ class IndicatorSinkRgbLed(Light):
     super().__init__()
 
     self.pwr = self.Port(VoltageSink.empty(), [Power])
-    self.red = self.Port(DigitalSink.empty())
-    self.green = self.Port(DigitalSink.empty())
-    self.blue = self.Port(DigitalSink.empty())
+    self.signals = self.Port(Vector(DigitalSink.empty()))
+    signal_red = self.signals.append_elt(DigitalSink.empty(), 'red')
+    signal_green = self.signals.append_elt(DigitalSink.empty(), 'green')
+    signal_blue = self.signals.append_elt(DigitalSink.empty(), 'blue')
 
     self.target_current_draw = self.Parameter(RangeExpr(current_draw))
-    self.require(self.red.current_draw.within((-1 * self.target_current_draw.upper(), 0)))
-    self.require(self.green.current_draw.within((-1 * self.target_current_draw.upper(), 0)))
-    self.require(self.blue.current_draw.within((-1 * self.target_current_draw.upper(), 0)))
+    self.require(signal_red.current_draw.within((-1 * self.target_current_draw.upper(), 0)))
+    self.require(signal_green.current_draw.within((-1 * self.target_current_draw.upper(), 0)))
+    self.require(signal_blue.current_draw.within((-1 * self.target_current_draw.upper(), 0)))
     self.require(self.pwr.current_draw.within((0, 3 * self.target_current_draw.upper())))
 
     self.package = self.Block(RgbLedCommonAnode())
 
     self.red_res = self.Block(Resistor(
-      resistance=(self.red.link().voltage.upper() / self.target_current_draw.upper(),
-                  self.red.link().output_thresholds.upper() / self.target_current_draw.lower())))
+      resistance=(signal_red.link().voltage.upper() / self.target_current_draw.upper(),
+                  signal_red.link().output_thresholds.upper() / self.target_current_draw.lower())))
     self.green_res = self.Block(Resistor(
-      resistance=(self.green.link().voltage.upper() / self.target_current_draw.upper(),
-                  self.green.link().output_thresholds.upper() / self.target_current_draw.lower())))
+      resistance=(signal_green.link().voltage.upper() / self.target_current_draw.upper(),
+                  signal_green.link().output_thresholds.upper() / self.target_current_draw.lower())))
     self.blue_res = self.Block(Resistor(
-      resistance=(self.blue.link().voltage.upper() / self.target_current_draw.upper(),
-                  self.blue.link().output_thresholds.upper() / self.target_current_draw.lower())))
+      resistance=(signal_blue.link().voltage.upper() / self.target_current_draw.upper(),
+                  signal_blue.link().output_thresholds.upper() / self.target_current_draw.lower())))
 
     self.connect(self.red_res.a, self.package.k_red)
     self.connect(self.green_res.a, self.package.k_green)
     self.connect(self.blue_res.a, self.package.k_blue)
     self.connect(self.red_res.b.as_digital_sink(
-      current_draw=(-1 * self.red.link().voltage.upper() / self.red_res.actual_resistance.lower(), 0)
-    ), self.red)
+      current_draw=(-1 * signal_red.link().voltage.upper() / self.red_res.actual_resistance.lower(), 0)
+    ), signal_red)
     self.connect(self.green_res.b.as_digital_sink(
-      current_draw=(-1 * self.green.link().voltage.upper() / self.green_res.actual_resistance.lower(), 0)
-    ), self.green)
+      current_draw=(-1 * signal_green.link().voltage.upper() / self.green_res.actual_resistance.lower(), 0)
+    ), signal_green)
     self.connect(self.blue_res.b.as_digital_sink(
-      current_draw=(-1 * self.blue.link().voltage.upper() / self.blue_res.actual_resistance.lower(), 0)
-    ), self.blue)
+      current_draw=(-1 * signal_blue.link().voltage.upper() / self.blue_res.actual_resistance.lower(), 0)
+    ), signal_blue)
 
     self.connect(self.pwr, self.package.a.as_voltage_sink(
       current_draw=(0,
-                    self.red.link().voltage.upper() / self.red_res.actual_resistance.lower() +
-                    self.green.link().voltage.upper() / self.green_res.actual_resistance.lower() +
-                    self.blue.link().voltage.upper() / self.blue_res.actual_resistance.lower())
+                    signal_red.link().voltage.upper() / self.red_res.actual_resistance.lower() +
+                    signal_green.link().voltage.upper() / self.green_res.actual_resistance.lower() +
+                    signal_blue.link().voltage.upper() / self.blue_res.actual_resistance.lower())
     ))

--- a/electronics_lib/PassiveCapacitor.py
+++ b/electronics_lib/PassiveCapacitor.py
@@ -116,7 +116,7 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
   MAX_CAP_PACKAGE = 'Capacitor_SMD:C_1206_3216Metric' # default package for largest possible capacitor
 
   @init_in_parent
-  def __init__(self, *args, footprint_spec: StringLike = "", derating_coeff: FloatLike = 1.0, **kwargs):
+  def __init__(self, *args, footprint: StringLike = "", derating_coeff: FloatLike = 1.0, **kwargs):
     """
     footprint_spec specifies an optional constraint on footprint
     derating_coeff specifies an optional derating coefficient (1.0 = no derating), that does not scale with package.
@@ -124,7 +124,7 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
     super().__init__(*args, **kwargs)
 
     self.generator(self.select_capacitor_no_prod_table, self.capacitance, self.voltage,
-                   footprint_spec, derating_coeff)
+                   footprint, derating_coeff)
 
     # Output values
     self.selected_nominal_capacitance = self.Parameter(RangeExpr())
@@ -177,7 +177,7 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
   ]
 
   def select_capacitor_no_prod_table(self, capacitance: Range, voltage: Range,
-                                     footprint_spec: str, derating_coeff: float) -> None:
+                                     footprint: str, derating_coeff: float) -> None:
     """
     Selects a generic capacitor without using product tables
 
@@ -191,10 +191,10 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
 
     def select_package(nominal_capacitance: float, voltage: Range) -> Optional[str]:
 
-      if footprint_spec == "":
+      if footprint == "":
         package_options = self.PACKAGE_SPECS
       else:
-        package_options = [spec for spec in self.PACKAGE_SPECS if spec.name == footprint_spec]
+        package_options = [spec for spec in self.PACKAGE_SPECS if spec.name == footprint]
 
       for package in package_options:
         if package.max >= nominal_capacitance:
@@ -211,10 +211,10 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
 
       self.assign(self.selected_nominal_capacitance, num_caps * nominal_capacitance)
 
-      if footprint_spec == "":
+      if footprint == "":
         split_package = self.MAX_CAP_PACKAGE
       else:
-        split_package = footprint_spec
+        split_package = footprint
 
       cap_model = DummyCapacitor(capacitance=Range.exact(self.SINGLE_CAP_MAX), voltage=voltage,
                                  footprint=split_package,
@@ -226,13 +226,13 @@ class SmtCeramicCapacitorGeneric(Capacitor, FootprintBlock, GeneratorBlock):
         self.connect(self.c[i].neg, self.neg)
     else:
       value = ESeriesUtil.choose_preferred_number(nominal_capacitance, ESeriesUtil.SERIES[24], 0)
-      assert value is not None, "cannot generate a preferred number"
-      valid_footprint_spec = select_package(value, voltage)
-      assert valid_footprint_spec is not None, "cannot generate a valid footprint spec"
+      assert value is not None, "cannot select a preferred number"
+      valid_footprint = select_package(value, voltage)
+      assert valid_footprint is not None, "cannot select a valid footprint"
       self.assign(self.selected_nominal_capacitance, value)
 
       self.footprint(
-        'C', valid_footprint_spec,
+        'C', valid_footprint,
         {
           '1': self.pos,
           '2': self.neg,

--- a/electronics_lib/test_capacitor_generic.py
+++ b/electronics_lib/test_capacitor_generic.py
@@ -87,7 +87,7 @@ class CapacitorTestCase(unittest.TestCase):
 
   def test_capacitor_footprint(self) -> None:
     compiled = ScalaCompiler.compile(CapacitorGenericTestTop, Refinements(
-      instance_values=[(['dut', 'footprint_spec'], 'Capacitor_SMD:C_1206_3216Metric')]
+      instance_values=[(['dut', 'footprint'], 'Capacitor_SMD:C_1206_3216Metric')]
     ))
     self.assertEqual(compiled.get_value(['dut', 'fp_footprint']), 'Capacitor_SMD:C_1206_3216Metric')
     self.assertEqual(compiled.get_value(['dut', 'fp_value']), '100nF')
@@ -119,7 +119,7 @@ class CapacitorTestCase(unittest.TestCase):
 
   def test_derated_capacitor(self) -> None:
     compiled = ScalaCompiler.compile(DeratedCapacitorGenericTestTop, Refinements(
-      instance_values=[(['dut', 'footprint_spec'], 'Capacitor_SMD:C_1206_3216Metric'),
+      instance_values=[(['dut', 'footprint'], 'Capacitor_SMD:C_1206_3216Metric'),
                        (['dut', 'derating_coeff'], 0.5),]
     ))
     self.assertEqual(compiled.get_value(['dut', 'fp_footprint']), 'Capacitor_SMD:C_1206_3216Metric')
@@ -127,7 +127,7 @@ class CapacitorTestCase(unittest.TestCase):
 
   def test_derated_multi_capacitor(self) -> None:
     compiled = ScalaCompiler.compile(BigMultiCapacitorGenericTestTop, Refinements(
-      instance_values=[(['dut', 'footprint_spec'], 'Capacitor_SMD:C_1206_3216Metric'),
+      instance_values=[(['dut', 'footprint'], 'Capacitor_SMD:C_1206_3216Metric'),
                        (['dut', 'derating_coeff'], 0.5),]
     ))
     self.assertEqual(compiled.get_value(['dut', 'c[0]', 'fp_footprint']), 'Capacitor_SMD:C_1206_3216Metric')

--- a/electronics_model/CanPort.py
+++ b/electronics_model/CanPort.py
@@ -56,8 +56,10 @@ class CanDiffLink(Link):
   def contents(self) -> None:
     super().contents()
 
-    self.canh = self.connect(self.nodes.map_extract(lambda node: node.canh))
-    self.canl = self.connect(self.nodes.map_extract(lambda node: node.canl))
+    self.canh = self.connect(self.nodes.map_extract(lambda node: node.canh),
+                             flatten=True)
+    self.canl = self.connect(self.nodes.map_extract(lambda node: node.canl),
+                             flatten=True)
 
 
 class CanDiffPort(Bundle[CanDiffLink]):

--- a/electronics_model/DebugPorts.py
+++ b/electronics_model/DebugPorts.py
@@ -15,14 +15,14 @@ class SwdLink(Link):
   def contents(self) -> None:
     super().contents()
     
-    self.swdio = self.connect(self.host.swdio, self.device.swdio,
-                              self.pull.map_extract(lambda port: port.swdio))
-    self.swclk = self.connect(self.host.swclk, self.device.swclk,
-                              self.pull.map_extract(lambda port: port.swclk))
-    self.swo = self.connect(self.host.swo, self.device.swo,
-                            self.pull.map_extract(lambda port: port.swo))
-    self.reset = self.connect(self.host.reset, self.device.reset,
-                              self.pull.map_extract(lambda port: port.reset))
+    self.swdio = self.connect(self.host.swdio, self.device.swdio, self.pull.map_extract(lambda port: port.swdio),
+                              flatten=True)
+    self.swclk = self.connect(self.host.swclk, self.device.swclk, self.pull.map_extract(lambda port: port.swclk),
+                              flatten=True)
+    self.swo = self.connect(self.host.swo, self.device.swo, self.pull.map_extract(lambda port: port.swo),
+                            flatten=True)
+    self.reset = self.connect(self.host.reset, self.device.reset, self.pull.map_extract(lambda port: port.reset),
+                              flatten=True)
 
 
 class SwdHostPort(Bundle[SwdLink]):

--- a/electronics_model/I2cPort.py
+++ b/electronics_model/I2cPort.py
@@ -17,12 +17,10 @@ class I2cLink(Link):
     super().contents()
     # TODO define all IDs
 
-    self.scl = self.connect(
-      self.pull.scl,
-      self.master.scl, self.devices.map_extract(lambda device: device.scl))
-    self.sda = self.connect(
-      self.pull.sda,
-      self.master.sda, self.devices.map_extract(lambda device: device.sda))
+    self.scl = self.connect(self.pull.scl, self.master.scl, self.devices.map_extract(lambda device: device.scl),
+                            flatten=True)
+    self.sda = self.connect(self.pull.sda, self.master.sda, self.devices.map_extract(lambda device: device.sda),
+                            flatten=True)
 
 
 class I2cPullupPort(Bundle[I2cLink]):

--- a/electronics_model/NetlistGenerator.py
+++ b/electronics_model/NetlistGenerator.py
@@ -27,7 +27,7 @@ Edges = Dict[TransformUtil.Path, List[TransformUtil.Path]]  # Pins (block name, 
 Names = Dict[TransformUtil.Path, TransformUtil.Path]  # Path -> shortened path name
 Hierarchy = Dict[TransformUtil.Path, str]  # path -> classname
 class NetlistCollect(TransformUtil.Transform):
-  def process_blocklike(self, path: TransformUtil.Path, block: edgir.BlockLikeTypes) -> None:
+  def process_blocklike(self, path: TransformUtil.Path, block: Union[edgir.Link, edgir.LinkArray, edgir.HierarchyBlock]) -> None:
     # generate short paths for children first
     short_path = self.short_paths[path]
 
@@ -185,6 +185,9 @@ class NetlistCollect(TransformUtil.Transform):
     self.process_blocklike(context.path, block)
 
   def visit_link(self, context: TransformUtil.TransformContext, link: edgir.Link) -> None:
+    self.process_blocklike(context.path, link)
+
+  def visit_linkarray(self, context: TransformUtil.TransformContext, link: edgir.LinkArray) -> None:
     self.process_blocklike(context.path, link)
 
   def __init__(self, design: CompiledDesign):

--- a/electronics_model/SpiPort.py
+++ b/electronics_model/SpiPort.py
@@ -12,9 +12,12 @@ class SpiLink(Link):
 
   def contents(self) -> None:
     super().contents()
-    self.sck = self.connect(self.master.sck, self.devices.map_extract(lambda device: device.sck))
-    self.miso = self.connect(self.master.miso, self.devices.map_extract(lambda device: device.miso))
-    self.mosi = self.connect(self.master.mosi, self.devices.map_extract(lambda device: device.mosi))
+    self.sck = self.connect(self.master.sck, self.devices.map_extract(lambda device: device.sck),
+                            flatten=True)
+    self.miso = self.connect(self.master.miso, self.devices.map_extract(lambda device: device.miso),
+                             flatten=True)
+    self.mosi = self.connect(self.master.mosi, self.devices.map_extract(lambda device: device.mosi),
+                             flatten=True)
 
 
 class SpiMaster(Bundle[SpiLink]):

--- a/electronics_model/UsbPort.py
+++ b/electronics_model/UsbPort.py
@@ -15,10 +15,10 @@ class UsbLink(Link):
     super().contents()
     # TODO write protocol-level signal constraints?
 
-    self.d_P = self.connect(self.host.dp, self.device.dp,
-                            self.passive.map_extract(lambda port: port.dp))
-    self.d_N = self.connect(self.host.dm, self.device.dm,
-                            self.passive.map_extract(lambda port: port.dm))
+    self.d_P = self.connect(self.host.dp, self.device.dp, self.passive.map_extract(lambda port: port.dp),
+                            flatten=True)
+    self.d_N = self.connect(self.host.dm, self.device.dm, self.passive.map_extract(lambda port: port.dm),
+                            flatten=True)
 
 
 class UsbHostPort(Bundle[UsbLink]):

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -62,13 +62,12 @@ class TestBlinkyBroken(BoardTop):
   def contents(self):
     super().contents()
     self.usb = self.Block(UsbDeviceCReceptacle())
-
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb.pwr, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.vusb, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 
@@ -84,21 +83,20 @@ class TestBlinkyFlattened(BoardTop):
   def contents(self):
     super().contents()
     self.usb = self.Block(UsbDeviceCReceptacle())
-
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb.pwr, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.vusb, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.usb_reg = imp.Block(BuckConverter(output_voltage=3.3*Volt(tol=0.05)))
 
     self.v3v3 = self.connect(self.usb_reg.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb_reg.pwr_out, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.v3v3, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 
@@ -166,16 +164,16 @@ class TestBlinkyComplete(BoardTop):
     self.gnd = self.connect(self.usb.gnd)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb.pwr, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.vusb, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.usb_reg = imp.Block(BuckConverter(output_voltage=3.3*Volt(tol=0.05)))
 
     self.v3v3 = self.connect(self.usb_reg.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb_reg.pwr_out, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.v3v3, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -142,12 +142,13 @@ class NewBlinkyMagsense(BoardTop):
 
     self.jack = self.Block(Pj_102a(voltage_out=5*Volt(tol=0.1)))
     self.buck = self.Block(BuckConverter(output_voltage=3.3*Volt(tol=0.05)))
-    self.connect(self.jack.pwr, self.buck.pwr_in)
-    self.connect(self.jack.gnd, self.buck.gnd)
+    self.vin = self.connect(self.jack.pwr, self.buck.pwr_in)
+    self.gnd = self.connect(self.jack.gnd, self.buck.gnd)
+    self.v3v3 = self.connect(self.buck.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.buck.pwr_out, [Power]),
-        ImplicitConnect(self.jack.gnd, [Common]),
+        ImplicitConnect(self.v3v3, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 
@@ -173,13 +174,13 @@ class NewBlinkyLightsense(BoardTop):
 
     self.usb = self.Block(UsbMicroBReceptacle())
     self.buck = self.Block(BuckConverter(output_voltage=3.3*Volt(tol=0.05)))
-    self._v5 = self.connect(self.usb.pwr, self.buck.pwr_in)
-    self._gnd = self.connect(self.usb.gnd, self.buck.gnd)
-    self._v3 = self.connect(self.buck.pwr_out)
+    self.v5 = self.connect(self.usb.pwr, self.buck.pwr_in)
+    self.gnd = self.connect(self.usb.gnd, self.buck.gnd)
+    self.v3v3 = self.connect(self.buck.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.buck.pwr_out, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.v3v3, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
       self.esd = imp.Block(UsbEsdDiode())

--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -46,13 +46,8 @@ class CanAdapter(BoardTop):
     self.connect(self.mcu.spi.allocate('lcd_spi'), self.lcd.spi)  # MISO unused
     self.connect(self.mcu.gpio.allocate('lcd_cs'), self.lcd.cs)
 
-    self.connect(self.mcu.gpio.allocate('rgb_usb_red'), self.rgb_usb.red)
-    self.connect(self.mcu.gpio.allocate('rgb_usb_grn'), self.rgb_usb.green)
-    self.connect(self.mcu.gpio.allocate('rgb_usb_blue'), self.rgb_usb.blue)
-
-    self.connect(self.mcu.gpio.allocate('rgb_can_red'), self.rgb_can.red)
-    self.connect(self.mcu.gpio.allocate('rgb_can_grn'), self.rgb_can.green)
-    self.connect(self.mcu.gpio.allocate('rgb_can_blue'), self.rgb_can.blue)
+    self.connect(self.mcu.gpio.allocate_vector('rgb_usb'), self.rgb_usb.signals)
+    self.connect(self.mcu.gpio.allocate_vector('rgb_can'), self.rgb_can.signals)
 
     # Isolated CAN Domain
     # self.can = self.Block(M12CanConnector())  # probably not a great idea for this particular application
@@ -100,10 +95,10 @@ class CanAdapter(BoardTop):
           'lcd_spi.miso=NC',
           'lcd_cs=22',
           'rgb_usb_red=2',
-          'rgb_usb_grn=1',
+          'rgb_usb_green=1',
           'rgb_usb_blue=3',
           'rgb_can_red=6',
-          'rgb_can_grn=4',
+          'rgb_can_green=4',
           'rgb_can_blue=7',
           'swd.swo=PIO0_8',
         ]))

--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -14,7 +14,7 @@ class CanAdapter(BoardTop):
     self.gnd = self.connect(self.usb.gnd)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       (self.usb_reg, ), _ = self.chain(
         self.usb.pwr,
@@ -24,8 +24,8 @@ class CanAdapter(BoardTop):
     self.v3v3 = self.connect(self.usb_reg.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb_reg.pwr_out, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.v3v3, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 
@@ -56,15 +56,15 @@ class CanAdapter(BoardTop):
     self.can_gnd = self.connect(self.can.gnd)
 
     with self.implicit_connect(
-        ImplicitConnect(self.can.gnd, [Common]),
+        ImplicitConnect(self.can_gnd, [Common]),
     ) as imp:
-      (self.can_reg, self.led_can), _ = self.chain(self.can.pwr,
+      (self.can_reg, self.led_can), _ = self.chain(self.can_vcan,
                                                    imp.Block(LinearRegulator(5.0*Volt(tol=0.05))),
                                                    imp.Block(VoltageIndicatorLed()))
       (self.can_esd, ), _ = self.chain(self.xcvr.can, imp.Block(CanEsdDiode()), self.can.differential)
 
     self.can_v5v = self.connect(self.can_reg.pwr_out, self.xcvr.can_pwr)
-    self.connect(self.can.gnd, self.xcvr.can_gnd)
+    self.connect(self.can_gnd, self.xcvr.can_gnd)
 
     # Misc board
     self.duck = self.Block(DuckLogo())

--- a/examples/test_datalogger.py
+++ b/examples/test_datalogger.py
@@ -103,19 +103,13 @@ class TestDatalogger(BoardTop):
       self.connect(self.mcu.gpio.allocate('ext_rts'), self.ext.rts)
 
       self.rgb1 = imp.Block(IndicatorSinkRgbLed())  # system RGB 1
-      self.connect(self.mcu.gpio.allocate('rgb1_red'), self.rgb1.red)
-      self.connect(self.mcu.gpio.allocate('rgb1_grn'), self.rgb1.green)
-      self.connect(self.mcu.gpio.allocate('rgb1_blue'), self.rgb1.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb1'), self.rgb1.signals)
 
       self.rgb2 = imp.Block(IndicatorSinkRgbLed())  # sd card RGB
-      self.connect(self.mcu.gpio.allocate('rgb2_red'), self.rgb2.red)
-      self.connect(self.mcu.gpio.allocate('rgb2_grn'), self.rgb2.green)
-      self.connect(self.mcu.gpio.allocate('rgb2_blue'), self.rgb2.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb2'), self.rgb2.signals)
 
       self.rgb3 = imp.Block(IndicatorSinkRgbLed())
-      self.connect(self.mcu.gpio.allocate('rgb3_red'), self.rgb3.red)
-      self.connect(self.mcu.gpio.allocate('rgb3_grn'), self.rgb3.green)
-      self.connect(self.mcu.gpio.allocate('rgb3_blue'), self.rgb3.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb3'), self.rgb3.signals)
 
       sw_pull_model = PullupResistor(4.7 * kOhm(tol=0.05))
       (self.sw1, self.sw1_pull), _ = self.chain(imp.Block(DigitalSwitch()),
@@ -173,13 +167,13 @@ class TestDatalogger(BoardTop):
           'ext_cts=62',
           'ext_rts=59',
           'rgb1_red=31',
-          'rgb1_grn=32',
+          'rgb1_green=32',
           'rgb1_blue=30',
           'rgb2_red=28',
-          'rgb2_grn=29',
+          'rgb2_green=29',
           'rgb2_blue=25',
           'rgb3_red=46',
-          'rgb3_grn=39',
+          'rgb3_green=39',
           'rgb3_blue=34',  # used to be 38, which is ISP_1
           'sw1=33',
           'sw2=23',

--- a/examples/test_datalogger.py
+++ b/examples/test_datalogger.py
@@ -17,9 +17,10 @@ class TestDatalogger(BoardTop):
 
     self.gnd_merge = self.Block(MergedVoltageSource()).connected_from(
       self.usb_conn.gnd, self.pwr_conn.gnd, self.bat.gnd)
+    self.gnd = self.connect(self.gnd_merge.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.gnd_merge.pwr_out, [Common]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       (self.pwr_5v,), _ = self.chain(
         self.pwr_conn.pwr,
@@ -42,11 +43,10 @@ class TestDatalogger(BoardTop):
     self.v5 = self.connect(self.pwr_5v_merge.pwr_out)
     self.v5_buffered = self.connect(self.buffer.pwr_out)
     self.v3v3 = self.connect(self.pwr_3v3.pwr_out)  # TODO better auto net names
-    self.gnd = self.connect(self.gnd_merge.pwr_out)
 
     with self.implicit_connect(
-      ImplicitConnect(self.pwr_3v3.pwr_out, [Power]),
-      ImplicitConnect(self.pwr_3v3.gnd, [Common]),
+      ImplicitConnect(self.v3v3, [Power]),
+      ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 
@@ -114,11 +114,11 @@ class TestDatalogger(BoardTop):
                                                 self.mcu.gpio.allocate('sw2'))
 
     with self.implicit_connect(
-        ImplicitConnect(self.pwr_3v3.gnd, [Common]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       div_model = VoltageDivider(output_voltage=3 * Volt(tol=0.15), impedance=(100, 1000) * Ohm)
-      (self.v12sense, ), _ = self.chain(self.pwr_conn.pwr, imp.Block(div_model), self.mcu.adc.allocate('v12sense'))
-      (self.v5sense, ), _ = self.chain(self.pwr_5v.pwr_out, imp.Block(div_model), self.mcu.adc.allocate('v5sense'))
+      (self.v12sense, ), _ = self.chain(self.vin, imp.Block(div_model), self.mcu.adc.allocate('v12sense'))
+      (self.v5sense, ), _ = self.chain(self.v5, imp.Block(div_model), self.mcu.adc.allocate('v5sense'))
       (self.vscsense, ), _ = self.chain(self.buffer.sc_out, imp.Block(div_model), self.mcu.adc.allocate('vscsense'))
 
     self.hole = ElementDict[MountingHole]()

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -45,8 +45,8 @@ class Debugger(BoardTop):
     self.gnd = self.connect(self.usb.gnd)
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb.pwr, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.vusb, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.usb_reg = imp.Block(LinearRegulator(3.3*Volt(tol=0.05)))
       self.usb_esd = imp.Block(UsbEsdDiode())
@@ -55,17 +55,18 @@ class Debugger(BoardTop):
       self.target_reg = imp.Block(Ap2204k_Block(3.3*Volt(tol=0.05)))
 
     self.v3v3 = self.connect(self.usb_reg.pwr_out)
+    self.vtarget = self.connect(self.target_reg.pwr_out)
 
     with self.implicit_connect(
-        ImplicitConnect(self.target_reg.pwr_out, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.vtarget, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.target = imp.Block(SwdCortexSourceHeaderHorizontal())
       self.led_target = imp.Block(VoltageIndicatorLed())
 
     with self.implicit_connect(
-        ImplicitConnect(self.usb_reg.pwr_out, [Power]),
-        ImplicitConnect(self.usb.gnd, [Common]),
+        ImplicitConnect(self.v3v3, [Power]),
+        ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.mcu = imp.Block(IoController())
 

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -99,13 +99,8 @@ class Debugger(BoardTop):
     self.connect(self.mcu.spi.allocate('lcd_spi'), self.lcd.spi)  # MISO unused
     self.connect(self.mcu.gpio.allocate('lcd_cs'), self.lcd.cs)
 
-    self.connect(self.mcu.gpio.allocate('rgb_usb_red'), self.rgb_usb.red)
-    self.connect(self.mcu.gpio.allocate('rgb_usb_grn'), self.rgb_usb.green)
-    self.connect(self.mcu.gpio.allocate('rgb_usb_blue'), self.rgb_usb.blue)
-
-    self.connect(self.mcu.gpio.allocate('rgb_tgt_red'), self.rgb_tgt.red)
-    self.connect(self.mcu.gpio.allocate('rgb_tgt_grn'), self.rgb_tgt.green)  # pinning on stock ST-Link
-    self.connect(self.mcu.gpio.allocate('rgb_tgt_blue'), self.rgb_tgt.blue)
+    self.connect(self.mcu.gpio.allocate_vector('rgb_usb'), self.rgb_usb.signals)
+    self.connect(self.mcu.gpio.allocate_vector('rgb_tgt'), self.rgb_tgt.signals)
 
     self.connect(self.mcu.gpio.allocate('sw_usb'), self.sw_usb.out)
 
@@ -141,10 +136,10 @@ class Debugger(BoardTop):
           'lcd_spi.miso=NC',
           'lcd_cs=28',
           'rgb_usb_red=14',
-          'rgb_usb_grn=12',
+          'rgb_usb_green=12',
           'rgb_usb_blue=11',
           'rgb_tgt_red=13',
-          'rgb_tgt_grn=30',
+          'rgb_tgt_green=30',  # pinning on stock st-link
           'rgb_tgt_blue=10',
           'sw_usb=38',
         ]))

--- a/examples/test_high_switch.py
+++ b/examples/test_high_switch.py
@@ -101,14 +101,10 @@ class TestHighSwitch(BoardTop):
         self.mcu.adc.allocate('vsense'))
 
       self.rgb1 = imp.Block(IndicatorSinkRgbLed())  # CAN RGB
-      self.connect(self.mcu.gpio.allocate('rgb1_red'), self.rgb1.red)
-      self.connect(self.mcu.gpio.allocate('rgb1_grn'), self.rgb1.green)
-      self.connect(self.mcu.gpio.allocate('rgb1_blue'), self.rgb1.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb1'), self.rgb1.signals)
 
       self.rgb2 = imp.Block(IndicatorSinkRgbLed())  # system RGB 2
-      self.connect(self.mcu.gpio.allocate('rgb2_red'), self.rgb2.red)
-      self.connect(self.mcu.gpio.allocate('rgb2_grn'), self.rgb2.green)
-      self.connect(self.mcu.gpio.allocate('rgb2_blue'), self.rgb2.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb2'), self.rgb2.signals)
 
     self.limit_light_current = self.Block(ForcedVoltageCurrentDraw((0, 2.5) * Amp))
     self.connect(self.pwr_conn.pwr, self.limit_light_current.pwr_in)
@@ -142,10 +138,10 @@ class TestHighSwitch(BoardTop):
           'can.rxd=44',
           'vsense=21',
           'rgb1_red=28',
-          'rgb1_grn=23',
+          'rgb1_green=23',
           'rgb1_blue=22',
           'rgb2_red=18',
-          'rgb2_grn=15',
+          'rgb2_green=15',
           'rgb2_blue=13',
           'light_00=12',
           'light_01=8',

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -244,9 +244,7 @@ class MultimeterTest(BoardTop):
       self.chain(self.mcu.gpio.allocate('gate_control'), self.gate.control)
 
       self.rgb = imp.Block(IndicatorSinkRgbLed())
-      self.connect(self.mcu.gpio.allocate('rgb_r'), self.rgb.red)
-      self.connect(self.mcu.gpio.allocate('rgb_g'), self.rgb.green)
-      self.connect(self.mcu.gpio.allocate('rgb_b'), self.rgb.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb'), self.rgb.signals)
 
       (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw1'))
       (self.sw2, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw2'))
@@ -350,9 +348,9 @@ class MultimeterTest(BoardTop):
       ],
       instance_values=[
         (['mcu', 'pin_assigns'], ';'.join([
-          'rgb_r=36',
-          'rgb_b=2',
-          'rgb_g=3',
+          'rgb_red=36',
+          'rgb_blue=2',
+          'rgb_green=3',
 
           'spi.miso=28',
           'adc_cs=5',

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -378,15 +378,15 @@ class MultimeterTest(BoardTop):
         (['reg_5v', 'dutycycle_limit'], Range(0, float('inf'))),  # allow the regulator to go into tracking mode
         (['reg_5v', 'ripple_current_factor'], Range(0.75, 1.0)),  # smaller inductor
         (['reg_5v', 'fb', 'div', 'series'], 12),  # JLC has limited resistors
-        (['measure', 'res', 'footprint_spec'], 'Resistor_SMD:R_2512_6332Metric'),
+        (['measure', 'res', 'footprint'], 'Resistor_SMD:R_2512_6332Metric'),
 
         # pin footprints to re-select parts with newer parts tables
-        (['driver', 'fet', 'footprint_spec'], 'Package_TO_SOT_SMD:SOT-23'),  # Q3
-        (['gate', 'amp_fet', 'footprint_spec'], 'Package_TO_SOT_SMD:SOT-23'),  # Q2
-        (['gate', 'ctl_diode', 'footprint_spec'], 'Diode_SMD:D_SOD-323'),  # D1
-        (['gate', 'btn_diode', 'footprint_spec'], 'Diode_SMD:D_SOD-323'),  # D2
-        (['gate', 'pwr_fet', 'footprint_spec'], 'Package_TO_SOT_SMD:SOT-23'),  # Q1
-        (['reg_5v', 'inductor', 'footprint_spec'], 'Inductor_SMD:L_0805_2012Metric'),  # L1
+        (['driver', 'fet', 'footprint'], 'Package_TO_SOT_SMD:SOT-23'),  # Q3
+        (['gate', 'amp_fet', 'footprint'], 'Package_TO_SOT_SMD:SOT-23'),  # Q2
+        (['gate', 'ctl_diode', 'footprint'], 'Diode_SMD:D_SOD-323'),  # D1
+        (['gate', 'btn_diode', 'footprint'], 'Diode_SMD:D_SOD-323'),  # D2
+        (['gate', 'pwr_fet', 'footprint'], 'Package_TO_SOT_SMD:SOT-23'),  # Q1
+        (['reg_5v', 'inductor', 'footprint'], 'Inductor_SMD:L_0805_2012Metric'),  # L1
       ],
       class_refinements=[
         (SwdCortexTargetWithTdiConnector, SwdCortexTargetTc2050),

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -440,13 +440,13 @@ class UsbSourceMeasureTest(BoardTop):
         # allow the regulator to go into tracking mode
         (['reg_5v', 'power_path', 'dutycycle_limit'], Range(0, float('inf'))),
         # NFET option: SQJ148EP-T1_GE3, NPN BJT option: PHPT60410NYX
-        (['control', 'driver', 'high_fet', 'footprint_spec'], 'Package_SO:PowerPAK_SO-8_Single'),
+        (['control', 'driver', 'high_fet', 'footprint'], 'Package_SO:PowerPAK_SO-8_Single'),
         (['control', 'driver', 'high_fet', 'power'], Range(0, 0)),
         # PFET option: SQJ431EP-T1_GE3, PNP BJT option: PHPT60410PYX
-        (['control', 'driver', 'low_fet', 'footprint_spec'], 'Package_SO:PowerPAK_SO-8_Single'),
+        (['control', 'driver', 'low_fet', 'footprint'], 'Package_SO:PowerPAK_SO-8_Single'),
         (['control', 'driver', 'low_fet', 'power'], Range(0, 0)),
         (['control', 'int_link', 'sink_impedance'], RangeExpr.INF),  # waive impedance check for integrator in
-        (['control', 'int', 'c', 'footprint_spec'], 'Capacitor_SMD:C_0603_1608Metric'),
+        (['control', 'int', 'c', 'footprint'], 'Capacitor_SMD:C_0603_1608Metric'),
 
       ],
       class_refinements=[

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -335,9 +335,7 @@ class UsbSourceMeasureTest(BoardTop):
       self.connect(self.mcu.gpio.allocate('pd_int'), self.pd.int)
 
       self.rgb = imp.Block(IndicatorSinkRgbLed())
-      self.connect(self.mcu.gpio.allocate('rgb_r'), self.rgb.red)
-      self.connect(self.mcu.gpio.allocate('rgb_g'), self.rgb.green)
-      self.connect(self.mcu.gpio.allocate('rgb_b'), self.rgb.blue)
+      self.connect(self.mcu.gpio.allocate_vector('rgb'), self.rgb.signals)
 
       (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw1'))
       (self.sw2, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw2'))
@@ -416,9 +414,9 @@ class UsbSourceMeasureTest(BoardTop):
           'sw1=43',
           'sw2=44',
           'sw3=45',
-          'rgb_b=46',
-          'rgb_g=47',
-          'rgb_r=48',
+          'rgb_blue=46',
+          'rgb_green=47',
+          'rgb_red=48',
 
           'dac_ldac=1',
           'dac_in_cs=2',


### PR DESCRIPTION
Resolves #20 fully - adds link arrays!
- Infrastructural refactoring to add ConnectionExprUtils, that provides a standardized way to map and manipulate port refs in connected-type constraints
- Infrastructural refactoring to add ConnectedConstraintManager, that centralizes parsing of the different types of connections
- Misc renaming in compiler to be more descriptive and categorical
- Adds LinkArray class in compiler, which includes functionality for expanding from port-array elements and link-elements.
- Complete refactoring of the connect system in the frontend to support array-array connections.
  - Also add support for using the result of connects in further connections - this allows naming connections and tacking more things onto them.
- Unit tests, unit tests, unit tests
- Refactors the RGB LED to use a port-array, which is then connected to the micro with an array connect operation. 1 line instead of 3.
- Refactors some examples to make better use of port-arrays.
- Some example cleanup from past PRs that weren't caught before

TODOs:
- [x] Support array connect allocate <-> link array
- [x] Frontend support, also separate connect construct from connect-flatten construct
- [x] Add flat-connect
- [x] Net renaming in examples

Future cleanups
- [ ] Clean up ExprBuilder/Ref/whatever - maybe standardize on ValueExpr returns?
- [ ] Maybe Ref should also take in `Seq[String]` (used in compiler), in addition to `String*` (used for test construction)
- [ ] Move more logic, especially decoding logic, into ConnectedConstraintManager
- [ ] Change the ElaborateRecord to not carry the constraint names - instead, a separate data structure can map port path -> connected constraints or the ConnectedConstraints data structure
- [ ] Cleanup the array / allocated connection lowering task generation that is just duplicated everywhere - perhaps have a superset function which either skips inapplicable ones, or can control which ones generate?