### PR TITLE
ToF array firmware PIO config fix

### DIFF
--- a/examples/test_tofarray/firmware/main.cpp
+++ b/examples/test_tofarray/firmware/main.cpp
@@ -1,5 +1,4 @@
 #include <mbed.h>
-#include "SoftSerial.h"
 #include "VL53L0X.h"
 
 I2C i2c(B11, B10);  // sda, scl
@@ -29,7 +28,7 @@ DigitalIn sw1(B1, PinMode::PullUp);
 // CAN RXD=B8, TXD=B9
 
 DigitalOut swoPin(B3);
-// SoftSerial serial(B3, NC);  // can't do SWO serial on STM32 =(
+// SoftSerial serial(B3, NC);  // can't do SWO serial on STM32 =(, SoftSerial also seems broken
 
 
 int main() {

--- a/examples/test_tofarray/firmware/platformio.ini
+++ b/examples/test_tofarray/firmware/platformio.ini
@@ -2,6 +2,9 @@
 src_dir = .
 
 [env:tofarray]
+lib_deps =
+  mbed-joelvonrotz/VL53L0X
+
 platform = ststm32
 board = bluepill_f103c8
 board_build.mcu = stm32f103c8t6
@@ -12,3 +15,4 @@ framework = mbed
 upload_protocol = cmsis-dap
 upload_speed = 4000
 monitor_speed = 115200
+debug_tool = cmsis-dap


### PR DESCRIPTION
Adds the required firmware library for the VL53L0X to the PlatformIO config.

For some reason this didn't make it into #122, but since this is part of that I'm just going to go ahead and merge it.