### PR TITLE
Better handling of HdlInterfaceServer crashes

### DIFF
--- a/HdlInterfaceService.py
+++ b/HdlInterfaceService.py
@@ -12,18 +12,9 @@ from edg_core import BufferDeserializer, BufferSerializer
 from blinky_skeleton import *
 
 if __name__ == '__main__':
-  verbose = False
-
-  def eprint(*args, **kwargs):
-    # Print to stderr, to avoid messing up the stdout communication channel
-    if verbose:
-      print(*args, **kwargs, file=sys.stderr, flush=True)
-
   server = HdlInterface()
   stdin_deserializer = BufferDeserializer(edgrpc.HdlRequest, sys.stdin.buffer)
   stdout_serializer = BufferSerializer[edgrpc.HdlResponse](sys.stdout.buffer)
-
-  eprint(f"HDL Interface Server started")
 
   while True:
     request = stdin_deserializer.read()
@@ -32,41 +23,15 @@ if __name__ == '__main__':
 
     response = edgrpc.HdlResponse()
     if request.HasField('index_module'):
-      eprint(f"IndexModule({request.index_module.name}) -> ", end='')
-
-      indexed = []
-      try:
-        indexed = server.IndexModule(request.index_module)
-      except BaseException as e:
-        # TODO pipe full error into response
-        eprint(f"Error {e}")
-
-      eprint(f"(Indexed {len(indexed)})")
+      indexed = server.IndexModule(request.index_module)  # by intent this crashes if it fails
       response.index_module.indexed.extend(indexed)
     elif request.HasField('get_library_element'):
-      if verbose:
-        eprint(f"GetLibraryElement({request.get_library_element.element.target.name}) -> ", end='')
-
       lib = server.GetLibraryElement(request.get_library_element)
-
-      if lib.HasField('error'):
-        eprint(f"Error {lib.error}")
-      elif lib.HasField('refinements'):
-        eprint(f"(elt, w/ refinements)")
-      else:
-        eprint(f"(elt)")
       response.get_library_element.CopyFrom(lib)
     elif request.HasField('elaborate_generator'):
-      eprint(f"ElaborateGenerator({request.elaborate_generator.element.target.name}) -> ", end='')
-
       gen = server.ElaborateGenerator(request.elaborate_generator)
-
-      if gen.HasField('error'):
-        eprint(f"Error {gen.error}")
-      else:
-        eprint(f"(generated)")
       response.elaborate_generator.CopyFrom(gen)
     else:
-      eprint(f"Unknown request {request}")
+      raise RuntimeError(f"Unknown request {request}")
 
     stdout_serializer.write(response)


### PR DESCRIPTION
- Gets rid of the print-to-stderr that was getting ignored anyways and the verbose mode we don't use
- Error cases in HdlInterfaceServer will actually error out now
- The PythonInterface in Scala checks for dead subprocess and throws an appropriate error (including stderr from the dead subprocess), to differentiate from other failures

This turns out to be a significant quality-of-life improvement so I'm just going to merge this, but feedback is welcome and can be addressed in a follow-on PR.