### PR TITLE
Support print() in user HDL

### DIFF
--- a/HdlInterfaceService.py
+++ b/HdlInterfaceService.py
@@ -14,7 +14,7 @@ from blinky_skeleton import *
 
 # In some cases stdout seems to buffer excessively, in which case starting python with -u seems to work
 # https://stackoverflow.com/a/35467658/5875811
-kHeaderMagicByte = b'\xfe'
+
 
 if __name__ == '__main__':
   server = HdlInterface()
@@ -39,5 +39,5 @@ if __name__ == '__main__':
     else:
       raise RuntimeError(f"Unknown request {request}")
 
-    sys.stdout.buffer.write(b'\xfe')
+    sys.stdout.buffer.write(stdin_deserializer.read_stdout())
     stdout_serializer.write(response)

--- a/HdlInterfaceService.py
+++ b/HdlInterfaceService.py
@@ -11,6 +11,11 @@ from edg_core import BufferDeserializer, BufferSerializer
 # even if nothing else in core depends on that test code
 from blinky_skeleton import *
 
+
+# In some cases stdout seems to buffer excessively, in which case starting python with -u seems to work
+# https://stackoverflow.com/a/35467658/5875811
+kHeaderMagicByte = b'\xfe'
+
 if __name__ == '__main__':
   server = HdlInterface()
   stdin_deserializer = BufferDeserializer(edgrpc.HdlRequest, sys.stdin.buffer)
@@ -34,4 +39,5 @@ if __name__ == '__main__':
     else:
       raise RuntimeError(f"Unknown request {request}")
 
+    sys.stdout.buffer.write(b'\xfe')
     stdout_serializer.write(response)

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -36,6 +36,7 @@ class ProtobufStdioSubprocess
       throw new ProtobufSubprocessException()
     }
 
+    process.getOutputStream.write(ProtobufStdioSubprocess.kHeaderMagicByte)
     message.writeDelimitedTo(process.getOutputStream)
     process.getOutputStream.flush()
   }

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -15,11 +15,15 @@ import scala.collection.mutable
 class ProtobufSubprocessException() extends Exception()
 
 
+object ProtobufStdioSubprocess {
+  val kHeaderMagicByte = 0xfe  // currently only for Python -> Scala
+}
+
+
 class ProtobufStdioSubprocess
     [RequestType <: scalapb.GeneratedMessage, ResponseType <: scalapb.GeneratedMessage](
     responseType: scalapb.GeneratedMessageCompanion[ResponseType],
     args: Seq[String]) {
-  val kHeaderMagicByte = 0xfe  // currently only for Python -> Scala
   protected val process = new ProcessBuilder(args: _*).start()
 
   // this provides a consistent Stream interface for both stdout and stderr
@@ -40,7 +44,7 @@ class ProtobufStdioSubprocess
     var doneReadingStdout: Boolean = false
     while (!doneReadingStdout) {
       val nextByte = process.getInputStream.read()
-     if (nextByte == kHeaderMagicByte) {
+     if (nextByte == ProtobufStdioSubprocess.kHeaderMagicByte) {
         doneReadingStdout = true
       } else if (nextByte < 0) {
         throw new ProtobufSubprocessException()
@@ -63,7 +67,7 @@ class ProtobufStdioSubprocess
     var doneReadingStdout: Boolean = false
     while (!doneReadingStdout) {
       val nextByte = process.getInputStream.read()
-      require(nextByte != kHeaderMagicByte)
+      require(nextByte != ProtobufStdioSubprocess.kHeaderMagicByte)
       if (nextByte < 0) {
         doneReadingStdout = true
       } else {

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -57,7 +57,8 @@ class ProtobufStdioSubprocess
     responseOpt.get
   }
 
-  def shutdown(): Unit = {
+  // Shuts down the stream and returns the exit value
+  def shutdown(): Int = {
     process.getOutputStream.close()
     var doneReadingStdout: Boolean = false
     while (!doneReadingStdout) {
@@ -70,6 +71,8 @@ class ProtobufStdioSubprocess
       }
     }
     outputSource.flush()
+    process.waitFor()
+    process.exitValue()
   }
 }
 
@@ -170,7 +173,7 @@ class PythonInterface(serverFile: File) {
     result
   }
 
-  def shutdown(): Unit = {
+  def shutdown(): Int = {
     process.shutdown()
   }
 }

--- a/compiler/src/main/scala/edg/util/QueueStream.scala
+++ b/compiler/src/main/scala/edg/util/QueueStream.scala
@@ -1,0 +1,23 @@
+package edg.util
+
+import java.io.InputStream
+import collection.mutable
+
+
+/** Why the heck are we writing another QueueStream when we have things like Apache QueueInputStream?
+  *
+  * Well it turns out that they never bothered to implement available(), which is needed for functional
+  * compatibility with how subprocess implements their streams.
+  * And PipedInputStream doesn't support single-threaded access, it has a limited buffer size and deadlocks.
+  *
+  * So here, yet another variation of Stream. Yay.
+  */
+class QueueStream extends InputStream {
+  protected val queue = mutable.Queue[Byte]()
+
+  override def read(): Int = queue.dequeue()
+  override def available(): Int = queue.length
+
+  // don't want to bother writing a separate OutputStream version, so the write methods are just stuffed in here
+  def write(data: Int): Unit = queue.enqueue(data.toByte)
+}

--- a/compiler/src/main/scala/edg/util/StreamUtils.scala
+++ b/compiler/src/main/scala/edg/util/StreamUtils.scala
@@ -1,0 +1,15 @@
+package edg.util
+
+import java.io.InputStream
+
+object StreamUtils {
+  def forAvailable(stream: InputStream)(fn: Array[Byte] => Unit): Unit = {
+    var available = stream.available()
+    while (available > 0) {
+      val array = new Array[Byte](available)
+      stream.read(array)
+      fn(array)
+      available = stream.available()
+    }
+  }
+}

--- a/compiler/src/test/scala/edg/compiler/PythonInterfaceTest.scala
+++ b/compiler/src/test/scala/edg/compiler/PythonInterfaceTest.scala
@@ -10,7 +10,8 @@ import java.io.File
 
 class PythonInterfaceTest extends AnyFlatSpec {
   "Python Interface" should "make basic connections" in {
-    val pyIf = new PythonInterface(new File("PolymorphicBlocks/HdlInterfaceService.py"))
+    val pyIf = new PythonInterface(new File("../HdlInterfaceService.py"))
     pyIf.indexModule("edg_core").getClass should equal(classOf[Errorable.Success[Seq[LibraryPath]]])
+    pyIf.shutdown() should equal(0)
   }
 }

--- a/compiler/src/test/scala/edg/compiler/PythonInterfaceTest.scala
+++ b/compiler/src/test/scala/edg/compiler/PythonInterfaceTest.scala
@@ -1,0 +1,16 @@
+package edg.compiler
+
+import edg.util.Errorable
+import edgir.ref.ref.LibraryPath
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+import java.io.File
+
+
+class PythonInterfaceTest extends AnyFlatSpec {
+  "Python Interface" should "make basic connections" in {
+    val pyIf = new PythonInterface(new File("PolymorphicBlocks/HdlInterfaceService.py"))
+    pyIf.indexModule("edg_core").getClass should equal(classOf[Errorable.Success[Seq[LibraryPath]]])
+  }
+}

--- a/edg_core/ScalaCompilerInterface.py
+++ b/edg_core/ScalaCompilerInterface.py
@@ -46,7 +46,6 @@ class ScalaCompilerInstance:
         print("Using development JAR")
       elif os.path.exists(self.PRECOMPIED_RELPATH):
         jar_path = self.PRECOMPIED_RELPATH
-        print("Using precompiled JAR")
       else:
         raise ValueError("No EDG Compiler JAR found")
 

--- a/edg_core/ScalaCompilerInterface.py
+++ b/edg_core/ScalaCompilerInterface.py
@@ -2,6 +2,7 @@ from typing import Optional, Any, Type, Iterable, Union
 
 import os
 import subprocess
+import sys
 
 import edgir
 import edgrpc
@@ -79,6 +80,10 @@ class ScalaCompilerInstance:
 
     self.request_serializer.write(request)
     result = self.response_deserializer.read()
+
+    sys.stdout.buffer.write(self.response_deserializer.read_stdout())
+    sys.stdout.buffer.flush()
+
     assert result is not None
     if not result.HasField('design'):
       raise CompilerCheckError(f"no compiled result, with error {result.error}")


### PR DESCRIPTION
Since communication between Python <-> Scala uses stdio (stdin and stdout), previously any stray print()s in user HDL would mess up that communication. This adds a non-ASCII magic header byte (0xfe) to the communication stream that is used to indicate the start of a proto message, the rest is interpreted as stdout prints.

As typical since this is purely a UI and quality-of-life change without modifying core semantics, I'm going to go ahead and merge this when ready. Post-merge feedback is still welcome.

This solution definitely has problems and should be replaced, see #131 

Implementation notes:
- buffering is pretty bad, the HdlInterfaceServer must be launched with -u otherwise it buffers excessively
  - print() seems to buffer separately from sys.stdout.buffer
- currently the println stdout forwarding is done by checking for data at the end of each request, then printing it to stdout as a block
  - since we don't read data from stderr, that's handled 'natively'
- adds a shutdown() to PythonInterface, to allow the process to stop when done
- adds hooks to PythonInterface that are called when requests are made, to allow the IDE to show progress and associate stdout logs with a particular block
- misc code cleanup
- update unit tests

