### PR TITLE
Instance refinements take priority over class refinements

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -488,7 +488,7 @@ class Compiler(inputDesignPb: schema.Design, library: edg.wir.Library,
 
     // add class-based refinements - must be set before refinement params
     // note that this operates on the post-refinement class
-    refinements.classValues.foreach {  case (classPath, refinements) =>
+    refinements.classValues.foreach { case (classPath, refinements) =>
       if (library.isSubclassOf(refinedLibraryPath, classPath)) {
         refinements.foreach { case (subpath, value) =>
           if (!refinementInstanceValuePaths.contains(path ++ subpath)) {  // instance values supersede class values

--- a/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
@@ -156,4 +156,11 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
       instanceValues = Map(DesignPath() + "block" + "superParam" -> IntValue(3))))
     compiler.getValue(IndirectDesignPath() + "block" + "superParam") should equal(Some(IntValue(3)))
   }
+
+  "Compiler on design with path values" should "supersede class values" in {
+    val (compiler, compiled) = testCompile(inputDesign, library, refinements = Refinements(
+      classValues = Map(LibraryPath("superclassBlock") -> Map(Ref("superParam") -> IntValue(0))),
+      instanceValues = Map(DesignPath() + "block" + "superParam" -> IntValue(3))))
+    compiler.getValue(IndirectDesignPath() + "block" + "superParam") should equal(Some(IntValue(3)))
+  }
 }


### PR DESCRIPTION
Perhaps not the cleanest implementation, but this suppresses class refinements when they both target the same parameter.

As a minor bugfix (instead of intentional semantics change) that a current design is dependent on I'm going to merge this when tests pass.