### PR TITLE
Support ++ on refinements

### DIFF
--- a/compiler/src/main/scala/edg/util/MapUtils.scala
+++ b/compiler/src/main/scala/edg/util/MapUtils.scala
@@ -1,0 +1,16 @@
+package edg.util
+
+object MapUtils {
+  /**
+    * Merges the argument maps, erroring out if there are duplicate names
+    */
+  def mergeMapSafe[K, V](maps: Map[K, V]*): Map[K, V] = {
+    maps.flatMap(_.toSeq) // to a list of pairs in the maps
+        .groupBy(_._1) // sort by name
+        .map {
+          case (name, Seq((_, value))) => name -> value
+          case (name, values) => throw new IllegalArgumentException(
+            s"maps contains ${values.length} conflicting members with name $name: $values")
+        }
+  }
+}

--- a/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
@@ -144,8 +144,8 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
       )
     ))
     val (compiler, compiled) = testCompile(inputDesign, library, refinements=Refinements(
-      classValues = Map(LibraryPath("superclassBlock") -> Seq(
-        (Ref("superParam"), IntValue(5))),
+      classValues = Map(LibraryPath("superclassBlock") -> Map(
+        Ref("superParam") -> IntValue(5)),
       )),
       expectedDesign=Some(expected))
     compiler.getValue(IndirectDesignPath() + "block" + "superParam") should equal(Some(IntValue(5)))

--- a/compiler/src/test/scala/edg/wir/RefinementsTest.scala
+++ b/compiler/src/test/scala/edg/wir/RefinementsTest.scala
@@ -1,0 +1,56 @@
+package edg.wir
+
+import edg.compiler.IntValue
+import edg.{ElemBuilder, ExprBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+
+/** Tests operations on the Refinements data structure
+  */
+class RefinementsTest extends AnyFlatSpec {
+  behavior of "Refinements"
+
+  it should "add refinements with nonoverlapping fields" in {
+    val testRefinement = Refinements(
+      classRefinements=Map(ElemBuilder.LibraryPath("base1") -> ElemBuilder.LibraryPath("sub1")),
+      instanceRefinements=Map(DesignPath() + "elt1" -> ElemBuilder.LibraryPath("sub1")),
+      classValues=Map(ElemBuilder.LibraryPath("base1") -> Map(ExprBuilder.Ref("param1") -> IntValue(1))),
+      instanceValues=Map(DesignPath() + "elt1" -> IntValue(1))
+    ) ++ Refinements(
+      classRefinements=Map(ElemBuilder.LibraryPath("base2") -> ElemBuilder.LibraryPath("sub1")),
+      instanceRefinements=Map(DesignPath() + "elt2" -> ElemBuilder.LibraryPath("sub1")),
+      classValues = Map(ElemBuilder.LibraryPath("base1") -> Map(ExprBuilder.Ref("param2") -> IntValue(1))),
+      instanceValues = Map(DesignPath() + "elt2" -> IntValue(1))
+    )
+    testRefinement should equal(Refinements(
+        classRefinements = Map(
+          ElemBuilder.LibraryPath("base1") -> ElemBuilder.LibraryPath("sub1"),
+          ElemBuilder.LibraryPath("base2") -> ElemBuilder.LibraryPath("sub1")
+        ),
+        instanceRefinements = Map(
+          DesignPath() + "elt1" -> ElemBuilder.LibraryPath("sub1"),
+          DesignPath() + "elt2" -> ElemBuilder.LibraryPath("sub1")
+        ),
+        classValues = Map(
+          ElemBuilder.LibraryPath("base1") -> Map(
+            ExprBuilder.Ref("param1") -> IntValue(1),
+            ExprBuilder.Ref("param2") -> IntValue(1)
+          )),
+        instanceValues = Map(
+          DesignPath() + "elt1" -> IntValue(1),
+          DesignPath() + "elt2" -> IntValue(1)
+        )
+    ))
+  }
+
+  it should "error on duplicate fields" in {
+    assertThrows[IllegalArgumentException] {
+      Refinements(
+        classRefinements = Map(ElemBuilder.LibraryPath("base1") -> ElemBuilder.LibraryPath("sub1"))
+      ) ++ Refinements(
+        classRefinements = Map(ElemBuilder.LibraryPath("base1") -> ElemBuilder.LibraryPath("sub1"))
+      )
+    }
+  }
+}


### PR DESCRIPTION
Needed for ongoing IDE work, to support stacking refinements on top of other refinements.

Also moves mergeMapSafe from the IDE into compiler.

Not a model or significant user-facing change, will be merged when automated tests pass.