### PR TITLE
Assertion refactor

### DIFF
--- a/compiler/src/main/scala/edg/compiler/CompilerError.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerError.scala
@@ -48,13 +48,14 @@ object CompilerError {
     override def toString: String = s"Abstract block: $path (of type ${blockType.toSimpleString})"
   }
 
+  sealed trait AssertionError extends CompilerError
   case class FailedAssertion(root: DesignPath, constrName: String,
-                             value: expr.ValueExpr, result: ExprValue) extends CompilerError {
+                             value: expr.ValueExpr, result: ExprValue) extends AssertionError {
     override def toString: String =
       s"Failed assertion: $root.$constrName, ${ExprToString.apply(value)} => $result"
   }
   case class MissingAssertion(root: DesignPath, constrName: String,
-                              value: expr.ValueExpr, missing: Set[IndirectDesignPath]) extends CompilerError {
+                              value: expr.ValueExpr, missing: Set[IndirectDesignPath]) extends AssertionError {
     override def toString: String =
       s"Unevaluated assertion: $root.$constrName (${ExprToString.apply(value)}), missing ${missing.mkString(", ")}"
   }

--- a/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
@@ -25,9 +25,8 @@ object CompilerServerMain {
       val refinements = Refinements(request.getRefinements)
       val compiler = new Compiler(request.getDesign, library, refinements)
       val compiled = compiler.compile()
-      val structuralChecker = new DesignStructuralValidate()
-      val refChecker = new DesignRefsValidate()
-      val errors = compiler.getErrors() ++ structuralChecker.map(compiled) ++ refChecker.validate(compiled)
+      val errors = compiler.getErrors() ++ new DesignAssertionCheck(compiler).map(compiled) ++
+        new DesignStructuralValidate().map(compiled) ++ new DesignRefsValidate().validate(compiled)
       val result = edgcompiler.CompilerResult(
         design = Some(compiled),
         error = errors.mkString("\n"),

--- a/compiler/src/main/scala/edg/compiler/DesignAssertionCheck.scala
+++ b/compiler/src/main/scala/edg/compiler/DesignAssertionCheck.scala
@@ -1,0 +1,59 @@
+package edg.compiler
+
+import edg.wir.DesignPath
+import edgir.elem.elem
+import edgir.expr.expr
+import edgir.ref.ref
+
+import scala.collection.SeqMap
+
+
+/** Evaluates all assertions and returns those that aren't valid or are missing parameters
+  */
+class DesignAssertionCheck(constProp: ConstProp) extends
+    DesignMap[Unit, Seq[CompilerError.AssertionError], Seq[CompilerError.AssertionError]] {
+  def mapConstraint(containingPath: DesignPath, constrName: String, constr: expr.ValueExpr):
+      Option[CompilerError.AssertionError] = {
+    new ExprEvaluatePartial(constProp, containingPath).map(constr) match {
+      case ExprResult.Result(BooleanValue(true)) => None
+      case ExprResult.Result(result) =>
+        Some(CompilerError.FailedAssertion(containingPath, constrName, constr, result))
+      case ExprResult.Missing(missing) =>
+        Some(CompilerError.MissingAssertion(containingPath, constrName, constr, missing))
+    }
+  }
+
+  override def mapPort(path: DesignPath, port: elem.Port): Unit = { }
+  override def mapPortArray(path: DesignPath, port: elem.PortArray,
+                   ports: SeqMap[String, Unit]): Unit = { }
+  override def mapBundle(path: DesignPath, port: elem.Bundle,
+                ports: SeqMap[String, Unit]): Unit = { }
+  override def mapPortLibrary(path: DesignPath, port: ref.LibraryPath): Unit = { }
+
+  override def mapBlock(path: DesignPath, block: elem.HierarchyBlock, ports: SeqMap[String, Unit],
+                        blocks: SeqMap[String, Seq[CompilerError.AssertionError]],
+                        links: SeqMap[String, Seq[CompilerError.AssertionError]]): Seq[CompilerError.AssertionError] = {
+    block.constraints.flatMap {
+      case (name, constr) => mapConstraint(path, name, constr)
+    }.toSeq ++ blocks.values.flatten ++ links.values.flatten
+  }
+  override def mapBlockLibrary(path: DesignPath, block: ref.LibraryPath): Seq[CompilerError.AssertionError] = {
+    Seq()  // block library errors should be checked elsewhere
+  }
+
+  override def mapLink(path: DesignPath, link: elem.Link, ports: SeqMap[String, Unit],
+                       links: SeqMap[String, Seq[CompilerError.AssertionError]]): Seq[CompilerError.AssertionError] = {
+    link.constraints.flatMap {
+      case (name, constr) => mapConstraint(path, name, constr)
+    }.toSeq ++ links.values.flatten
+  }
+  override def mapLinkArray(path: DesignPath, link: elem.LinkArray, ports: SeqMap[String, Unit],
+                            links: SeqMap[String, Seq[CompilerError.AssertionError]]): Seq[CompilerError.AssertionError] = {
+    link.constraints.flatMap {
+      case (name, constr) => mapConstraint(path, name, constr)
+    }.toSeq ++ links.values.flatten
+  }
+  override def mapLinkLibrary(path: DesignPath, link: ref.LibraryPath): Seq[CompilerError.AssertionError] = {
+    Seq()  // link library errors should be checked elsewhere
+  }
+}

--- a/compiler/src/test/scala/edg/CompilerTestUtil.scala
+++ b/compiler/src/test/scala/edg/CompilerTestUtil.scala
@@ -1,6 +1,6 @@
 package edg
 
-import edg.compiler.{Compiler, DesignAssertionCheck}
+import edg.compiler.{Compiler, DesignAssertionCheck, DesignRefsValidate, DesignStructuralValidate}
 import edg.wir.{EdgirLibrary, Refinements}
 import edgir.schema.schema.{Design, Library}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,6 +13,8 @@ trait CompilerTestUtil extends AnyFlatSpec {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(library), refinements)
     val compiled = compiler.compile()
     compiler.getErrors() shouldBe empty
+    new DesignStructuralValidate().map(compiled) shouldBe empty
+    new DesignRefsValidate().validate(compiled) shouldBe empty
     new DesignAssertionCheck(compiler).map(compiled) shouldBe empty
     expectedDesign match {
       case Some(expectedDesign) => compiled should equal(expectedDesign)

--- a/compiler/src/test/scala/edg/CompilerTestUtil.scala
+++ b/compiler/src/test/scala/edg/CompilerTestUtil.scala
@@ -1,6 +1,6 @@
 package edg
 
-import edg.compiler.{Compiler, PartialCompile}
+import edg.compiler.{Compiler, DesignAssertionCheck}
 import edg.wir.{EdgirLibrary, Refinements}
 import edgir.schema.schema.{Design, Library}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,6 +13,7 @@ trait CompilerTestUtil extends AnyFlatSpec {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(library), refinements)
     val compiled = compiler.compile()
     compiler.getErrors() shouldBe empty
+    new DesignAssertionCheck(compiler).map(compiled) shouldBe empty
     expectedDesign match {
       case Some(expectedDesign) => compiled should equal(expectedDesign)
       case _ =>

--- a/edg_core/ScalaCompilerInterface.py
+++ b/edg_core/ScalaCompilerInterface.py
@@ -74,7 +74,6 @@ class ScalaCompilerInstance:
       assert self.process.stdout is not None
       self.response_deserializer = BufferDeserializer(edgrpc.CompilerResult, self.process.stdout)
 
-
   def compile(self, block: Type[Block], refinements: Refinements = Refinements()) -> CompiledDesign:
     self.check_started()
     assert self.request_serializer is not None

--- a/edg_core/test_assertion.py
+++ b/edg_core/test_assertion.py
@@ -1,0 +1,27 @@
+import unittest
+
+from . import *
+from edg_core.ScalaCompilerInterface import ScalaCompiler
+
+
+class TestAssertionFailureBlock(Block):
+  def __init__(self) -> None:
+    super().__init__()
+    self.require(BoolExpr._to_expr_type(False))
+
+
+class TestAssertionMissingBlock(Block):
+  def __init__(self) -> None:
+    super().__init__()
+    self.missing = self.Parameter(BoolExpr())
+    self.require(self.missing)
+
+
+class AssertionTestCase(unittest.TestCase):
+  def test_failure(self) -> None:
+    with self.assertRaises(CompilerCheckError):
+      ScalaCompiler.compile(TestAssertionFailureBlock)
+
+  def test_missing(self) -> None:
+    with self.assertRaises(CompilerCheckError):
+      ScalaCompiler.compile(TestAssertionMissingBlock)


### PR DESCRIPTION
Changes assertion checking to be done by a separate transform, instead of interleaved with the main compiler. This also removes the assertion state from the compiler, which was redundant in any case with the final design.

Adds unit tests to check assertion behavior, both in the failed and missing cases.

This shouldn't change any behavior or interfaces, this is purely an implementation detail refactoring.