### PR TITLE
Clean up require_basic_part

### DIFF
--- a/edg/BoardTop.py
+++ b/edg/BoardTop.py
@@ -30,12 +30,7 @@ class BaseBoardTop(DesignTop):
 
 
 class BoardTop(BaseBoardTop):
-  def refinements(self) -> Refinements:
-    return super().refinements() + Refinements(
-      class_values=[
-        (JlcPart, ['require_basic_part'], False),  # for non-JLC boards, we don't care about this
-      ]
-    )
+  pass
 
 
 class JlcBoardTop(BaseBoardTop):
@@ -62,5 +57,9 @@ class JlcBoardTop(BaseBoardTop):
         (Fet, JlcFet),
 
         (UsbEsdDiode, Esda5v3l),
+      ],
+      class_values=[  # realistically only RCs are going to likely be basic parts
+        (JlcResistor, ['require_basic_part'], True),
+        (JlcCapacitor, ['require_basic_part'], True),
       ],
     )

--- a/electronics_lib/JlcPart.py
+++ b/electronics_lib/JlcPart.py
@@ -6,9 +6,11 @@ from electronics_abstract_parts import *
 
 @abstract_block
 class JlcPart(Block):
-  """Provides additional data fields for JLCPCB parts for their SMT service."""
+  """Provides additional data fields for JLCPCB parts for their SMT service.
+  By default, this does not check for basic parts, but that can be changed in refinements.
+  """
   @init_in_parent
-  def __init__(self, require_basic_part: BoolLike = True):
+  def __init__(self, require_basic_part: BoolLike = False):
     super().__init__()
     self.lcsc_part = self.Parameter(StringExpr())
     self.actual_basic_part = self.Parameter(BoolExpr())

--- a/examples/test_ledmatrix.py
+++ b/examples/test_ledmatrix.py
@@ -153,16 +153,6 @@ class LedMatrixTest(JlcBoardTop):
           'led_6=10',
           'sw1=18',
         ]),
-
-        (['mcu', 'ic', 'require_basic_part'], False),
-        (['reg_3v3', 'ic', 'require_basic_part'], False),
-        (['prot_3v3', 'diode', 'require_basic_part'], False),
-        (['usb_esd', 'require_basic_part'], False),
-        (['usb', 'conn', 'require_basic_part'], False),
-      ],
-      class_values=[
-        (TestPoint, ['require_basic_part'], False),
-        (ResistorArray, ['require_basic_part'], False),
       ],
       class_refinements=[
         (PassiveConnector, PinHeader254),

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -421,7 +421,6 @@ class MultimeterTest(JlcBoardTop):
 
 
   def refinements(self) -> Refinements:
-    from electronics_lib.Speakers import Tpa2005d1_Device
     return super().refinements() + Refinements(
       instance_refinements=[
         (['reg_5v'], Xc9142),

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -488,22 +488,9 @@ class MultimeterTest(JlcBoardTop):
 
         # JLC does not have frequency specs, must be checked TODO
         (['reg_5v', 'power_path', 'inductor', 'frequency'], Range(0, 0)),
-        (['reg_5v', 'power_path', 'inductor', 'require_basic_part'], False),
-
-        # (['prot_5v', 'diode', 'require_basic_part'], False),  # use the big boy Zener
-        (['prot_3v3', 'diode', 'require_basic_part'], False),
-        (['prot_analog', 'diode', 'require_basic_part'], False),
-
-        (['gate', 'ctl_diode', 'require_basic_part'], False),
-        (['gate', 'btn_diode', 'require_basic_part'], False),
-        (['usb_esd', 'require_basic_part'], False),
-        (['data_usb', 'conn', 'require_basic_part'], False),
       ],
       class_values=[
         (AnalogSwitchTree, ['switch_size'], 2),
-        (TestPoint, ['require_basic_part'], False),
-        (Tpa2005d1_Device, ['require_basic_part'], False),
-        (SmtRgbLed, ['require_basic_part'], False),
       ],
       class_refinements=[
         (SwdCortexTargetWithTdiConnector, SwdCortexTargetTc2050Nl),

--- a/examples/test_tofarray.py
+++ b/examples/test_tofarray.py
@@ -159,18 +159,6 @@ class TofArrayTest(JlcBoardTop):
           'tof_xshut_3=3',
           'tof_xshut_4=2',
         ]),
-
-        (['mcu', 'ic', 'require_basic_part'], False),
-        (['reg_3v3', 'ic', 'require_basic_part'], False),
-        (['prot_3v3', 'diode', 'require_basic_part'], False),
-        (['usb_esd', 'require_basic_part'], False),
-        (['usb', 'conn', 'require_basic_part'], False),
-      ],
-      class_values=[
-        (TestPoint, ['require_basic_part'], False),
-        (SmtRgbLed, ['require_basic_part'], False),
-        (Vl53l0x_Device, ['require_basic_part'], False),
-        (Tpa2005d1_Device, ['require_basic_part'], False),
       ],
       class_refinements=[
         (SwdCortexTargetWithTdiConnector, SwdCortexTargetTc2050),

--- a/examples/test_tofarray.py
+++ b/examples/test_tofarray.py
@@ -132,8 +132,6 @@ class TofArrayTest(JlcBoardTop):
 
 
   def refinements(self) -> Refinements:
-    from electronics_lib.Distance_Vl53l0x import Vl53l0x_Device
-    from electronics_lib.Speakers import Tpa2005d1_Device
     return super().refinements() + Refinements(
       instance_refinements=[
         (['mcu'], Stm32f103_48),

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -452,17 +452,6 @@ class UsbSourceMeasureTest(JlcBoardTop):
         (['control', 'driver', 'low_fet', 'power'], Range(0, 0)),
         (['control', 'int_link', 'sink_impedance'], RangeExpr.INF),  # waive impedance check for integrator in
         (['control', 'int', 'c', 'footprint_spec'], 'Capacitor_SMD:C_0603_1608Metric'),
-
-        (['reg_5v', 'power_path', 'inductor', 'require_basic_part'], False),
-        (['prot_3v3', 'diode', 'require_basic_part'], False),
-        (['control', 'err_source', 'diode', 'require_basic_part'], False),
-        (['control', 'err_sink', 'diode', 'require_basic_part'], False),
-        (['pwr_usb', 'conn', 'require_basic_part'], False),
-        (['data_usb', 'conn', 'require_basic_part'], False),
-        (['usb_esd', 'require_basic_part'], False),
-      ],
-      class_values=[
-        (SmtRgbLed, ['require_basic_part'], False),
       ],
       class_refinements=[
         (SwdCortexTargetWithTdiConnector, SwdCortexTargetTc2050),


### PR DESCRIPTION
One of those rare PRs with much more deletions than additions!

This changes the JLC parts to not require basic parts by default, since in most cases there is not going to be a basic part available and just results in a lot of boilerplate code. The only exceptions are the RCs where this check might be meaningful. Users can also override this to be true to get errors for all non-basic parts.