### PR TITLE
Automatically generate USB-C CC pull resistors, add programming button to ESP32-C3

### DIFF
--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -220,9 +220,8 @@ class Esp32c3_Wroom02(PinMappable, Microcontroller, IoController, Block):
       self.io8_pull = imp.Block(PullupResistor(10 * kOhm(tol=0.05))).connected(io=self.ic.io8)
       self.io2_pull = imp.Block(PullupResistor(10 * kOhm(tol=0.05))).connected(io=self.ic.io2)
       self.en_pull = imp.Block(PullupDelayRc(10 * kOhm(tol=0.05), 10*mSecond(tol=0.2))).connected(io=self.ic.en)
+      # by default instantiate a programming switch, TODO option to disable as a config
+      (self.prog, ), _ = self.chain(imp.Block(DigitalSwitch()), self.ic.io9)
 
       self.uart0 = imp.Block(EspProgrammingHeader())
       self.connect(self.uart0.uart, self.ic.uart0)
-
-      # IO9 left open - to be manually shorted with tweezers, to save space
-      # TODO: alternative programming headers that include IO9?

--- a/electronics_lib/UsbPorts.py
+++ b/electronics_lib/UsbPorts.py
@@ -40,7 +40,7 @@ class UsbAReceptacle(UsbConnector, FootprintBlock):
 
 
 class UsbCReceptacle_Device(FootprintBlock, JlcPart):
-  """"Raw" USB Type-C Receptacle
+  """Raw USB Type-C Receptacle
   Pullup capable indicates whether this port (or more accurately, the device on the other side) can pull
   up the signal. In UFP (upstream-facing, device) mode the power source should pull up CC."""
   @init_in_parent
@@ -109,6 +109,8 @@ class UsbCReceptacle(UsbConnector, GeneratorBlock):
   def generate(self, pwr_connected: bool, cc_connected: bool) -> None:
     if cc_connected:  # if CC externally connected, connect directly to USB port
       self.connect(self.cc, self.conn.cc)
+      self.require(self.cc.is_connected().implies(self.pwr.is_connected()),
+                   "USB power not used when CC connected")
     elif pwr_connected:  # otherwise generate the pulldown resistors for USB2 mode
       (self.cc_pull, ), _ = self.chain(self.conn.cc, self.Block(UsbCcPulldownResistor()))
       self.connect(self.cc_pull.gnd, self.gnd)

--- a/electronics_lib/UsbPorts.py
+++ b/electronics_lib/UsbPorts.py
@@ -39,10 +39,13 @@ class UsbAReceptacle(UsbConnector, FootprintBlock):
     )
 
 
-class UsbCReceptacle(UsbConnector, FootprintBlock, JlcPart):
+class UsbCReceptacle_Device(FootprintBlock, JlcPart):
+  """"Raw" USB Type-C Receptacle
+  Pullup capable indicates whether this port (or more accurately, the device on the other side) can pull
+  up the signal. In UFP (upstream-facing, device) mode the power source should pull up CC."""
   @init_in_parent
-  def __init__(self, voltage_out: RangeExpr = UsbConnector.USB2_VOLTAGE_RANGE,  # allow custom PD voltage and current
-               current_limits: RangeExpr = UsbConnector.USB2_CURRENT_LIMITS,
+  def __init__(self, voltage_out: RangeLike = UsbConnector.USB2_VOLTAGE_RANGE,  # allow custom PD voltage and current
+               current_limits: RangeLike = UsbConnector.USB2_CURRENT_LIMITS,
                cc_pullup_capable: BoolLike = Default(False)) -> None:
     super().__init__()
     self.pwr = self.Port(VoltageSource(voltage_out=voltage_out, current_limits=current_limits), optional=True)
@@ -88,6 +91,36 @@ class UsbCReceptacle(UsbConnector, FootprintBlock, JlcPart):
     )
 
 
+class UsbCReceptacle(UsbConnector, GeneratorBlock):
+  """USB Type-C Receptacle that automatically generates the CC resistors if CC is not connected."""
+  @init_in_parent
+  def __init__(self, voltage_out: RangeLike = UsbConnector.USB2_VOLTAGE_RANGE,  # allow custom PD voltage and current
+               current_limits: RangeLike = UsbConnector.USB2_CURRENT_LIMITS) -> None:
+    super().__init__()
+
+    self.conn = self.Block(UsbCReceptacle_Device(voltage_out=voltage_out, current_limits=current_limits))
+    self.pwr = self.Export(self.conn.pwr, optional=True)
+    self.gnd = self.Export(self.conn.gnd)
+    self.usb = self.Export(self.conn.usb, optional=True)
+    self.cc = self.Port(UsbCcPort.empty(), optional=True)  # external connectivity defines the circuit
+
+    self.generator(self.generate, self.pwr.is_connected(), self.cc.is_connected())
+
+  def generate(self, pwr_connected: bool, cc_connected: bool) -> None:
+    if cc_connected:  # if CC externally connected, connect directly to USB port
+      self.connect(self.cc, self.conn.cc)
+    elif pwr_connected:  # otherwise generate the pulldown resistors for USB2 mode
+      (self.cc_pull, ), _ = self.chain(self.conn.cc, self.Block(UsbCcPulldownResistor()))
+      self.connect(self.cc_pull.gnd, self.gnd)
+      self.require(self.pwr.voltage_out == UsbConnector.USB2_VOLTAGE_RANGE,
+                   "when CC not connected, port restricted to USB 2.0 voltage")
+      self.require(self.pwr.current_limits == UsbConnector.USB2_CURRENT_LIMITS,
+                   "when CC not connected, port restricted to USB 2.0 current")
+
+    # TODO there does not seem to be full agreement on what to do with the shield pin, we arbitrarily ground it
+    self.connect(self.gnd, self.conn.shield.as_ground())
+
+
 @abstract_block
 class UsbDeviceConnector(UsbConnector):
   """Abstract base class for a USB 2.0 device-side port connector"""
@@ -128,23 +161,6 @@ class UsbMicroBReceptacle(UsbDeviceConnector, FootprintBlock):
       mfr='Molex', part='105017-0001',
       datasheet='https://www.molex.com/pdm_docs/sd/1050170001_sd.pdf'
     )
-
-
-class UsbDeviceCReceptacle(UsbDeviceConnector):
-  """Implementation of a USB device using a Type-C receptacle as a upstream-facing port.
-  Includes pull-down resistors on the CC pins so a Type-C downstream-facing port can supply the default 5v power.
-  High speed pins are left open."""
-  def __init__(self) -> None:
-    super().__init__()
-
-  def contents(self) -> None:
-    # TODO for a UFP we expect a pull-up on the CC lines on the DFP side
-    self.port = self.Block(UsbCReceptacle(cc_pullup_capable=True))
-    self.connect(self.pwr, self.port.pwr)
-    self.connect(self.usb, self.port.usb)
-
-    (self.cc_pull, ), _ = self.chain(self.port.cc, self.Block(UsbCcPulldownResistor()))
-    self.connect(self.gnd, self.port.gnd, self.port.shield.as_ground(), self.cc_pull.gnd)
 
 
 class UsbCcPulldownResistor(Block):

--- a/electronics_lib/__init__.py
+++ b/electronics_lib/__init__.py
@@ -48,7 +48,7 @@ from .Microcontroller_nRF52840 import Holyiot_18010, Mdbt50q_1mv2
 from .Microcontroller_Esp32c3 import Esp32c3_Wroom02
 
 from .PowerConnectors import PowerBarrelJack, Pj_102a
-from .UsbPorts import UsbConnector, UsbAReceptacle, UsbCReceptacle, UsbDeviceConnector, UsbMicroBReceptacle, UsbDeviceCReceptacle
+from .UsbPorts import UsbConnector, UsbAReceptacle, UsbCReceptacle, UsbDeviceConnector, UsbMicroBReceptacle
 from .UsbPorts import UsbEsdDiode, Tpd2e009, Esda5v3l
 from .Fusb302b import Fusb302b
 from .Connector_Banana import Ct3151, Fcr7350

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -61,7 +61,7 @@ class TestBlinkySimpleChain(BoardTop):
 class TestBlinkyBroken(BoardTop):
   def contents(self):
     super().contents()
-    self.usb = self.Block(UsbDeviceCReceptacle())
+    self.usb = self.Block(UsbCReceptacle())
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)
 
@@ -82,7 +82,7 @@ class TestBlinkyBroken(BoardTop):
 class TestBlinkyFlattened(BoardTop):
   def contents(self):
     super().contents()
-    self.usb = self.Block(UsbDeviceCReceptacle())
+    self.usb = self.Block(UsbCReceptacle())
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)
 
@@ -158,7 +158,7 @@ class Mcp9700(Block):
 class TestBlinkyComplete(BoardTop):
   def contents(self):
     super().contents()
-    self.usb = self.Block(UsbDeviceCReceptacle())
+    self.usb = self.Block(UsbCReceptacle())
 
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)

--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -8,7 +8,7 @@ class CanAdapter(BoardTop):
     super().contents()
 
     # USB Domain
-    self.usb = self.Block(UsbDeviceCReceptacle())
+    self.usb = self.Block(UsbCReceptacle())
 
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -39,7 +39,7 @@ class Debugger(BoardTop):
   def contents(self) -> None:
     super().contents()
 
-    self.usb = self.Block(UsbDeviceCReceptacle())
+    self.usb = self.Block(UsbCReceptacle())
 
     self.vusb = self.connect(self.usb.pwr)
     self.gnd = self.connect(self.usb.gnd)

--- a/examples/test_ledmatrix.py
+++ b/examples/test_ledmatrix.py
@@ -158,7 +158,7 @@ class LedMatrixTest(JlcBoardTop):
         (['reg_3v3', 'ic', 'require_basic_part'], False),
         (['prot_3v3', 'diode', 'require_basic_part'], False),
         (['usb_esd', 'require_basic_part'], False),
-        (['usb', 'require_basic_part'], False),
+        (['usb', 'conn', 'require_basic_part'], False),
       ],
       class_values=[
         (TestPoint, ['require_basic_part'], False),

--- a/examples/test_ledmatrix.py
+++ b/examples/test_ledmatrix.py
@@ -62,7 +62,7 @@ class CharlieplexedLedMatrix(GeneratorBlock):
         else:
           connect_passive_io(row, led.a)
 
-    # generate the adapters andconnect the internal passive IO to external typed IO
+    # generate the adapters and connect the internal passive IO to external typed IO
     for index, passive_io in passive_ios.items():
       # if there is a cathode resistor attached to this index, then include the sunk current
       if index < cols:

--- a/examples/test_ledmatrix.py
+++ b/examples/test_ledmatrix.py
@@ -82,7 +82,7 @@ class CharlieplexedLedMatrix(GeneratorBlock):
 
 
 class LedMatrixTest(JlcBoardTop):
-  """A USB-connected WiFi-enabled LED matrix that demonstrates a charlieplexing LEX matrix generator.
+  """A USB-connected WiFi-enabled LED matrix that demonstrates a charlieplexing LED matrix generator.
   """
   def contents(self) -> None:
     super().contents()

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -496,10 +496,10 @@ class MultimeterTest(JlcBoardTop):
         (['gate', 'ctl_diode', 'require_basic_part'], False),
         (['gate', 'btn_diode', 'require_basic_part'], False),
         (['usb_esd', 'require_basic_part'], False),
+        (['data_usb', 'conn', 'require_basic_part'], False),
       ],
       class_values=[
         (AnalogSwitchTree, ['switch_size'], 2),
-        (UsbCReceptacle, ['require_basic_part'], False),
         (TestPoint, ['require_basic_part'], False),
         (Tpa2005d1_Device, ['require_basic_part'], False),
         (SmtRgbLed, ['require_basic_part'], False),

--- a/examples/test_tofarray.py
+++ b/examples/test_tofarray.py
@@ -164,7 +164,7 @@ class TofArrayTest(JlcBoardTop):
         (['reg_3v3', 'ic', 'require_basic_part'], False),
         (['prot_3v3', 'diode', 'require_basic_part'], False),
         (['usb_esd', 'require_basic_part'], False),
-        (['usb', 'require_basic_part'], False),
+        (['usb', 'conn', 'require_basic_part'], False),
       ],
       class_values=[
         (TestPoint, ['require_basic_part'], False),

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -457,10 +457,11 @@ class UsbSourceMeasureTest(JlcBoardTop):
         (['prot_3v3', 'diode', 'require_basic_part'], False),
         (['control', 'err_source', 'diode', 'require_basic_part'], False),
         (['control', 'err_sink', 'diode', 'require_basic_part'], False),
+        (['pwr_usb', 'conn', 'require_basic_part'], False),
+        (['data_usb', 'conn', 'require_basic_part'], False),
         (['usb_esd', 'require_basic_part'], False),
       ],
       class_values=[
-        (UsbCReceptacle, ['require_basic_part'], False),  # both top-side
         (SmtRgbLed, ['require_basic_part'], False),
       ],
       class_refinements=[


### PR DESCRIPTION
Resolves #121, resolves #123 

Changes the Type-C receptacle to automatically generate the CC pull resistors when CC not externally connected and power is used. Removes the Type-C Device Connector block which included the CC pull resistors but did not give a CC port option - this one unifies both in one smart block. Also grounds the shield pin, but this can be revisited with more options in the future since there doesn't seem to be wide agreement on what should be done with this pin.

Also adds a programming button to the ESP32-C3 module. In the future (when there's a use case) this may be disable-able by a user toggle or something.

Largely a hardware change based on lessons learned from the LED matrix board. Review not gating since core models do not change but feedback is welcome.