### PR TITLE
User name of file for output directory of compiling boards

### DIFF
--- a/edg/BoardCompiler.py
+++ b/edg/BoardCompiler.py
@@ -36,9 +36,10 @@ def compile_board(design: Type[Block], target_dir: str, target_name: str) -> Com
 def compile_board_inplace(design: Type[Block]) -> CompiledDesign:
   """Compiles a board and writes the results in a sub-directory
   where the module containing the top-level is located"""
+  designfile = inspect.getfile(design)
   compiled = compile_board(
     design,
-    os.path.join(os.path.dirname(inspect.getfile(design)), design.__module__.split(".")[-1]),
+    os.path.join(os.path.dirname(designfile), os.path.splitext(designfile)[0]),
     design.__name__)
 
   return compiled


### PR DESCRIPTION
... previously if run as `__main__` the output gets stuffed in a `__main__` directory. This is bad for running blinky_skeleton from the command line.

This should not affect the behavior of existing unit tests, it only fixes the behavior when running as `__main__`.