### PR TITLE
Refactor PassivePort adapter syntax, add FPC supertype, add OLED

### DIFF
--- a/edg/BoardTop.py
+++ b/edg/BoardTop.py
@@ -20,6 +20,7 @@ class BaseBoardTop(DesignTop):
 
         (IndicatorSinkLed, IndicatorSinkLedResistor),
 
+        (Fpc050, HiroseFh12sh),
         (UsbEsdDiode, Tpd2e009),
         (TestPoint, Keystone5015),
 

--- a/edg_core/Ports.py
+++ b/edg_core/Ports.py
@@ -130,7 +130,6 @@ class Port(BasePort, Generic[PortLinkType]):
     self._link_instance: Optional[PortLinkType] = None
     self.bridge_type: Optional[Type[PortBridge]] = None
     self._bridge_instance: Optional[PortBridge] = None  # internal only
-    self.adapter_types: List[Type[PortAdapter]] = []
 
     # TODO delete type ignore after https://github.com/python/mypy/issues/5374
     self._parameters: SubElementDict[ConstraintExpr] = self.manager.new_dict(ConstraintExpr)  # type: ignore

--- a/electronics_abstract_parts/AbstractAnalogSwitch.py
+++ b/electronics_abstract_parts/AbstractAnalogSwitch.py
@@ -96,11 +96,11 @@ class AnalogMuxer(GeneratorBlock):
     self.control = self.Export(self.device.control)
 
     self.inputs = self.Port(Vector(AnalogSink.empty()))
-    self.out = self.Export(self.device.com.as_analog_source(
+    self.out = self.Export(self.device.com.adapt_to(AnalogSource(
       voltage_out=self.inputs.hull(lambda x: x.link().voltage),
       current_limits=self.device.analog_current_limits,  # this device only, current draw propagated
       impedance=self.device.analog_on_resistance + self.inputs.hull(lambda x: x.link().source_impedance)
-    ))
+    )))
 
     self.generator(self.generate, self.inputs.allocated())
 
@@ -109,11 +109,11 @@ class AnalogMuxer(GeneratorBlock):
     for elt in elts:
       self.connect(
         self.inputs.append_elt(AnalogSink().empty(), elt),
-        self.device.inputs.allocate(elt).as_analog_sink(
+        self.device.inputs.allocate(elt).adapt_to(AnalogSink(
           voltage_limits=self.device.analog_voltage_limits,  # this device only, voltages propagated
           current_draw=self.out.link().current_drawn,
           impedance=self.out.link().sink_impedance + self.device.analog_on_resistance
-        ))
+        )))
 
   def mux_to(self, inputs: Optional[List[Port[AnalogLink]]] = None,
              output: Optional[Port[AnalogLink]] = None) -> 'AnalogMuxer':
@@ -136,11 +136,11 @@ class AnalogDemuxer(GeneratorBlock):
     self.control = self.Export(self.device.control)
 
     self.outputs = self.Port(Vector(AnalogSource.empty()))
-    self.input = self.Export(self.device.com.as_analog_sink(
+    self.input = self.Export(self.device.com.adapt_to(AnalogSink(
       voltage_limits=self.device.analog_voltage_limits,  # this device only, voltages propagated
       current_draw=self.outputs.hull(lambda x: x.link().current_drawn),
       impedance=self.device.analog_on_resistance + self.outputs.hull(lambda x: x.link().sink_impedance)
-    ))
+    )))
 
     self.generator(self.generate, self.outputs.allocated())
 
@@ -149,11 +149,11 @@ class AnalogDemuxer(GeneratorBlock):
     for elt in elts:
       self.connect(
         self.outputs.append_elt(AnalogSource().empty(), elt),
-        self.device.inputs.allocate(elt).as_analog_source(
+        self.device.inputs.allocate(elt).adapt_to(AnalogSource(
           voltage_out=self.input.link().voltage,
           current_limits=self.device.analog_current_limits,  # this device only, voltages propagated
           impedance=self.input.link().source_impedance + self.device.analog_on_resistance
-        ))
+        )))
 
   def demux_to(self, input: Optional[Port[AnalogLink]] = None,
                    outputs: Optional[List[Port[AnalogLink]]] = None) -> 'AnalogDemuxer':

--- a/electronics_abstract_parts/AbstractCapacitor.py
+++ b/electronics_abstract_parts/AbstractCapacitor.py
@@ -218,8 +218,11 @@ class DecouplingCapacitor(DiscreteApplication):
     super().__init__()
 
     self.cap = self.Block(Capacitor(capacitance, voltage=RangeExpr()))
-    self.gnd = self.Export(self.cap.neg.as_voltage_sink(), [Common])
-    self.pwr = self.Export(self.cap.pos.as_voltage_sink(), [Power])
+    self.gnd = self.Export(self.cap.neg.adapt_to(Ground()), [Common])
+    self.pwr = self.Export(self.cap.pos.adapt_to(VoltageSink(
+      voltage_limits=self.cap.actual_voltage_rating + self.gnd.link().voltage,
+      current_draw=0*Amp(tol=0)
+    )), [Power])
 
     self.assign(self.cap.voltage, self.pwr.link().voltage - self.gnd.link().voltage)
 

--- a/electronics_abstract_parts/AbstractCrystal.py
+++ b/electronics_abstract_parts/AbstractCrystal.py
@@ -110,4 +110,5 @@ class OscillatorCrystal(DiscreteApplication):  # TODO rename to disambiguate fro
     self.cap_b = self.Block(cap_model)
     self.connect(self.cap_a.pos, self.crystal.a)
     self.connect(self.cap_b.pos, self.crystal.b)
-    self.connect(self.gnd, self.cap_a.neg.as_ground(), self.cap_b.neg.as_ground())
+    self.connect(self.gnd, self.cap_a.neg.adapt_to(Ground()),
+                 self.cap_b.neg.adapt_to(Ground()))

--- a/electronics_abstract_parts/AbstractDiodes.py
+++ b/electronics_abstract_parts/AbstractDiodes.py
@@ -192,8 +192,8 @@ class ProtectionZenerDiode(DiscreteApplication):
   def contents(self):
     super().contents()
     self.diode = self.Block(ZenerDiode(zener_voltage=self.voltage))
-    self.connect(self.diode.cathode.as_voltage_sink(
+    self.connect(self.diode.cathode.adapt_to(VoltageSink(
       voltage_limits=(0, self.voltage.lower()),
       current_draw=(0, 0)*Amp  # TODO should be leakage current
-    ), self.pwr)
-    self.connect(self.diode.anode.as_voltage_sink(), self.gnd)
+    )), self.pwr)
+    self.connect(self.diode.anode.adapt_to(Ground()), self.gnd)

--- a/electronics_abstract_parts/AbstractFets.py
+++ b/electronics_abstract_parts/AbstractFets.py
@@ -21,11 +21,11 @@ class Fet(DiscreteSemiconductor):
   - https://www.allaboutcircuits.com/technical-articles/choosing-the-right-transistor-understanding-dynamic-mosfet-parameters/
   """
   @staticmethod
-  def NFet(*args, **kwargs):
+  def NFet(*args, **kwargs) -> 'Fet':
     return Fet(*args, **kwargs, channel='N')
 
   @staticmethod
-  def PFet(*args, **kwargs):
+  def PFet(*args, **kwargs) -> 'Fet':
     return Fet(*args, **kwargs, channel='P')
 
   @init_in_parent

--- a/electronics_abstract_parts/AbstractLed.py
+++ b/electronics_abstract_parts/AbstractLed.py
@@ -63,12 +63,12 @@ class IndicatorLed(Light):
       resistance=(self.signal.link().voltage.upper() / self.target_current_draw.upper(),
                   self.signal.link().output_thresholds.upper() / self.target_current_draw.lower())))
 
-    self.connect(self.signal, self.package.a.as_digital_sink(
+    self.connect(self.signal, self.package.a.adapt_to(DigitalSink(
       current_draw=self.signal.link().voltage / self.res.actual_resistance
-    ))
+    )))
 
     self.connect(self.res.a, self.package.k)
-    self.connect(self.res.b.as_ground(), self.gnd)
+    self.connect(self.res.b.adapt_to(Ground()), self.gnd)
 
 
 @abstract_block
@@ -100,14 +100,14 @@ class IndicatorSinkLedResistor(IndicatorSinkLed):
       resistance=(self.signal.link().voltage.upper() / self.current_draw.upper(),
                   self.signal.link().output_thresholds.upper() / self.current_draw.lower())))
 
-    self.connect(self.package.a.as_voltage_sink(
+    self.connect(self.package.a.adapt_to(VoltageSink(
       current_draw=self.signal.link().voltage / self.res.actual_resistance
-    ), self.pwr)
+    )), self.pwr)
 
     self.connect(self.res.a, self.package.k)
-    self.connect(self.res.b.as_digital_sink(
+    self.connect(self.res.b.adapt_to(DigitalSink(
       current_draw=-self.signal.link().voltage / self.res.actual_resistance
-    ), self.signal)
+    )), self.signal)
 
 
 class IndicatorSinkLedArray(Light, GeneratorBlock):
@@ -151,11 +151,11 @@ class VoltageIndicatorLed(Light):
       resistance=(self.signal.link().voltage.upper() / self.target_current_draw.upper(),
                   self.signal.link().voltage.lower() / self.target_current_draw.lower())))
 
-    self.connect(self.signal, self.package.a.as_voltage_sink(
+    self.connect(self.signal, self.package.a.adapt_to(VoltageSink(
       current_draw=self.signal.link().voltage / self.res.actual_resistance
-    ))
+    )))
     self.connect(self.res.a, self.package.k)
-    self.connect(self.res.b.as_ground(), self.gnd)
+    self.connect(self.res.b.adapt_to(Ground()), self.gnd)
 
 
 # TODO should there be some kind of abstract LED class, that works for both CA and CC type LEDs?
@@ -195,21 +195,21 @@ class IndicatorSinkRgbLed(Light):
     self.connect(self.red_res.a, self.package.k_red)
     self.connect(self.green_res.a, self.package.k_green)
     self.connect(self.blue_res.a, self.package.k_blue)
-    self.connect(self.red_res.b.as_digital_sink(
+    self.connect(self.red_res.b.adapt_to(DigitalSink(
       current_draw=(-1 * signal_red.link().voltage.upper() / self.red_res.actual_resistance.lower(), 0)
-    ), signal_red)
-    self.connect(self.green_res.b.as_digital_sink(
+    )), signal_red)
+    self.connect(self.green_res.b.adapt_to(DigitalSink(
       current_draw=(-1 * signal_green.link().voltage.upper() / self.green_res.actual_resistance.lower(), 0)
-    ), signal_green)
-    self.connect(self.blue_res.b.as_digital_sink(
+    )), signal_green)
+    self.connect(self.blue_res.b.adapt_to(DigitalSink(
       current_draw=(-1 * signal_blue.link().voltage.upper() / self.blue_res.actual_resistance.lower(), 0)
-    ), signal_blue)
+    )), signal_blue)
 
-    self.connect(self.pwr, self.package.a.as_voltage_sink(
+    self.connect(self.pwr, self.package.a.adapt_to(VoltageSink(
       current_draw=signal_red.current_draw * -1 +
                    signal_green.current_draw * -1 +
                    signal_blue.current_draw * -1
-    ))
+    )))
 
 
 class IndicatorSinkPackedRgbLedElement(IndicatorSinkLed):

--- a/electronics_abstract_parts/AbstractOpamp.py
+++ b/electronics_abstract_parts/AbstractOpamp.py
@@ -111,18 +111,18 @@ class Amplifier(AnalogFilter, GeneratorBlock):
     self.r2 = self.Block(Resistor(
       resistance=Range.from_tolerance(bottom_resistance, tolerance)
     ))
-    self.connect(self.amp.out, self.output, self.r1.a.as_analog_sink(
+    self.connect(self.amp.out, self.output, self.r1.a.adapt_to(AnalogSink(
       impedance=self.r1.actual_resistance + self.r2.actual_resistance
-    ))
-    self.connect(self.r1.b.as_analog_source(
+    )))
+    self.connect(self.r1.b.adapt_to(AnalogSource(
       voltage_out=self.amp.out.voltage_out,
       impedance=1/(1 / self.r1.actual_resistance + 1 / self.r2.actual_resistance)
-    ), self.r2.a.as_analog_sink(
+    )), self.r2.a.adapt_to(AnalogSink(
       # treated as an ideal sink for now
-    ), self.amp.inn)
-    self.connect(self.reference, self.r2.b.as_analog_sink(
+    )), self.amp.inn)
+    self.connect(self.reference, self.r2.b.adapt_to(AnalogSink(
       impedance=self.r1.actual_resistance + self.r2.actual_resistance
-    ))
+    )))
 
     self.assign(self.actual_amplification, 1 + (self.r1.actual_resistance / self.r2.actual_resistance))
 
@@ -216,33 +216,33 @@ class DifferentialAmplifier(AnalogFilter, GeneratorBlock):
     ))
     self.assign(self.actual_ratio, self.rf.actual_resistance / self.r1.actual_resistance)
 
-    self.connect(self.input_negative, self.r1.a.as_analog_sink(
+    self.connect(self.input_negative, self.r1.a.adapt_to(AnalogSink(
       # TODO very simplified and probably very wrong
       impedance=self.r1.actual_resistance + self.rf.actual_resistance
-    ))
-    self.connect(self.input_positive, self.r2.a.as_analog_sink(
+    )))
+    self.connect(self.input_positive, self.r2.a.adapt_to(AnalogSink(
       impedance=self.r2.actual_resistance + self.rg.actual_resistance
-    ))
+    )))
 
-    self.connect(self.amp.out, self.output, self.rf.a.as_analog_sink(
+    self.connect(self.amp.out, self.output, self.rf.a.adapt_to(AnalogSink(
       # TODO very simplified and probably very wrong
       impedance=self.r1.actual_resistance + self.rf.actual_resistance
-    ))
-    self.connect(self.r1.b.as_analog_source(
+    )))
+    self.connect(self.r1.b.adapt_to(AnalogSource(
       voltage_out=self.input_negative.link().voltage.hull(self.output.link().voltage),
       impedance=1 / (1 / self.r1.actual_resistance + 1 / self.rf.actual_resistance)  # combined R1 and Rf resistance
-    ), self.rf.b.as_analog_sink(
+    )), self.rf.b.adapt_to(AnalogSink(
       # treated as an ideal sink for now
-    ), self.amp.inn)
-    self.connect(self.r2.b.as_analog_source(
+    )), self.amp.inn)
+    self.connect(self.r2.b.adapt_to(AnalogSource(
       voltage_out=self.input_positive.link().voltage.hull(self.output_reference.link().voltage),
       impedance=1 / (1 / self.r2.actual_resistance + 1 / self.rg.actual_resistance)  # combined R2 and Rg resistance
-    ), self.rg.b.as_analog_sink(
+    )), self.rg.b.adapt_to(AnalogSink(
       # treated as an ideal sink for now
-    ), self.amp.inp)
-    self.connect(self.rg.a.as_analog_sink(
+    )), self.amp.inp)
+    self.connect(self.rg.a.adapt_to(AnalogSink(
       impedance=self.r2.actual_resistance + self.rg.actual_resistance
-    ), self.output_reference)
+    )), self.output_reference)
 
 
 class IntegratorValues(ESeriesRatioValue):
@@ -326,12 +326,12 @@ class IntegratorInverting(AnalogFilter, GeneratorBlock):
 
     self.assign(self.actual_factor, 1 / self.r.actual_resistance / self.c.actual_capacitance)
 
-    self.connect(self.input, self.r.a.as_analog_sink(
+    self.connect(self.input, self.r.a.adapt_to(AnalogSink(
       # TODO very simplified and probably very wrong
       impedance=self.r.actual_resistance
-    ))
-    self.connect(self.amp.out, self.output, self.c.pos.as_analog_sink())  # TODO impedance of the feedback circuit?
-    self.connect(self.r.b.as_analog_source(
+    )))
+    self.connect(self.amp.out, self.output, self.c.pos.adapt_to(AnalogSink()))  # TODO impedance of the feedback circuit?
+    self.connect(self.r.b.adapt_to(AnalogSource(
       impedance=self.r.actual_resistance
-    ), self.c.neg.as_analog_sink(), self.amp.inn)
+    )), self.c.neg.adapt_to(AnalogSink()), self.amp.inn)
     self.connect(self.reference, self.amp.inp)

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -190,13 +190,14 @@ class BuckConverterPowerPath(GeneratorBlock):
       current=(0, self.peak_current),
       frequency=frequency*Hertz
     ))
-    self.connect(self.switch, self.inductor.a.as_voltage_sink(
+    self.connect(self.switch, self.inductor.a.adapt_to(VoltageSink(
       voltage_limits=RangeExpr.ALL,
-      current_draw=self.pwr_out.link().current_drawn*dutycycle))
-    self.connect(self.pwr_out, self.inductor.b.as_voltage_source(
+      current_draw=self.pwr_out.link().current_drawn*dutycycle
+    )))
+    self.connect(self.pwr_out, self.inductor.b.adapt_to(VoltageSource(
       voltage_out=self.output_voltage,
       current_limits=self.current_limits
-    ))
+    )))
 
     # TODO pick a single worst-case DC
     input_capacitance = Range.from_lower(output_current.upper * effective_dutycycle.upper * (1 - effective_dutycycle.lower) /
@@ -303,12 +304,14 @@ class BoostConverterPowerPath(GeneratorBlock):
       current=(0, self.peak_current),
       frequency=frequency*Hertz
     ))
-    self.connect(self.pwr_in, self.inductor.a.as_voltage_sink(
+    self.connect(self.pwr_in, self.inductor.a.adapt_to(VoltageSink(
       voltage_limits=RangeExpr.ALL,
-      current_draw=self.pwr_out.link().current_drawn / (1 - effective_dutycycle)))
-    self.connect(self.switch, self.inductor.b.as_voltage_sink(
+      current_draw=self.pwr_out.link().current_drawn / (1 - effective_dutycycle)
+    )))
+    self.connect(self.switch, self.inductor.b.adapt_to(VoltageSink(
       voltage_limits=RangeExpr.ALL,
-      current_draw=self.pwr_out.link().current_drawn / (1 - effective_dutycycle)))
+      current_draw=self.pwr_out.link().current_drawn / (1 - effective_dutycycle)
+    )))
 
     input_capacitance = Range.from_lower((output_current.upper / effective_dutycycle.lower) * (1 - effective_dutycycle.lower) /
                                          (frequency.lower * input_voltage_ripple))

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -153,7 +153,7 @@ class SeriesPowerResistor(DiscreteApplication):
              self.current_limits.upper() * self.current_limits.upper() * self.resistance.upper())
     ))
 
-    self.pwr_in = self.Port(VoltageSink(), [Power, Input])  # forward declaration
+    self.pwr_in = self.Port(VoltageSink().empty(), [Power, Input])  # forward declaration
     self.pwr_out = self.Export(self.res.b.adapt_to(VoltageSource(
       voltage_out=self.pwr_in.link().voltage - self.current_limits * self.resistance,
       current_limits=self.current_limits

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -104,8 +104,8 @@ class PullupResistor(DiscreteApplication):
 
     self.res = self.Block(Resistor(resistance, 0*Watt(tol=0)))  # TODO automatically calculate power
 
-    self.pwr = self.Export(self.res.a.as_voltage_sink(), [Power])
-    self.io = self.Export(self.res.b.as_digital_pull_high_from_supply(self.pwr), [InOut])
+    self.pwr = self.Export(self.res.a.adapt_to(VoltageSink()), [Power])
+    self.io = self.Export(self.res.b.adapt_to(DigitalSingleSource.high_from_supply(self.pwr)), [InOut])
 
   def connected(self, pwr: Optional[Port[VoltageLink]] = None, io: Optional[Port[DigitalLink]] = None) -> \
       'PullupResistor':
@@ -125,8 +125,8 @@ class PulldownResistor(DiscreteApplication):
 
     self.res = self.Block(Resistor(resistance, 0*Watt(tol=0)))  # TODO automatically calculate power
 
-    self.gnd = self.Export(self.res.a.as_ground(), [Common])
-    self.io = self.Export(self.res.b.as_digital_pull_low_from_supply(self.gnd), [InOut])
+    self.gnd = self.Export(self.res.a.adapt_to(Ground()), [Common])
+    self.io = self.Export(self.res.b.adapt_to(DigitalSingleSource.low_from_supply(self.gnd)), [InOut])
 
   def connected(self, gnd: Optional[Port[VoltageLink]] = None, io: Optional[Port[DigitalLink]] = None) -> \
       'PulldownResistor':
@@ -153,14 +153,14 @@ class SeriesPowerResistor(DiscreteApplication):
              self.current_limits.upper() * self.current_limits.upper() * self.resistance.upper())
     ))
 
-    self.pwr_in = self.Export(self.res.a.as_voltage_sink(
+    self.pwr_in = self.Export(self.res.a.adapt_to(VoltageSink(
       voltage_limits=(-float('inf'), float('inf')),
       current_draw=RangeExpr()
-    ), [Power, Input])
-    self.pwr_out = self.Export(self.res.b.as_voltage_source(
+    )), [Power, Input])
+    self.pwr_out = self.Export(self.res.b.adapt_to(VoltageSource(
       voltage_out=self.pwr_in.link().voltage - self.current_limits * self.resistance,
       current_limits=self.current_limits
-    ), [Output])
+    )), [Output])
     self.assign(self.pwr_in.current_draw, self.pwr_out.link().current_drawn)
 
   def connected(self, pwr_in: Optional[Port[VoltageLink]] = None, pwr_out: Optional[Port[VoltageLink]] = None) -> \

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -153,15 +153,15 @@ class SeriesPowerResistor(DiscreteApplication):
              self.current_limits.upper() * self.current_limits.upper() * self.resistance.upper())
     ))
 
-    self.pwr_in = self.Export(self.res.a.adapt_to(VoltageSink(
-      voltage_limits=(-float('inf'), float('inf')),
-      current_draw=RangeExpr()
-    )), [Power, Input])
+    self.pwr_in = self.Port(VoltageSink(), [Power, Input])  # forward declaration
     self.pwr_out = self.Export(self.res.b.adapt_to(VoltageSource(
       voltage_out=self.pwr_in.link().voltage - self.current_limits * self.resistance,
       current_limits=self.current_limits
     )), [Output])
-    self.assign(self.pwr_in.current_draw, self.pwr_out.link().current_drawn)
+    self.connect(self.pwr_in, self.res.a.adapt_to(VoltageSink(
+      voltage_limits=(-float('inf'), float('inf')),
+      current_draw=self.pwr_out.link().current_drawn
+    )))
 
   def connected(self, pwr_in: Optional[Port[VoltageLink]] = None, pwr_out: Optional[Port[VoltageLink]] = None) -> \
       'SeriesPowerResistor':

--- a/electronics_abstract_parts/AbstractSolidStateRelay.py
+++ b/electronics_abstract_parts/AbstractSolidStateRelay.py
@@ -50,21 +50,21 @@ class DigitalAnalogIsolatedSwitch(Block):
       resistance=(self.signal.link().voltage.upper() / self.ic.led_current_recommendation.upper(),
                   self.signal.link().output_thresholds.upper() / self.ic.led_current_recommendation.lower())
     ))
-    self.connect(self.signal, self.ic.leda.as_digital_sink(
+    self.connect(self.signal, self.ic.leda.adapt_to(DigitalSink(
       current_draw=self.signal.link().voltage / self.res.actual_resistance
-    ))
+    )))
     self.connect(self.res.a, self.ic.ledk)
-    self.connect(self.res.b.as_ground(), self.gnd)
+    self.connect(self.res.b.adapt_to(Ground()), self.gnd)
 
-    self.connect(self.ain, self.ic.feta.as_analog_sink(
+    self.connect(self.ain, self.ic.feta.adapt_to(AnalogSink(
       voltage_limits=self.apull.link().voltage + self.ic.load_voltage_limit,
       impedance=self.aout.link().sink_impedance + self.ic.load_resistance
-    ))
+    )))
     self.pull_merge = self.Block(MergedAnalogSource()).connected_from(
       self.apull,
-      self.ic.fetb.as_analog_source(
+      self.ic.fetb.adapt_to(AnalogSource(
         voltage_out=self.ain.link().voltage,
         current_limits=self.ic.load_current_limit,
         impedance=self.ain.link().source_impedance + self.ic.load_resistance
-    ))
+    )))
     self.connect(self.pull_merge.output, self.aout)

--- a/electronics_abstract_parts/AbstractSwitch.py
+++ b/electronics_abstract_parts/AbstractSwitch.py
@@ -27,9 +27,9 @@ class DigitalSwitch(DiscreteApplication):
     self.package = self.Block(Switch(current=self.out.link().current_limits,
                                      voltage=self.out.link().voltage))
 
-    self.connect(self.out, self.package.a.as_digital_single_source(
+    self.connect(self.out, self.package.a.adapt_to(DigitalSingleSource(
       voltage_out=self.gnd.link().voltage,
       output_thresholds=(self.gnd.link().voltage.upper(), float('inf')),
       pulldown_capable=False, low_signal_driver=True
-    ))
-    self.connect(self.gnd, self.package.b.as_ground())
+    )))
+    self.connect(self.gnd, self.package.b.adapt_to(Ground()))

--- a/electronics_abstract_parts/AbstractTestPoint.py
+++ b/electronics_abstract_parts/AbstractTestPoint.py
@@ -36,7 +36,7 @@ class VoltageTestPoint(Block):
     super().__init__()
     self.io = self.Port(VoltageSink().empty(), [InOut])
     self.tp = self.Block(TestPoint(name=self.io.link().name()))
-    self.connect(self.io, self.tp.io.as_voltage_sink())
+    self.connect(self.io, self.tp.io.adapt_to(VoltageSink()))
 
   def connected(self, io: Port[VoltageLink]) -> 'VoltageTestPoint':
     cast(Block, builder.get_enclosing_block()).connect(io, self.io)
@@ -49,7 +49,7 @@ class DigitalTestPoint(Block):
     super().__init__()
     self.io = self.Port(DigitalSink().empty(), [InOut])
     self.tp = self.Block(TestPoint(name=self.io.link().name()))
-    self.connect(self.io, self.tp.io.as_digital_sink())
+    self.connect(self.io, self.tp.io.adapt_to(DigitalSink()))
 
   def connected(self, io: Port[DigitalLink]) -> 'DigitalTestPoint':
     cast(Block, builder.get_enclosing_block()).connect(io, self.io)
@@ -62,7 +62,7 @@ class AnalogTestPoint(Block):
     super().__init__()
     self.io = self.Port(AnalogSink().empty(), [InOut])
     self.tp = self.Block(TestPoint(name=self.io.link().name()))
-    self.connect(self.io, self.tp.io.as_analog_sink())
+    self.connect(self.io, self.tp.io.adapt_to(AnalogSink()))
 
   def connected(self, io: Port[AnalogLink]) -> 'AnalogTestPoint':
     cast(Block, builder.get_enclosing_block()).connect(io, self.io)

--- a/electronics_abstract_parts/DigitalAmplifiers.py
+++ b/electronics_abstract_parts/DigitalAmplifiers.py
@@ -136,7 +136,7 @@ class HalfBridgeNFet(Block):
     self.connect(self.gate_high, self.high.gate.adapt_to(DigitalSink(
       current_draw=(0, 0)*Amp  # voltage limits and thresholds are passed through to the FETs
     )))
-    self.connect(self.pwr, self.high.drain.VoltageSink(
+    self.connect(self.pwr, self.high.drain.adapt_to(VoltageSink(
       current_draw=(0,  # from sink/source current to source only
                     self.output.link().current_drawn.upper().max(-1 * self.output.link().current_drawn.lower()))
-    ))
+    )))

--- a/electronics_abstract_parts/PassiveFilters.py
+++ b/electronics_abstract_parts/PassiveFilters.py
@@ -70,14 +70,13 @@ class DigitalLowPassRc(DigitalFilter, Block):
     self.rc = self.Block(LowPassRc(impedance=impedance, cutoff_freq=cutoff_freq,
                                    voltage=self.input.link().voltage))
     self.connect(self.input, self.rc.input.adapt_to(DigitalSink(
-      current_draw=RangeExpr()
+      current_draw=self.output.link().current_drawn
     )))
     self.connect(self.output, self.rc.output.adapt_to(DigitalSource(
       current_limits=RangeExpr.ALL,
       voltage_out=self.input.link().voltage,
       output_thresholds=self.input.link().output_thresholds
     )))
-    self.assign(self.input.current_draw, self.output.link().current_drawn)
 
     self.gnd = self.Export(self.rc.gnd.adapt_to(Ground()), [Common])
 

--- a/electronics_abstract_parts/ResistiveDivider.py
+++ b/electronics_abstract_parts/ResistiveDivider.py
@@ -124,7 +124,7 @@ class BaseVoltageDivider(Filter, Block):
     self.ratio = self.Parameter(RangeExpr())  # "internal" forward-declared parameter
     self.div = self.Block(ResistiveDivider(ratio=self.ratio, impedance=impedance))
 
-    self.input = self.Port(VoltageSink(), [Input])  # forward declaration only
+    self.input = self.Port(VoltageSink().empty(), [Input])  # forward declaration only
     self.output = self.Export(self.div.center.adapt_to(AnalogSource(
       voltage_out=(self.input.link().voltage.lower() * self.div.actual_ratio.lower(),
                    self.input.link().voltage.upper() * self.div.actual_ratio.upper()),

--- a/electronics_abstract_parts/ResistiveDivider.py
+++ b/electronics_abstract_parts/ResistiveDivider.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from math import log10, ceil
 from typing import List, Tuple
 
-from edg_core import *
-from edg_core.Blocks import DescriptionString
-from electronics_model import Common, Passive
+from electronics_model import *
 from . import AnalogFilter, DiscreteApplication, Resistor, Filter
 from .ESeriesUtil import ESeriesUtil, ESeriesRatioUtil, ESeriesRatioValue
 
@@ -126,24 +124,22 @@ class BaseVoltageDivider(Filter, Block):
     self.ratio = self.Parameter(RangeExpr())  # "internal" forward-declared parameter
     self.div = self.Block(ResistiveDivider(ratio=self.ratio, impedance=impedance))
 
-    self.input = self.Export(self.div.top.as_voltage_sink(
-      current_draw=RangeExpr(),
-      voltage_limits=RangeExpr.ALL
-    ), [Input])
-    self.output = self.Export(self.div.center.as_analog_source(
+    self.input = self.Port(VoltageSink(), [Input])  # forward declaration only
+    self.output = self.Export(self.div.center.adapt_to(AnalogSource(
       voltage_out=(self.input.link().voltage.lower() * self.div.actual_ratio.lower(),
                    self.input.link().voltage.upper() * self.div.actual_ratio.upper()),
       current_limits=RangeExpr.ALL,
       impedance=self.div.actual_impedance
-    ), [Output])
-    self.gnd = self.Export(self.div.bottom.as_ground(), [Common])
+    )), [Output])
+    self.connect(self.input, self.div.top.adapt_to(VoltageSink(
+      current_draw=self.output.link().current_drawn,
+      voltage_limits=RangeExpr.ALL
+    )))
+    self.gnd = self.Export(self.div.bottom.adapt_to(Ground()), [Common])
 
     self.actual_ratio = self.Parameter(RangeExpr(self.div.actual_ratio))
     self.actual_impedance = self.Parameter(RangeExpr(self.div.actual_impedance))
     self.actual_series_impedance = self.Parameter(RangeExpr(self.div.actual_series_impedance))
-
-    self.assign(self.input.current_draw, self.output.link().current_drawn)
-    # TODO also model static current draw into gnd
 
 class VoltageDivider(BaseVoltageDivider):
   """Voltage divider that takes in a ratio and parallel impedance spec, and produces an output analog signal
@@ -190,16 +186,16 @@ class SignalDivider(AnalogFilter, Block):
     super().__init__()
 
     self.div = self.Block(ResistiveDivider(ratio=ratio, impedance=impedance))
-    self.input = self.Export(self.div.top.as_analog_sink(
+    self.input = self.Export(self.div.top.adapt_to(AnalogSink(
       impedance=self.div.actual_series_impedance,
       current_draw=RangeExpr(),
       voltage_limits=RangeExpr.ALL
-    ), [Input])
-    self.output = self.Export(self.div.center.as_analog_source(
+    )), [Input])
+    self.output = self.Export(self.div.center.adapt_to(AnalogSource(
       voltage_out=(self.input.link().voltage.lower() * self.div.actual_ratio.lower(),
                    self.input.link().voltage.upper() * self.div.actual_ratio.upper()),
       current_limits=RangeExpr.ALL,
       impedance=self.div.actual_impedance
-    ), [Output])
-    self.gnd = self.Export(self.div.bottom.as_ground(), [Common])
+    )), [Output])
+    self.gnd = self.Export(self.div.bottom.adapt_to(Ground()), [Common])
     self.assign(self.input.current_draw, self.output.link().current_drawn)

--- a/electronics_lib/BatteryProtector_S8200A.py
+++ b/electronics_lib/BatteryProtector_S8200A.py
@@ -87,4 +87,4 @@ class BatteryProtector_S8200A(Block):
 
     self.vm_res = self.Block(
       SeriesPowerResistor(2 * kOhm(tol=0.10), (0 * uAmp, self.ic.vdd.current_draw.upper()))
-    ).connected(self.gnd_out, self.ic.vm.as_voltage_sink())
+    ).connected(self.gnd_out, self.ic.vm.adapt_to(VoltageSink()))

--- a/electronics_lib/BatteryProtector_S8200A.py
+++ b/electronics_lib/BatteryProtector_S8200A.py
@@ -2,7 +2,7 @@ from electronics_abstract_parts import *
 
 
 class BatteryProtector_S8200A_Device(DiscreteChip, FootprintBlock):
-  def __init__(self):
+  def __init__(self) -> None:
     super().__init__()
 
     self.vss = self.Port(Ground())
@@ -16,7 +16,7 @@ class BatteryProtector_S8200A_Device(DiscreteChip, FootprintBlock):
     self.co = self.Port(Passive())
 
 
-  def contents(self):
+  def contents(self) -> None:
     super().contents()
     self.footprint(
       'U', 'Package_TO_SOT_SMD:SOT-23-6',
@@ -75,14 +75,14 @@ class BatteryProtector_S8200A(Block):
     ).connected(self.ic.vss, self.ic.vdd)
 
     # do fet
-    self.connect(self.ic.vss, self.do_fet.source.as_ground())
+    self.connect(self.ic.vss, self.do_fet.source.adapt_to(Ground()))
     self.connect(self.ic.do, self.do_fet.gate)
 
     # do co
     self.connect(self.do_fet.drain, self.co_fet.drain)
 
     # co fet
-    self.connect(self.gnd_out, self.co_fet.source.as_ground_source())
+    self.connect(self.gnd_out, self.co_fet.source.adapt_to(GroundSource()))
     self.connect(self.ic.co, self.co_fet.gate)
 
     self.vm_res = self.Block(

--- a/electronics_lib/BoostConverters_DiodesInc.py
+++ b/electronics_lib/BoostConverters_DiodesInc.py
@@ -68,8 +68,8 @@ class Ap3012(DiscreteBoostConverter):
         voltage_drop=(0, 0.4)*Volt,
         reverse_recovery_time=(0, 500) * nSecond  # guess from Digikey's classification for "fast recovery"
       ))
-      self.connect(self.ic.sw, self.rect.anode.as_voltage_sink())
-      self.connect(self.pwr_out, self.rect.cathode.as_voltage_source(
+      self.connect(self.ic.sw, self.rect.anode.adapt_to(VoltageSink()))
+      self.connect(self.pwr_out, self.rect.cathode.adapt_to(VoltageSource(
         voltage_out=self.pwr_out.voltage_out,  # TODO cyclic dependency?
         current_limits=(0, 0.5)*Amp  # TODO proper switch current modeling?
-      ))
+      )))

--- a/electronics_lib/BuckConverter_TexasInstruments.py
+++ b/electronics_lib/BuckConverter_TexasInstruments.py
@@ -56,8 +56,8 @@ class Tps561201(DiscreteBuckConverter):
       self.hf_in_cap = imp.Block(DecouplingCapacitor(capacitance=0.1*uFarad(tol=0.2)))  # Datasheet 8.2.2.4
 
       self.vbst_cap = self.Block(Capacitor(capacitance=0.1*uFarad(tol=0.2), voltage=(0, 6) * Volt))
-      self.connect(self.vbst_cap.neg.as_voltage_sink(), self.ic.sw)
-      self.connect(self.vbst_cap.pos.as_voltage_sink(), self.ic.vbst)
+      self.connect(self.vbst_cap.neg.adapt_to(VoltageSink()), self.ic.sw)
+      self.connect(self.vbst_cap.pos.adapt_to(VoltageSink()), self.ic.vbst)
 
       # TODO: the control mechanism requires a specific capacitor / inductor selection, datasheet 8.2.2.3
       self.power_path = imp.Block(BuckConverterPowerPath(
@@ -133,14 +133,14 @@ class Tps54202h(DiscreteBuckConverter):
       self.hf_in_cap = imp.Block(DecouplingCapacitor(capacitance=0.1*uFarad(tol=0.2)))  # Datasheet 8.2.3.1, "optional"?
 
       self.boot_cap = self.Block(Capacitor(capacitance=0.1*uFarad(tol=0.2), voltage=(0, 6) * Volt))
-      self.connect(self.boot_cap.neg.as_voltage_sink(), self.ic.sw)
-      self.connect(self.boot_cap.pos.as_voltage_sink(), self.ic.boot)
+      self.connect(self.boot_cap.neg.adapt_to(VoltageSink()), self.ic.sw)
+      self.connect(self.boot_cap.pos.adapt_to(VoltageSink()), self.ic.boot)
 
       # an internal 6.9v Zener clamps the enable voltage, datasheet recommends at 510k resistor
       # a pull-up resistor isn't used because
       self.en_res = self.Block(Resistor(resistance=510*kOhm(tol=0.05), power=0*Amp(tol=0)))
-      self.connect(self.pwr_in, self.en_res.a.as_voltage_sink())
-      self.connect(self.en_res.b.as_digital_source(), self.ic.en)
+      self.connect(self.pwr_in, self.en_res.a.adapt_to(VoltageSink()))
+      self.connect(self.en_res.b.adapt_to(DigitalSource()), self.ic.en)
 
       self.power_path = imp.Block(BuckConverterPowerPath(
         self.pwr_in.link().voltage, self.fb.actual_input_voltage, self.frequency,

--- a/electronics_lib/EInk_E2154fs091.py
+++ b/electronics_lib/EInk_E2154fs091.py
@@ -114,11 +114,11 @@ class E2154fs091(EInk):
     self.boot_cap = self.Block(Capacitor(
       capacitance=(4.7, float('inf'))*uFarad, voltage=(0, 16)*Volt  # lower-bounded so it can be derated
     ))
-    self.connect(self.pwr, self.boost_ind.a.as_voltage_sink())
+    self.connect(self.pwr, self.boost_ind.a.adapt_to(VoltageSink()))
     self.connect(self.boost_ind.b, self.boost_sw.drain, self.boot_cap.pos)
     self.connect(self.boost_sw.gate, self.ic.gdr)
     self.connect(self.boost_sw.source, self.boost_res.a, self.ic.rese)
-    self.connect(self.boost_res.b.as_voltage_sink(), self.gnd)
+    self.connect(self.boost_res.b.adapt_to(VoltageSink()), self.gnd)
 
     self.vdd_cap0 = self.Block(DecouplingCapacitor(capacitance=0.11*uFarad(tol=0.2))).connected(self.gnd, self.pwr)
     self.vdd_cap1 = self.Block(DecouplingCapacitor(capacitance=1*uFarad(tol=0.2))).connected(self.gnd, self.pwr)
@@ -146,14 +146,14 @@ class E2154fs091(EInk):
     self.connect(self.ic.vcom, self.vcom_cap.pos)
 
     self.connect(self.gnd,
-                 self.vslr_cap.neg.as_voltage_sink(),
-                 self.vdhr_cap.neg.as_voltage_sink(),
-                 self.vddd_cap.neg.as_voltage_sink(),
-                 self.vdh_cap.neg.as_voltage_sink(),
-                 self.vgh_cap.neg.as_voltage_sink(),
-                 self.vdl_cap.neg.as_voltage_sink(),
-                 self.vgl_cap.neg.as_voltage_sink(),
-                 self.vcom_cap.neg.as_voltage_sink())
+                 self.vslr_cap.neg.adapt_to(Ground()),
+                 self.vdhr_cap.neg.adapt_to(Ground()),
+                 self.vddd_cap.neg.adapt_to(Ground()),
+                 self.vdh_cap.neg.adapt_to(Ground()),
+                 self.vgh_cap.neg.adapt_to(Ground()),
+                 self.vdl_cap.neg.adapt_to(Ground()),
+                 self.vgl_cap.neg.adapt_to(Ground()),
+                 self.vcom_cap.neg.adapt_to(Ground()))
 
     diode_model = Diode(
       reverse_voltage=(0, 25)*Volt, current=(0, 2)*Amp, voltage_drop=(0, 0.4)*Volt,
@@ -168,4 +168,4 @@ class E2154fs091(EInk):
     self.connect(self.vgl_dio.cathode, self.boot_cap.neg)
     self.boot_dio = self.Block(diode_model)
     self.connect(self.boot_cap.neg, self.boot_dio.anode)
-    self.connect(self.boot_dio.cathode.as_voltage_sink(), self.gnd)
+    self.connect(self.boot_dio.cathode.adapt_to(Ground()), self.gnd)

--- a/electronics_lib/Lcd_Qt096t_if09.py
+++ b/electronics_lib/Lcd_Qt096t_if09.py
@@ -69,11 +69,11 @@ class Qt096t_if09(Lcd, Block):
     super().contents()
 
     self.led_res = self.Block(Resistor(resistance=100*Ohm(tol=0.05)))  # TODO dynamic sizing, power
-    self.connect(self.led_res.a.as_digital_sink(
+    self.connect(self.led_res.a.adapt_to(DigitalSink(
       # no voltage limits, since the resistor is autogen'd
       input_thresholds=(3, 3),  # TODO more accurate model
       current_draw=(16, 20) * mAmp  # TODO user-configurable?
-    ), self.led)
+    )), self.led)
     self.connect(self.led_res.b, self.device.leda)
     self.connect(self.spi.sck, self.device.scl)
     self.connect(self.spi.mosi, self.device.sda)

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -177,10 +177,10 @@ class EspProgrammingHeader(ProgrammingConnector):
     self.uart = self.Port(UartPort.empty(), [Output])
 
     self.conn = self.Block(PassiveConnector())
-    self.connect(self.pwr, self.conn.pins.allocate('1').as_voltage_sink())
-    self.connect(self.uart.tx, self.conn.pins.allocate('2').as_digital_source())
-    self.connect(self.uart.rx, self.conn.pins.allocate('3').as_digital_sink())
-    self.connect(self.gnd, self.conn.pins.allocate('4').as_voltage_sink())
+    self.connect(self.pwr, self.conn.pins.allocate('1').adapt_to(VoltageSink()))
+    self.connect(self.uart.tx, self.conn.pins.allocate('2').adapt_to(DigitalSource()))
+    self.connect(self.uart.rx, self.conn.pins.allocate('3').adapt_to(DigitalSink()))
+    self.connect(self.gnd, self.conn.pins.allocate('4').adapt_to(Ground()))
 
 
 class PulldownJumper(Block):
@@ -191,8 +191,8 @@ class PulldownJumper(Block):
     self.io = self.Port(DigitalSource.empty(), [Output])
 
     self.conn = self.Block(PassiveConnector())
-    self.connect(self.io, self.conn.pins.allocate('1').as_digital_source())
-    self.connect(self.gnd, self.conn.pins.allocate('2').as_voltage_sink())
+    self.connect(self.io, self.conn.pins.allocate('1').adapt_to(DigitalSource()))
+    self.connect(self.gnd, self.conn.pins.allocate('2').adapt_to(VoltageSink()))
 
 
 class Esp32c3_Wroom02(PinMappable, Microcontroller, IoController, Block):

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -267,8 +267,8 @@ class UsbDpPullUp(Block):
     self.usb = self.Port(UsbPassivePort.empty(), [InOut])
 
     self.dp = self.Block(Resistor(resistance))
-    self.connect(self.dp.a.as_voltage_sink(), self.pwr)
-    self.connect(self.usb.dp, self.dp.b.as_digital_bidir())  # ideal
+    self.connect(self.dp.a.adapt_to(VoltageSink()), self.pwr)
+    self.connect(self.usb.dp, self.dp.b.adapt_to(DigitalBidir()))  # ideal
     self.usb.dm.init_from(DigitalBidir())  # ideal
 
 

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -364,10 +364,10 @@ class Mdbt50q_UsbSeriesResistor(Block):
     self.usb_outer = self.Port(UsbDevicePort().empty())
     self.res_dp = self.Block(Resistor(27*Ohm(tol=0.01)))
     self.res_dm = self.Block(Resistor(27*Ohm(tol=0.01)))
-    self.connect(self.usb_inner.dp, self.res_dp.a.as_digital_bidir())  # TODO propagate params - needs bridge mechanism
-    self.connect(self.usb_outer.dp, self.res_dp.b.as_digital_bidir())
-    self.connect(self.usb_inner.dm, self.res_dm.a.as_digital_bidir())
-    self.connect(self.usb_outer.dm, self.res_dm.b.as_digital_bidir())
+    self.connect(self.usb_inner.dp, self.res_dp.a.adapt_to(DigitalBidir()))  # TODO propagate params - needs bridge mechanism
+    self.connect(self.usb_outer.dp, self.res_dp.b.adapt_to(DigitalBidir()))
+    self.connect(self.usb_inner.dm, self.res_dm.a.adapt_to(DigitalBidir()))
+    self.connect(self.usb_outer.dm, self.res_dm.b.adapt_to(DigitalBidir()))
 
 
 class Mdbt50q_1mv2(PinMappable, Microcontroller, IoController, GeneratorBlock):

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -26,8 +26,8 @@ class Er_Oled_091_3_Device(DiscreteChip):
         self.iref = self.Export(self.conn.pins.allocate('13'))
 
         self.spi = self.Port(SpiSlave.empty())
-        self.connect(self.spi.sck, self.conn.pins.allocate('11').as_digital_sink)
-        self.connect(self.spi.mosi, self.conn.pins.allocate('12').as_digital_sink)
+        self.connect(self.spi.sck, self.conn.pins.allocate('11').as_digital_sink())
+        self.connect(self.spi.mosi, self.conn.pins.allocate('12').as_digital_sink())
         self.spi.miso.not_connected()
 
         self.dc = self.Export(self.conn.pins.allocate('10').as_digital_sink())
@@ -46,7 +46,7 @@ class Er_Oled_091_3(Lcd, Block):
     def __init__(self) -> None:
         super().__init__()
         self.device = self.Block(Er_Oled_091_3_Device())
-        self.gnd = self.Export(self.device.gnd, [Common])
+        self.gnd = self.Export(self.device.vss, [Common])
         self.pwr = self.Export(self.device.vdd, [Power])
         self.res = self.Export(self.device.res)
         self.spi = self.Export(self.device.spi)

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -56,7 +56,7 @@ class Er_Oled_091_3(Lcd, Block):
         self.device = self.Block(Er_Oled_091_3_Device())
         self.gnd = self.Export(self.device.vss, [Common])
         self.pwr = self.Export(self.device.vdd, [Power])
-        self.res = self.Export(self.device.res)
+        self.reset = self.Export(self.device.res)
         self.spi = self.Export(self.device.spi)
         self.cs = self.Export(self.device.cs)
         self.dc = self.Export(self.device.dc)

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -8,7 +8,7 @@ class Er_Oled_091_3_Device(DiscreteChip):
     https://www.buydisplay.com/download/manual/ER-OLED0.91-3_Series_Datasheet.pdf"""
     def __init__(self) -> None:
         super().__init__()
-        # TODO IO models and whatnot
+
         self.conn = self.Block(Fpc050(length=15))
 
         self.vcc = self.Export(self.conn.pins.allocate('15').adapt_to(VoltageSource(
@@ -19,8 +19,12 @@ class Er_Oled_091_3_Device(DiscreteChip):
             voltage_limits=(1.65, 4)*Volt,  # use the absolute maximum upper limit to allow tolerance on 3.3v
             current_draw=(1, 300)*uAmp
         )))
+        # this provides a way to modify the minimum Vbat, which apparently works lower than the datasheet specification
+        # and is needed to drive both Vbat and Vdd off of a common 3.3v supply
+        # default of 3.3 is using SSD1306 datasheet v1.6, the panel datasheet is more restrictive
+        self.vbat_min = self.Parameter(FloatExpr(3.3*Volt))
         self.vbat = self.Export(self.conn.pins.allocate('5').adapt_to(VoltageSink(
-            voltage_limits=(3.3, 4.2)*Volt,  # using SSD1306 datasheet; OLED datasheet is more restrictive
+            voltage_limits=(self.vbat_min, 4.2*Volt),
             current_draw=(23, 29)*mAmp
         )))
         self.vss = self.Export(self.conn.pins.allocate('6').adapt_to(Ground()), [Common])

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -1,0 +1,79 @@
+from typing import *
+from electronics_abstract_parts import *
+from electronics_lib import Fpc050
+
+
+class Er_Oled_091_3_Device(DiscreteChip):
+    """15-pin FPC connector for the ER-OLED-0.91-3* device
+    https://www.buydisplay.com/download/manual/ER-OLED0.91-3_Series_Datasheet.pdf"""
+    def __init__(self) -> None:
+        super().__init__()
+        # TODO IO models and whatnot
+        self.conn = self.Block(Fpc050(length=15))
+
+        self.vcc = self.Export(self.conn.pins.allocate('15').as_voltage_source(
+
+        ))
+        self.vdd = self.Export(self.conn.pins.allocate('7').as_voltage_sink(
+
+        ))
+        self.vbat = self.Export(self.conn.pins.allocate('5').as_voltage_sink(
+
+        ))
+        self.vss = self.Export(self.conn.pins.allocate('6').as_ground(), [Common])
+
+        self.vcomh = self.Export(self.conn.pins.allocate('14'))
+        self.iref = self.Export(self.conn.pins.allocate('13'))
+
+        self.spi = self.Port(SpiSlave.empty())
+        self.connect(self.spi.sck, self.conn.pins.allocate('11').as_digital_sink)
+        self.connect(self.spi.mosi, self.conn.pins.allocate('12').as_digital_sink)
+        self.spi.miso.not_connected()
+
+        self.dc = self.Export(self.conn.pins.allocate('10').as_digital_sink())
+        self.res = self.Export(self.conn.pins.allocate('9').as_digital_sink())
+        self.cs = self.Export(self.conn.pins.allocate('8').as_digital_sink())
+
+        self.c2p = self.Export(self.conn.pins.allocate('1'))
+        self.c2n = self.Export(self.conn.pins.allocate('2'))
+        self.c1p = self.Export(self.conn.pins.allocate('3'))
+        self.c1n = self.Export(self.conn.pins.allocate('4'))
+
+
+class Er_Oled_091_3(Lcd, Block):
+    """SSD1306-based 0.91" 128x32 monochrome OLED.
+    TODO (maybe?) add the power gating circuit in the reference schematic"""
+    def __init__(self) -> None:
+        super().__init__()
+        self.device = self.Block(Er_Oled_091_3_Device())
+        self.gnd = self.Export(self.device.gnd, [Common])
+        self.pwr = self.Export(self.device.vdd, [Power])
+        self.res = self.Export(self.device.res)
+        self.spi = self.Export(self.device.spi)
+        self.cs = self.Export(self.device.cs)
+        self.dc = self.Export(self.device.dc)
+
+    def contents(self):
+        super().contents()
+
+        self.c1_cap = self.Block(Capacitor(0.1*uFarad(tol=0.2), (0, 6.3)*Volt))
+        self.connect(self.c1_cap.pos, self.device.c1p)
+        self.connect(self.c1_cap.neg, self.device.c1n)
+        self.c2_cap = self.Block(Capacitor(0.1*uFarad(tol=0.2), (0, 6.3)*Volt))
+        self.connect(self.c2_cap.pos, self.device.c2p)
+        self.connect(self.c2_cap.neg, self.device.c2n)
+        self.vcomh_cap = self.Block(Capacitor(2.2*uFarad(tol=0.2), (0, 16)*Volt))
+        self.connect(self.vcomh_cap.pos, self.device.vcomh)
+        self.connect(self.vcomh_cap.neg.as_ground(), self.gnd)
+
+        self.iref_res = self.Block(Resistor(resistance=560*kOhm(tol=0.05)))  # TODO dynamic sizing
+        self.connect(self.iref_res.a, self.device.iref)
+        self.connect(self.iref_res.b.as_ground(), self.gnd)
+
+        self.vdd_cap1 = self.Block(DecouplingCapacitor(capacitance=0.1*uFarad(tol=0.2))).connected(self.gnd, self.pwr)
+        self.vdd_cap2 = self.Block(DecouplingCapacitor(capacitance=4.7*uFarad(tol=0.2))).connected(self.gnd, self.pwr)
+
+        self.vcc_cap1 = self.Block(DecouplingCapacitor(capacitance=0.1*uFarad(tol=0.2)))\
+            .connected(self.gnd, self.device.vcc)
+        self.vcc_cap2 = self.Block(DecouplingCapacitor(capacitance=4.7*uFarad(tol=0.2)))\
+            .connected(self.gnd, self.device.vcc)

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -64,6 +64,8 @@ class Er_Oled_091_3(Lcd, Block):
     def contents(self):
         super().contents()
 
+        self.connect(self.pwr, self.device.vbat)
+
         self.c1_cap = self.Block(Capacitor(0.1*uFarad(tol=0.2), (0, 6.3)*Volt))
         self.connect(self.c1_cap.pos, self.device.c1p)
         self.connect(self.c1_cap.neg, self.device.c1n)
@@ -72,11 +74,10 @@ class Er_Oled_091_3(Lcd, Block):
         self.connect(self.c2_cap.neg, self.device.c2n)
         self.vcomh_cap = self.Block(Capacitor(2.2*uFarad(tol=0.2), (0, 16)*Volt))
         self.connect(self.vcomh_cap.pos, self.device.vcomh)
-        self.connect(self.vcomh_cap.neg.as_ground(), self.gnd)
-
+        self.connect(self.vcomh_cap.neg.adapt_to(Ground()), self.gnd)
         self.iref_res = self.Block(Resistor(resistance=560*kOhm(tol=0.05)))  # TODO dynamic sizing
         self.connect(self.iref_res.a, self.device.iref)
-        self.connect(self.iref_res.b.as_ground(), self.gnd)
+        self.connect(self.iref_res.b.adapt_to(Ground()), self.gnd)
 
         self.vdd_cap1 = self.Block(DecouplingCapacitor(capacitance=0.1*uFarad(tol=0.2))).connected(self.gnd, self.pwr)
         self.vdd_cap2 = self.Block(DecouplingCapacitor(capacitance=4.7*uFarad(tol=0.2))).connected(self.gnd, self.pwr)

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -91,22 +91,20 @@ class Fpc050Bottom(Fpc050):
   IMPORTANT: the pin numbering scheme differs for top- and bottom-contact connectors."""
 
 
-@abstract_block
 class HiroseFh12sh(Fpc050Bottom, FootprintBlock):
   """Hirose FH12 SH FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
   # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
-  _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
+  _fh12_pins = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
                      30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}
   # positions for which there are KiCad footprints
-  _kicad_positions = {6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28,
+  _kicad_pins = {6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28,
                       30, 32, 33, 34, 35, 36, 40, 45, 50, 53}
-  allowed_positions = _fh12_positions.intersection(_kicad_positions)
+  allowed_pins = _fh12_pins.intersection(_kicad_pins)
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_FFC-FPC:Hirose_FH12-{length}S-0.5SH_1x{length:02d}-1MP_P0.50mm_Horizontal',
             "Hirose", f"FH12-{length}S-0.5SH")
 
 
-@abstract_block
 class Te1734839(Fpc050Top, FootprintBlock):
   """TE x-1734839 FFC/FPC connector, 0.50mm pitch horizontal top contacts."""
   allowed_positions = range(5, 50)

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -81,16 +81,18 @@ class Fpc050(PassiveConnector):
 
 @abstract_block
 class Fpc050Top(Fpc050):
-  """Abstract base class for top-contact FPC connectors."""
+  """Abstract base class for top-contact FPC connectors.
+  IMPORTANT: the pin numbering scheme differs for top- and bottom-contact connectors."""
 
 
 @abstract_block
 class Fpc050Bottom(Fpc050):
-  """Abstract base class for top-contact FPC connectors."""
+  """Abstract base class for bottom-contact FPC connectors.
+  IMPORTANT: the pin numbering scheme differs for top- and bottom-contact connectors."""
 
 
 @abstract_block
-class HiroseFh12sh(Fpc050, FootprintBlock):
+class HiroseFh12sh(Fpc050Bottom, FootprintBlock):
   """Hirose FH12 SH FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
   # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
   _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
@@ -105,8 +107,8 @@ class HiroseFh12sh(Fpc050, FootprintBlock):
 
 
 @abstract_block
-class Te1734839(Fpc050, FootprintBlock):
-  """TE x-1734839 FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
+class Te1734839(Fpc050Top, FootprintBlock):
+  """TE x-1734839 FFC/FPC connector, 0.50mm pitch horizontal top contacts."""
   # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
   _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
                      30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -109,13 +109,7 @@ class HiroseFh12sh(Fpc050Bottom, FootprintBlock):
 @abstract_block
 class Te1734839(Fpc050Top, FootprintBlock):
   """TE x-1734839 FFC/FPC connector, 0.50mm pitch horizontal top contacts."""
-  # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
-  _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
-                     30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}
-  # positions for which there are KiCad footprints
-  _kicad_positions = {6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28,
-                      30, 32, 33, 34, 35, 36, 40, 45, 50, 53}
-  allowed_positions = _fh12_positions.intersection(_kicad_positions)
+  allowed_positions = range(5, 50)
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_FFC-FPC:TE_{length // 10}-1734839-{length % 10}_1x{length:02d}-1MP_P0.5mm_Horizontal',
             "TE Connectivity", f"{length // 10}-1734839-{length % 10}")

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -74,3 +74,19 @@ class MolexSl(PassiveConnector, FootprintBlock):
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_Molex:Molex_SL_171971-00{length:02d}_1x{length:02d}_P2.54mm_Vertical',
             "Molex", f"171971-00{length:02d}_1x{length:02d}")
+
+
+@abstract_block
+class Fpc050(PassiveConnector):
+  """Abstract base class for 0.50mm pitch FPC connectors."""
+
+
+@abstract_block
+class HiroseFh12sh(Fpc050, FootprintBlock):
+  """Hirose FH12 FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
+  allowed_pins = (2, 25)
+  def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
+    return (f'Connector_Molex:Molex_SL_171971-00{length:02d}_1x{length:02d}_P2.54mm_Vertical',
+            "Molex", f"171971-00{length:02d}_1x{length:02d}")
+
+    Hirose_FH12-6S-0.5SH_1x06-1MP_P0.50mm_Horizontal

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Iterable
 from electronics_abstract_parts import *
 
 
@@ -11,7 +11,7 @@ class PassiveConnector(Connector, GeneratorBlock, FootprintBlock):
   than the maximum pin index (but can be smaller, unassigned pins are NC).
   The allocated pin names correlate with the footprint pin, 1-indexed (per electronics convention).
   It is up to the instantiating layer to set the pinmap (or allow the user to set it by refinements)."""
-  allowed_pins: Tuple[int, int] = (0, 0)  # inclusive on both ends, default disallowed anywhere
+  allowed_pins: Iterable[int]
 
   @init_in_parent
   def __init__(self, length: IntLike = 0):
@@ -38,10 +38,8 @@ class PassiveConnector(Connector, GeneratorBlock, FootprintBlock):
     self.assign(self.actual_length, length)
     self.require(max_pin_index <= self.actual_length,
                  f"maximum pin index {max_pin_index} over requested length {length}")
-    self.require(self.actual_length >= self.allowed_pins[0],
-                 f"requested length {length} below allowed range {self.allowed_pins[0]} - {self.allowed_pins[1]}")
-    self.require(self.actual_length <= self.allowed_pins[1],
-                 f"requested length {length} above allowed range {self.allowed_pins[0]} - {self.allowed_pins[1]}")
+    # TODO ideally this is require, but we don't support set ops in the IR
+    assert length in self.allowed_pins, f"requested length {length} outside allowed length {self.allowed_pins}"
 
     (footprint, mfr, part) = self.part_footprint_mfr_name(length)
     self.footprint(
@@ -53,7 +51,7 @@ class PassiveConnector(Connector, GeneratorBlock, FootprintBlock):
 
 class PinHeader254(PassiveConnector, FootprintBlock):
   """Generic 2.54mm pin header in vertical through-hole."""
-  allowed_pins = (2, 16)
+  allowed_pins = range(2, 16+1)
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_PinHeader_2.54mm:PinHeader_1x{length:02d}_P2.54mm_Vertical',
             "Generic", f"PinHeader2.54 1x{length}")
@@ -61,7 +59,7 @@ class PinHeader254(PassiveConnector, FootprintBlock):
 
 class JstPhK(PassiveConnector, FootprintBlock):
   """JST PH-K series connector: 2.00mm shrouded and polarized, in vertical through-hole."""
-  allowed_pins = (2, 16)
+  allowed_pins = range(2, 16+1)
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_JST:JST_PH_B{length}B-PH-K_1x{length:02d}_P2.00mm_Vertical',
             "JST", f"B{length}B-PH-K")
@@ -70,7 +68,7 @@ class JstPhK(PassiveConnector, FootprintBlock):
 class MolexSl(PassiveConnector, FootprintBlock):
   """Molex SL series connector: 2.54mm shrouded and polarized, in vertical through-hole.
   Breadboard wire compatible - especially for debugging in a pinch."""
-  allowed_pins = (2, 25)
+  allowed_pins = range(2, 25+1)
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_Molex:Molex_SL_171971-00{length:02d}_1x{length:02d}_P2.54mm_Vertical',
             "Molex", f"171971-00{length:02d}_1x{length:02d}")
@@ -82,11 +80,15 @@ class Fpc050(PassiveConnector):
 
 
 @abstract_block
-class HiroseFh12sh(Fpc050, FootprintBlock):
+class HiroseFh12(Fpc050, FootprintBlock):
   """Hirose FH12 FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
-  allowed_pins = (2, 25)
+  # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
+  _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
+                     30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}
+  # positions for which there are KiCad footprints
+  _kicad_positions = {6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28,
+                      30, 32, 33, 34, 35, 36, 40, 45, 50, 53}
+  allowed_positions = _fh12_positions.intersection(_kicad_positions)
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
-    return (f'Connector_Molex:Molex_SL_171971-00{length:02d}_1x{length:02d}_P2.54mm_Vertical',
-            "Molex", f"171971-00{length:02d}_1x{length:02d}")
-
-    Hirose_FH12-6S-0.5SH_1x06-1MP_P0.50mm_Horizontal
+    return (f'Connector_FFC-FPC:Hirose_FH12-{length}S-0.5SH_1x{length:02d}-1MP_P0.50mm_Horizontal',
+            "Hirose", f"FH12-{length}S-0.5SH")

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -92,7 +92,8 @@ class Fpc050Bottom(Fpc050):
 
 
 class HiroseFh12sh(Fpc050Bottom, FootprintBlock):
-  """Hirose FH12 SH FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
+  """Hirose FH12 SH FFC/FPC connector, 0.50mm pitch horizontal bottom contacts.
+  Mostly footprint-compatible with TE 1775333-8, which is cheaper."""
   # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
   _fh12_pins = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
                      30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -80,8 +80,18 @@ class Fpc050(PassiveConnector):
 
 
 @abstract_block
-class HiroseFh12(Fpc050, FootprintBlock):
-  """Hirose FH12 FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
+class Fpc050Top(Fpc050):
+  """Abstract base class for top-contact FPC connectors."""
+
+
+@abstract_block
+class Fpc050Bottom(Fpc050):
+  """Abstract base class for top-contact FPC connectors."""
+
+
+@abstract_block
+class HiroseFh12sh(Fpc050, FootprintBlock):
+  """Hirose FH12 SH FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
   # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
   _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
                      30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}
@@ -92,3 +102,18 @@ class HiroseFh12(Fpc050, FootprintBlock):
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     return (f'Connector_FFC-FPC:Hirose_FH12-{length}S-0.5SH_1x{length:02d}-1MP_P0.50mm_Horizontal',
             "Hirose", f"FH12-{length}S-0.5SH")
+
+
+@abstract_block
+class Te1734839(Fpc050, FootprintBlock):
+  """TE x-1734839 FFC/FPC connector, 0.50mm pitch horizontal bottom contacts."""
+  # positions the FH12 exists in, per https://www.hirose.com/product/series/FH12
+  _fh12_positions = {4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28, 29,
+                     30, 32, 33, 34, 35, 36, 40, 42, 45, 49, 50, 53, 60}
+  # positions for which there are KiCad footprints
+  _kicad_positions = {6, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 25, 26, 28,
+                      30, 32, 33, 34, 35, 36, 40, 45, 50, 53}
+  allowed_positions = _fh12_positions.intersection(_kicad_positions)
+  def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
+    return (f'Connector_FFC-FPC:TE_{length // 10}-1734839-{length % 10}_1x{length:02d}-1MP_P0.5mm_Horizontal',
+            "TE Connectivity", f"{length // 10}-1734839-{length % 10}")

--- a/electronics_lib/PowerConditioning.py
+++ b/electronics_lib/PowerConditioning.py
@@ -101,7 +101,7 @@ class BufferedSupply(PowerConditioner):
         voltage_out=(0, self.pwr.link().voltage.upper()),
         impedance=0*Ohm(tol=0)
       )))
-      self.connect(self.amp.out, self.fet.gate.as_analog_sink())
+      self.connect(self.amp.out, self.fet.gate.adapt_to(AnalogSink()))
 
     self.cap = self.Block(Supercap())
     self.connect(self.sc_out, self.cap.pos)

--- a/electronics_lib/Speakers.py
+++ b/electronics_lib/Speakers.py
@@ -68,7 +68,7 @@ class Lm4871(IntegratedCircuit):
       capacitance=1.0*uFarad(tol=0.2),
       voltage=self.pwr.link().voltage  # TODO actually half the voltage, but needs const prop
     ))
-    self.connect(self.gnd, self.byp_cap.neg.as_ground())
+    self.connect(self.gnd, self.byp_cap.neg.adapt_to(Ground()))
 
     self.sig_cap = self.Block(Capacitor(  # TODO replace with dc-block filter
       capacitance=0.47*uFarad(tol=0.2),
@@ -80,10 +80,10 @@ class Lm4871(IntegratedCircuit):
     self.fb_res = self.Block(Resistor(
       resistance=20*kOhm(tol=0.2)
     ))
-    self.connect(self.sig, self.sig_cap.neg.as_analog_sink())
+    self.connect(self.sig, self.sig_cap.neg.adapt_to(AnalogSink()))
     self.connect(self.sig_cap.pos, self.sig_res.a)
     self.connect(self.sig_res.b, self.fb_res.a, self.ic.inm)
-    self.connect(self.spk.a, self.ic.vo1, self.fb_res.b.as_analog_sink())
+    self.connect(self.spk.a, self.ic.vo1, self.fb_res.b.adapt_to(AnalogSink()))
     self.connect(self.spk.b, self.ic.vo2)
 
     self.connect(self.byp_cap.pos, self.ic.inp, self.ic.byp)
@@ -179,15 +179,15 @@ class Tpa2005d1(IntegratedCircuit, GeneratorBlock):
 
     self.inp_cap = self.Block(in_cap_model)
     self.inp_res = self.Block(in_res_model)
-    self.connect(self.sig, self.inp_cap.neg.as_analog_sink())
+    self.connect(self.sig, self.inp_cap.neg.adapt_to(AnalogSink()))
     self.connect(self.inp_cap.pos, self.inp_res.a)
-    self.connect(self.inp_res.b.as_analog_source(), self.ic.inp)
+    self.connect(self.inp_res.b.adapt_to(AnalogSource()), self.ic.inp)
 
     self.inn_cap = self.Block(in_cap_model)
     self.inn_res = self.Block(in_res_model)
-    self.connect(self.gnd, self.inn_cap.neg.as_ground())
+    self.connect(self.gnd, self.inn_cap.neg.adapt_to(Ground()))
     self.connect(self.inn_cap.pos, self.inn_res.a)
-    self.connect(self.inn_res.b.as_analog_source(), self.ic.inn)
+    self.connect(self.inn_res.b.adapt_to(AnalogSource()), self.ic.inn)
 
     self.connect(self.spk.a, self.ic.vo1)
     self.connect(self.spk.b, self.ic.vo2)
@@ -209,5 +209,9 @@ class ConnectorSpeaker(Speaker):
 
     self.conn = self.Block(PassiveConnector())
 
-    self.connect(self.input.a, self.conn.pins.allocate('1').as_analog_sink(impedance=impedance))
-    self.connect(self.input.b, self.conn.pins.allocate('2').as_analog_sink(impedance=impedance))
+    self.connect(self.input.a, self.conn.pins.allocate('1').adapt_to(AnalogSink(
+      impedance=impedance)
+    ))
+    self.connect(self.input.b, self.conn.pins.allocate('2').adapt_to(AnalogSink(
+      impedance=impedance)
+    ))

--- a/electronics_lib/UsbPorts.py
+++ b/electronics_lib/UsbPorts.py
@@ -144,7 +144,7 @@ class UsbDeviceCReceptacle(UsbDeviceConnector):
     self.connect(self.usb, self.port.usb)
 
     (self.cc_pull, ), _ = self.chain(self.port.cc, self.Block(UsbCcPulldownResistor()))
-    self.connect(self.gnd, self.port.gnd, self.port.shield.as_ground(), self.cc_pull.gnd)
+    self.connect(self.gnd, self.port.gnd, self.port.shield.adapt_to(Ground()), self.cc_pull.gnd)
 
 
 class UsbCcPulldownResistor(Block):

--- a/electronics_lib/__init__.py
+++ b/electronics_lib/__init__.py
@@ -63,6 +63,7 @@ from .DacSpi_Mcp4901 import Mcp4921
 from .Rtc_Pcf2129 import Pcf2129
 from .RfModules import Xbee_S3b, BlueSmirf
 from .Lcd_Qt096t_if09 import Qt096t_if09
+from .Oled_Er_Oled_091_3 import Er_Oled_091_3
 from .Oled_Nhd_312_25664uc import Nhd_312_25664uc
 from .EInk_E2154fs091 import E2154fs091
 from .SolidStateRelay_G3VM_61GR2 import G3VM_61GR2

--- a/electronics_lib/__init__.py
+++ b/electronics_lib/__init__.py
@@ -28,6 +28,7 @@ from .Opamp_Tlv9061 import Tlv9061
 from .Opamp_Opa197 import Opa197
 
 from .PassiveConnector import PassiveConnector, PinHeader254, JstPhK, MolexSl
+from .PassiveConnector import Fpc050, Fpc050Top, Fpc050Bottom, HiroseFh12sh, Te1734839
 
 from .DebugHeaders import SwdCortexTargetWithTdiConnector, SwdCortexTargetHeader
 from .DebugHeaders import SwdCortexSourceHeaderHorizontal

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -262,7 +262,6 @@ class DigitalSource(DigitalBase):
                pulldown_capable: BoolLike = Default(False)) -> None:
     super().__init__()
     self.bridge_type = DigitalSourceBridge
-    self.adapter_types = [DigitalSourceAdapterVoltageSource]
 
     self.voltage_out: RangeExpr = self.Parameter(RangeExpr(voltage_out))
     self.current_limits: RangeExpr = self.Parameter(RangeExpr(current_limits))

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -40,8 +40,8 @@ class DigitalLink(CircuitLink):
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.voltage_limits, "V"),
       "\n<b>current</b>: ", DescriptionString.FormatUnits(self.current_drawn, "A"),
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.current_limits, "A"),
-      "\n<b>output thresholds</b>: ", DescriptionString.FormatUnits(self.output_thresholds, "Ω"),
-      ", <b>input thresholds</b>: ", DescriptionString.FormatUnits(self.input_thresholds, "Ω"))
+      "\n<b>output thresholds</b>: ", DescriptionString.FormatUnits(self.output_thresholds, "V"),
+      ", <b>input thresholds</b>: ", DescriptionString.FormatUnits(self.input_thresholds, "V"))
 
   def contents(self):
     super().contents()

--- a/electronics_model/PassivePort.py
+++ b/electronics_model/PassivePort.py
@@ -148,6 +148,8 @@ class Passive(CircuitPort[PassiveLink]):
     # with the adapter constructor argument fields by name
     import inspect
     adapter_type_map: Dict[Type[Port], Type[CircuitPortAdapter]] = {
+      VoltageSource: PassiveAdapterVoltageSource,
+      VoltageSink: PassiveAdapterVoltageSink,
       DigitalSink: PassiveAdapterDigitalSink,
       DigitalSource: PassiveAdapterDigitalSource,
       DigitalBidir: PassiveAdapterDigitalBidir,
@@ -161,8 +163,8 @@ class Passive(CircuitPort[PassiveLink]):
     adapter_init_params = inspect.signature(adapter_cls.__init__).parameters
     adapter_init_kwargs = {}  # make everything kwargs for simplicity
     for arg_name, arg_param in list(adapter_init_params.items())[1:]:  # discard 0=self
-      assert arg_param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD),\
-        "*args, **kwargs not supported"
+      assert arg_param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD),\
+        "only positional and keyword args supported for initializer, *args and **kwargs not supported"
       that_initializer = that._parameters[arg_name].initializer
       assert that_initializer is not None
       adapter_init_kwargs[arg_name] = that_initializer

--- a/electronics_model/PassivePort.py
+++ b/electronics_model/PassivePort.py
@@ -160,14 +160,10 @@ class Passive(CircuitPort[PassiveLink]):
     adapter_cls = adapter_type_map[that.__class__]
 
     # map initializers from that to constructor args
-    adapter_init_params = inspect.signature(adapter_cls.__init__).parameters
     adapter_init_kwargs = {}  # make everything kwargs for simplicity
-    for arg_name, arg_param in list(adapter_init_params.items())[1:]:  # discard 0=self
-      assert arg_param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD),\
-        "only positional and keyword args supported for initializer, *args and **kwargs not supported"
-      that_initializer = that._parameters[arg_name].initializer
-      assert that_initializer is not None
-      adapter_init_kwargs[arg_name] = that_initializer
+    for param_name, param in that._parameters.items():
+      assert param.initializer is not None
+      adapter_init_kwargs[param_name] = param.initializer
 
     return self._convert(adapter_cls(**adapter_init_kwargs))
 

--- a/electronics_model/VoltagePorts.py
+++ b/electronics_model/VoltagePorts.py
@@ -155,7 +155,6 @@ class VoltageSource(VoltageBase):
                current_limits: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()
     self.bridge_type = VoltageSourceBridge
-    self.adapter_types = [VoltageSinkAdapterDigitalSource, VoltageSinkAdapterAnalogSource]
 
     self.voltage_out: RangeExpr = self.Parameter(RangeExpr(voltage_out))
     self.current_limits: RangeExpr = self.Parameter(RangeExpr(current_limits))

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -264,8 +264,8 @@ class Ref_Bh1620fvc(Block):
 
     self.require(rload.within((1, 1000)*kOhm))
     self.load = self.Block(Resistor(resistance=rload))
-    self.connect(self.vout, self.load.a.as_analog_sink())
-    self.connect(self.gnd, self.load.b.as_ground())
+    self.connect(self.vout, self.load.a.adapt_to(AnalogSink()))
+    self.connect(self.gnd, self.load.b.adapt_to(Ground()))
 
   def contents(self) -> None:
     super().contents()

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -24,15 +24,17 @@ class SwdSourceBitBang(Block):
     self.swo_res = self.Block(Resistor(resistance=22*Ohm(tol=0.05)))
 
     # TODO simplify using DigitalSeriesResistor(?) and chain
-    self.connect(self.reset_res.a.as_digital_sink(), self.reset_in)
-    self.connect(self.reset_res.b.as_digital_source(), self.swd.reset)
-    self.connect(self.swclk_res.a.as_digital_sink(), self.swclk_in)
-    self.connect(self.swclk_res.b.as_digital_source(), self.swd.swclk)
-    self.connect(self.swdio_drv_res.a.as_digital_sink(), self.swdio_in)
-    self.connect(self.swdio_res.a.as_digital_bidir(), self.swdio_drv_res.b.as_digital_bidir(), self.swdio_out)
-    self.connect(self.swdio_res.b.as_digital_sink(), self.swd.swdio)
-    self.connect(self.swo_res.a.as_digital_source(), self.swo_out)
-    self.connect(self.swo_res.b.as_digital_sink(), self.swd.swo)
+    self.connect(self.reset_res.a.adapt_to(DigitalSink()), self.reset_in)
+    self.connect(self.reset_res.b.adapt_to(DigitalSource()), self.swd.reset)
+    self.connect(self.swclk_res.a.adapt_to(DigitalSink()), self.swclk_in)
+    self.connect(self.swclk_res.b.adapt_to(DigitalSource()), self.swd.swclk)
+    self.connect(self.swdio_drv_res.a.adapt_to(DigitalSink()), self.swdio_in)
+    self.connect(self.swdio_res.a.adapt_to(DigitalBidir()),
+                 self.swdio_drv_res.b.adapt_to(DigitalBidir()),
+                 self.swdio_out)
+    self.connect(self.swdio_res.b.adapt_to(DigitalSink()), self.swd.swdio)
+    self.connect(self.swo_res.a.adapt_to(DigitalSource()), self.swo_out)
+    self.connect(self.swo_res.b.adapt_to(DigitalSink()), self.swd.swo)
 
 
 class Debugger(BoardTop):
@@ -74,7 +76,7 @@ class Debugger(BoardTop):
       self.tdi_res = imp.Block(Resistor(22*Ohm(tol=0.05)))
 
       self.connect(self.target_drv.swd, self.target.swd)
-      self.connect(self.tdi_res.b.as_digital_source(), self.target.tdi)
+      self.connect(self.tdi_res.b.adapt_to(DigitalSource()), self.target.tdi)
 
       self.sw_usb = imp.Block(DigitalSwitch())
 
@@ -92,7 +94,7 @@ class Debugger(BoardTop):
     self.connect(self.mcu.gpio.allocate('target_swdio_in'), self.target_drv.swdio_in)
     self.connect(self.mcu.gpio.allocate('target_reset'), self.target_drv.reset_in)
     self.connect(self.mcu.gpio.allocate('target_swo'), self.target_drv.swo_out)
-    self.connect(self.mcu.gpio.allocate('target_tdi'), self.tdi_res.a.as_digital_source())
+    self.connect(self.mcu.gpio.allocate('target_tdi'), self.tdi_res.a.adapt_to(DigitalSource()))
 
     self.connect(self.mcu.gpio.allocate('lcd_led'), self.lcd.led)
     self.connect(self.mcu.gpio.allocate('lcd_reset'), self.lcd.reset)

--- a/examples/test_ledmatrix.py
+++ b/examples/test_ledmatrix.py
@@ -78,7 +78,7 @@ class CharlieplexedLedMatrix(GeneratorBlock):
         source_current = (io_voltage / col_res.actual_resistance).upper().max(source_current)
 
       self.connect(self.ios.append_elt(DigitalSink.empty(), str(index)),
-                   passive_io.as_digital_sink(current_draw=(sink_current, source_current)))
+                   passive_io.adapt_to(DigitalSink(current_draw=(sink_current, source_current))))
 
 
 class LedMatrixTest(JlcBoardTop):

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -139,7 +139,7 @@ class MultimeterCurrentDriver(Block):
 
       self.sw = imp.Block(AnalogMuxer()).mux_to(  # enable switch
         [fet_source_node, self.amp.out],
-        self.fet.gate.as_analog_sink()
+        self.fet.gate.adapt_to(AnalogSink())
       )
       self.connect(self.enable, self.sw.control.allocate())
 
@@ -185,14 +185,14 @@ class FetPowerGate(Block):
       drain_current=(0, max_current),
       gate_voltage=(max_voltage, max_voltage),  # TODO this ignores the diode drop
     ))
-    self.connect(self.pwr_in, self.pwr_fet.source.as_voltage_sink(
+    self.connect(self.pwr_in, self.pwr_fet.source.adapt_to(VoltageSink(
       current_draw=self.pwr_out.link().current_drawn,
       voltage_limits=RangeExpr.ALL,
-    ))
-    self.connect(self.pwr_fet.drain.as_voltage_source(
+    )))
+    self.connect(self.pwr_fet.drain.adapt_to(VoltageSource(
       voltage_out = self.pwr_in.link().voltage,
       current_limits=RangeExpr.ALL,
-    ), self.pwr_out)
+    )), self.pwr_out)
 
     self.amp_res = self.Block(Resistor(
       resistance=10*kOhm(tol=0.05)  # TODO kind of arbitrary

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -59,7 +59,7 @@ class MultimeterAnalog(Block):
     super().contents()
 
     self.res = self.Block(Resistor(1*MOhm(tol=0.01)))
-    self.connect(self.res.a.as_analog_sink(), self.input_positive)
+    self.connect(self.res.a.adapt_to(AnalogSink()), self.input_positive)
 
     with self.implicit_connect(
         ImplicitConnect(self.gnd, [Common]),
@@ -71,12 +71,12 @@ class MultimeterAnalog(Block):
         100*kOhm(tol=0.01),  # 1:10 step (+/- 10 V range)
         Range(float('inf'), float('inf'))  # 1:1 step, open circuit
       ]))
-      self.connect(self.range.input.as_analog_sink(), self.input_negative)
-      self.connect(self.res.b.as_analog_source(
+      self.connect(self.range.input.adapt_to(AnalogSink()), self.input_negative)
+      self.connect(self.res.b.adapt_to(AnalogSource(
         voltage_out=(self.gnd.link().voltage.lower(), self.pwr.link().voltage.upper()),
         current_limits=(-10, 10)*mAmp,
         impedance=1*mOhm(tol=0)
-      ), self.range.com.as_analog_sink(), self.output)
+      )), self.range.com.adapt_to(AnalogSink()), self.output)
 
       self.connect(self.select, self.range.control)
 
@@ -123,17 +123,17 @@ class MultimeterCurrentDriver(Block):
         100*kOhm(tol=0.01),  # 10 uA range
         1*MOhm(tol=0.01),  # 1 uA range (for MOhm measurements)
       ]))
-      self.connect(self.pwr, self.range.input.as_voltage_sink(
+      self.connect(self.pwr, self.range.input.adapt_to(VoltageSink(
         current_draw=(0, max_in_voltage / 1000)  # approx lowest resistance - TODO properly model the resistor mux
-      ))
-      fet_source_node = self.fet.source.as_analog_sink()
+      )))
+      fet_source_node = self.fet.source.adapt_to(AnalogSink())
       self.connect(
         self.amp.inn,
         fet_source_node,
-        self.range.com.as_analog_source(
+        self.range.com.adapt_to(AnalogSource(
           voltage_out=(0, max_in_voltage),
           impedance=(1, 1000)*kOhm  # TODO properly model resistor mux
-        ))
+        )))
 
       self.connect(self.select, self.range.control)
 
@@ -150,9 +150,9 @@ class MultimeterCurrentDriver(Block):
       reverse_recovery_time=RangeExpr.ALL
     ))
     self.connect(self.fet.drain, self.diode.anode)
-    self.connect(self.diode.cathode.as_analog_sink(  # TODO should be analog source
+    self.connect(self.diode.cathode.adapt_to(AnalogSink(  # TODO should be analog source
       voltage_limits=self.voltage_rating
-    ), self.output)
+    )), self.output)
 
 
 class FetPowerGate(Block):
@@ -179,7 +179,7 @@ class FetPowerGate(Block):
     self.pull_res = self.Block(Resistor(
       resistance=10*kOhm(tol=0.05)  # TODO kind of arbitrrary
     ))
-    self.connect(self.pwr_in, self.pull_res.a.as_voltage_sink())
+    self.connect(self.pwr_in, self.pull_res.a.adapt_to(VoltageSink()))
     self.pwr_fet = self.Block(Fet.PFet(
       drain_voltage=(0, max_voltage),
       drain_current=(0, max_current),
@@ -202,7 +202,8 @@ class FetPowerGate(Block):
       drain_current=(0, 0),  # effectively no current
       gate_voltage=(self.control.link().output_thresholds.upper(), self.control.link().voltage.upper())
     ))
-    self.connect(self.control, self.amp_fet.gate.as_digital_sink(), self.amp_res.a.as_digital_sink())  # TODO more modeling here?
+    self.connect(self.control, self.amp_fet.gate.adapt_to(DigitalSink()),
+                 self.amp_res.a.adapt_to(DigitalSink()))  # TODO more modeling here?
 
     self.ctl_diode = self.Block(Diode(
       reverse_voltage=(0, max_voltage),
@@ -218,14 +219,14 @@ class FetPowerGate(Block):
     ))
     self.btn = self.Block(Switch(voltage=0*Volt(tol=0)))  # TODO - actually model switch voltage
     self.connect(self.btn.a, self.ctl_diode.cathode, self.btn_diode.cathode)
-    self.connect(self.gnd, self.amp_fet.source.as_ground(), self.amp_res.b.as_ground(),
-                 self.btn.b.as_ground())
+    self.connect(self.gnd, self.amp_fet.source.adapt_to(Ground()), self.amp_res.b.adapt_to(Ground()),
+                 self.btn.b.adapt_to(Ground()))
 
-    self.connect(self.btn_diode.anode.as_digital_single_source(
+    self.connect(self.btn_diode.anode.adapt_to(DigitalSingleSource(
       voltage_out=self.gnd.link().voltage,  # TODO model diode drop,
       output_thresholds=(self.gnd.link().voltage.upper(), float('inf')),
       low_signal_driver=True
-    ), self.btn_out)
+    )), self.btn_out)
 
     self.connect(self.pull_res.b, self.ctl_diode.anode, self.pwr_fet.gate, self.amp_fet.drain)
 
@@ -362,17 +363,17 @@ class MultimeterTest(JlcBoardTop):
         inputs=[self.gnd_src.dst, self.ref_buf.output]
       )
       self.inn_merge = self.Block(MergedAnalogSource()).connected_from(
-        self.inn_mux.out, self.inn.port.as_analog_source())
+        self.inn_mux.out, self.inn.port.adapt_to(AnalogSource()))
 
       self.connect(self.mcu.gpio.allocate_vector('inn_control'), self.inn_mux.control)
 
       # POSITIVE PORT
       self.inp = self.Block(BananaSafetyJack())
-      inp_port = self.inp.port.as_analog_source(
+      inp_port = self.inp.port.adapt_to(AnalogSource(
         voltage_out=VOLTAGE_RATING,
         current_limits=(0, 10)*mAmp,
         impedance=(0, 100)*Ohm,
-      )
+      ))
 
       # MEASUREMENT / SIGNAL CONDITIONING CIRCUITS
       adc_spi = self.mcu.spi.allocate('adc_spi')

--- a/examples/test_tofarray.py
+++ b/examples/test_tofarray.py
@@ -13,13 +13,13 @@ class CanConnector(Connector):
     self.differential = self.Port(CanDiffPort().empty(), [Output])
 
     self.conn = self.Block(PassiveConnector())
-    self.connect(self.pwr, self.conn.pins.allocate('2').as_voltage_source(
+    self.connect(self.pwr, self.conn.pins.allocate('2').adapt_to(VoltageSource(
       voltage_out=(7, 14) * Volt,  # TODO get limits from CAN power brick?
       current_limits=(0, 0.15) * Amp  # TODO get actual limits from ???
-    ))
-    self.connect(self.gnd, self.conn.pins.allocate('3').as_ground_source())
-    self.connect(self.differential.canh, self.conn.pins.allocate('4').as_digital_source())
-    self.connect(self.differential.canl, self.conn.pins.allocate('5').as_digital_source())
+    )))
+    self.connect(self.gnd, self.conn.pins.allocate('3').adapt_to(GroundSource()))
+    self.connect(self.differential.canh, self.conn.pins.allocate('4').adapt_to(DigitalSource()))
+    self.connect(self.differential.canl, self.conn.pins.allocate('5').adapt_to(DigitalSource()))
 
 
 class TofArrayTest(JlcBoardTop):

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -76,10 +76,10 @@ class GatedEmitterFollower(Block):
 
       self.connect(self.high_fet.source, self.high_res.a)
       self.connect(self.low_fet.source, self.low_res.a)
-      self.connect(self.high_res.b.as_analog_source(), self.high_gate.apull)
-      self.connect(self.low_res.b.as_analog_source(), self.low_gate.apull)
-      self.connect(self.high_gate.aout, self.high_fet.gate.as_analog_sink())
-      self.connect(self.low_gate.aout, self.low_fet.gate.as_analog_sink())
+      self.connect(self.high_res.b.adapt_to(AnalogSource()), self.high_gate.apull)
+      self.connect(self.low_res.b.adapt_to(AnalogSource()), self.low_gate.apull)
+      self.connect(self.high_gate.aout, self.high_fet.gate.adapt_to(AnalogSink()))
+      self.connect(self.low_gate.aout, self.low_fet.gate.adapt_to(AnalogSink()))
 
 
 class ErrorAmplifier(GeneratorBlock):
@@ -127,16 +127,16 @@ class ErrorAmplifier(GeneratorBlock):
     self.rbot = self.Block(Resistor(
       resistance=Range.from_tolerance(bottom_resistance, tolerance)
     ))
-    self.connect(self.target, self.rtop.a.as_analog_sink(
+    self.connect(self.target, self.rtop.a.adapt_to(AnalogSink(
       impedance=self.rtop.actual_resistance + self.rbot.actual_resistance
-    ))
-    self.connect(self.actual, self.rbot.a.as_analog_sink(
+    )))
+    self.connect(self.actual, self.rbot.a.adapt_to(AnalogSink(
       impedance=self.rtop.actual_resistance + self.rbot.actual_resistance
-    ))
-    self.connect(self.amp.inp, self.rtop.b.as_analog_source(
+    )))
+    self.connect(self.amp.inp, self.rtop.b.adapt_to(AnalogSource(
       voltage_out=self.target.link().voltage.hull(self.actual.link().voltage),
       impedance=1 / (1 / self.rtop.actual_resistance + 1 / self.rbot.actual_resistance)
-    ), self.rbot.b.as_analog_sink())  # a side contains aggregate params, b side is dummy
+    )), self.rbot.b.adapt_to(AnalogSink()))  # a side contains aggregate params, b side is dummy
 
     self.rout = self.Block(Resistor(
       resistance=output_resistance
@@ -151,26 +151,26 @@ class ErrorAmplifier(GeneratorBlock):
         reverse_recovery_time=(0, 500)*nSecond  # arbitrary for "fast recovery"
       ))
       if diode_spec == 'source':
-        self.connect(self.amp.out, self.diode.anode.as_analog_sink(
+        self.connect(self.amp.out, self.diode.anode.adapt_to(AnalogSink(
           impedance=self.rout.actual_resistance + self.output.link().sink_impedance
-        ))
-        resistor_output_port = self.diode.cathode.as_analog_source(
+        )))
+        resistor_output_port = self.diode.cathode.adapt_to(AnalogSource(
           impedance=self.amp.out.link().source_impedance + self.rout.actual_resistance
-        )
+        ))
       elif diode_spec == 'sink':
-        self.connect(self.amp.out, self.diode.cathode.as_analog_sink(
+        self.connect(self.amp.out, self.diode.cathode.adapt_to(AnalogSink(
           impedance=self.rout.actual_resistance + self.output.link().sink_impedance
-        ))
-        resistor_output_port = self.diode.anode.as_analog_source(
+        )))
+        resistor_output_port = self.diode.anode.adapt_to(AnalogSource(
           impedance=self.amp.out.link().source_impedance + self.rout.actual_resistance
-        )
+        ))
       else:
         raise ValueError(f"invalid diode spec '{diode_spec}', expected '', 'source', or 'sink'")
-    self.connect(resistor_output_port, self.rout.a.as_analog_sink())
-    self.connect(self.output, self.rout.b.as_analog_source(
+    self.connect(resistor_output_port, self.rout.a.adapt_to(AnalogSink()))
+    self.connect(self.output, self.rout.b.adapt_to(AnalogSource(
       voltage_out=self.amp.out.link().voltage,
       impedance=self.rout.actual_resistance
-    ), self.amp.inn)
+    )), self.amp.inn)
 
 
 class SourceMeasureControl(Block):
@@ -383,9 +383,9 @@ class UsbSourceMeasureTest(JlcBoardTop):
       self.connect(self.mcu.gpio.allocate('low_en'), self.control.low_en)
 
     self.outn = self.Block(BananaSafetyJack())
-    self.connect(self.gnd, self.outn.port.as_voltage_sink())
+    self.connect(self.gnd, self.outn.port.adapt_to(VoltageSink()))
     self.outp = self.Block(BananaSafetyJack())
-    self.connect(self.outp.port.as_voltage_sink(), self.control.out)
+    self.connect(self.outp.port.adapt_to(VoltageSink()), self.control.out)
 
     # TODO next revision: add high precision ADCs
 

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -47,17 +47,17 @@ class GatedEmitterFollower(Block):
       gate_charge=RangeExpr.ALL,  # don't care, it's analog not switching
       power=self.pwr.link().voltage * self.current))
 
-    self.connect(self.pwr, self.high_fet.drain.as_voltage_sink(
+    self.connect(self.pwr, self.high_fet.drain.adapt_to(VoltageSink(
       current_draw=self.current,
       voltage_limits=self.high_fet.actual_drain_voltage_rating.intersect(
         self.low_fet.actual_drain_voltage_rating)
-    ))
-    self.connect(self.gnd, self.low_fet.drain.as_voltage_sink())
-    output_driver = self.high_fet.source.as_voltage_source(
+    )))
+    self.connect(self.gnd, self.low_fet.drain.adapt_to(VoltageSink()))
+    output_driver = self.high_fet.source.adapt_to(VoltageSource(
       voltage_out=self.pwr.link().voltage,
       current_limits=self.current
-    )
-    self.connect(output_driver, self.low_fet.source.as_voltage_sink(),
+    ))
+    self.connect(output_driver, self.low_fet.source.adapt_to(VoltageSink()),
                  self.out)
 
     # TODO all the analog parameter modeling


### PR DESCRIPTION
New subcircuits are untested and not yet used, but planned to be in an upcoming board.

Main infrastructure change is the change in PassivePort adapter syntax. Previously, it would have been `port.as_ground()` or `port.as_voltage_sink(... params ...)`, but that's now `port.adapt_to(Ground())` and `port.adapt_to(VoltageSink(... params ...))`, which is more compositional and supports convenience constructors like `DigitalSink.from_supply(...)` without duplicating that in PassivePort.

This adds an abstract superclass for FPC connectors and refactors the existing 8-pin LCD to use this. Also adds a mini OLED display that uses an 15-pin FPC connector. This was the use case for better adapters for Passive - because it uses an internal block with Passive ports instead of a footprint directly it needs to adapt those to the typed (eg, VoltageSink) ports.

Additional minor changes
- Delete unused Port.adapter_types
- Fix description string for DigitalLink
- Add input_threshold_factor option for DigitalSink.from_supply(...)