### PR TITLE
Rename allocate -> request for port arrays

### DIFF
--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: install mypy
       run: |
-        pip install mypy types-protobuf
+        pip install mypy types-protobuf types-Deprecated
     - name: mypy
       run: |
         mypy --install-types .
@@ -57,7 +57,7 @@ jobs:
 
     - name: install dependencies
       run: |
-        pip install protobuf kinparse
+        pip install protobuf kinparse Deprecated
     - name: unittest
       run: python -m unittest discover
       

--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,6 @@ name = "pypi"
 protobuf = "*"
 typing_extensions = "*"
 kinparse = "*"
+Deprecated = "*"
 
 [dev-packages]

--- a/edg_core/Array.py
+++ b/edg_core/Array.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 from typing import *
+from deprecated import deprecated
 
 import edgir
 from .Binding import LengthBinding, AllocatedBinding
@@ -106,7 +107,7 @@ class Vector(BaseVector, Generic[VectorType]):
     self._allocates: List[Tuple[Optional[str], BasePort]] = []  # used to track allocate / allocate_vector for ref_map
 
     self._length = IntExpr()._bind(LengthBinding(self))
-    self._allocated = ArrayStringExpr()._bind(AllocatedBinding(self))
+    self._requested = ArrayStringExpr()._bind(AllocatedBinding(self))
 
   def __repr__(self) -> str:
     # TODO dedup w/ Core.__repr__
@@ -170,7 +171,7 @@ class Vector(BaseVector, Generic[VectorType]):
 
     return super()._get_ref_map(prefix) + IdentityDict[Refable, edgir.LocalPath](
       [(self._length, edgir.localpath_concat(prefix, edgir.LENGTH)),
-       (self._allocated, edgir.localpath_concat(prefix, edgir.ALLOCATED))],
+       (self._requested, edgir.localpath_concat(prefix, edgir.ALLOCATED))],
       *[elt._get_ref_map(edgir.localpath_concat(prefix, index)) for (index, elt) in elts_items]) + IdentityDict(
       *[elt._get_ref_map(edgir.localpath_concat(prefix, edgir.Allocate(suggested_name)))
         for (suggested_name, elt) in self._allocates]
@@ -218,7 +219,11 @@ class Vector(BaseVector, Generic[VectorType]):
     self._elts[suggested_name] = tpe._bind(self)
     return self._elts[suggested_name]
 
+  @deprecated(reason="renamed to request")
   def allocate(self, suggested_name: Optional[str] = None) -> VectorType:
+    return self.request(suggested_name)
+
+  def request(self, suggested_name: Optional[str] = None) -> VectorType:
     """Returns a new port of this Vector.
     Can only be called from the block containing the block containing this as a port (used to allocate a
     port of an internal block).
@@ -235,7 +240,11 @@ class Vector(BaseVector, Generic[VectorType]):
     self._allocates.append((suggested_name, allocated))
     return allocated
 
+  @deprecated(reason="renamed to request_vector")
   def allocate_vector(self, suggested_name: Optional[str] = None) -> Vector[VectorType]:
+    return self.request_vector(suggested_name)
+
+  def request_vector(self, suggested_name: Optional[str] = None) -> Vector[VectorType]:
     """Returns a new dynamic-length, array-port slice of this Vector.
     Can only be called from the block containing the block containing this as a port (used to allocate a
     port of an internal block).
@@ -255,8 +264,12 @@ class Vector(BaseVector, Generic[VectorType]):
   def length(self) -> IntExpr:
     return self._length
 
+  @deprecated(reason="renamed to requested")
   def allocated(self) -> ArrayStringExpr:
-    return self._allocated
+    return self.requested()
+
+  def requested(self) -> ArrayStringExpr:
+    return self._requested
 
   def _type_of(self) -> Hashable:
     return (self._elt_sample._type_of(),)

--- a/edg_core/MultipackBlock.py
+++ b/edg_core/MultipackBlock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TypeVar, NamedTuple, Optional, Union, List, Tuple, Generic, Callable, overload
+from deprecated import deprecated
 
 from .Array import Vector
 from .ArrayExpr import ArrayExpr, ArrayBoolExpr, ArrayStringExpr, ArrayRangeExpr, ArrayFloatExpr, ArrayIntExpr
@@ -55,7 +56,11 @@ class PackedBlockArray(Generic[PackedBlockElementType]):
     clone._elt_sample = self._tpe._bind(parent)
     return clone
 
+  @deprecated(reason="renamed to request")
   def allocate(self, suggested_name: Optional[str] = None) -> PackedBlockAllocate:
+    return self.request(suggested_name)
+
+  def request(self, suggested_name: Optional[str] = None) -> PackedBlockAllocate:
     """External API, to request a new instance for an array element / packed part."""
     assert self._parent is not None, "no parent set, cannot allocate"
     return PackedBlockAllocate(self, suggested_name)

--- a/edg_core/test_block_portvector.py
+++ b/edg_core/test_block_portvector.py
@@ -51,8 +51,8 @@ class TestBlockPortVectorConnect(Block):
     self.sink = self.Block(TestBlockPortVectorBase())
     self.source0 = self.Block(TestBlockSource())
     self.source1 = self.Block(TestBlockSource())
-    self.conn0 = self.connect(self.source0.source, self.sink.vector.allocate())
-    self.conn1 = self.connect(self.source1.source, self.sink.vector.allocate())
+    self.conn0 = self.connect(self.source0.source, self.sink.vector.request())
+    self.conn1 = self.connect(self.source1.source, self.sink.vector.request())
 
 
 class TestBlockPortVectorConstraint(TestBlockPortVectorBase):

--- a/edg_core/test_connect_array.py
+++ b/edg_core/test_connect_array.py
@@ -17,11 +17,11 @@ class TestBlockSinkElasticArray(GeneratorBlock):
   def __init__(self) -> None:
     super().__init__()
     self.sinks = self.Port(Vector(TestPortSink()))
-    self.generator(self.generate, self.sinks.allocated())
+    self.generator(self.generate, self.sinks.requested())
 
-  def generate(self, allocateds: List[str]):
-    for allocated in allocateds:
-      self.sinks.append_elt(TestPortSink(), allocated)
+  def generate(self, requests: List[str]):
+    for request in requests:
+      self.sinks.append_elt(TestPortSink(), request)
 
 
 class ArrayConnectBlock(Block):
@@ -76,8 +76,8 @@ class ArrayAllocatedConnectBlock(Block):
     self.source1 = self.Block(TestBlockSourceFixedArray())
     self.source2 = self.Block(TestBlockSourceFixedArray())
     self.sink = self.Block(TestBlockSinkElasticArray())
-    self.test_net1 = self.connect(self.source1.sources, self.sink.sinks.allocate_vector())
-    self.test_net2 = self.connect(self.source2.sources, self.sink.sinks.allocate_vector())
+    self.test_net1 = self.connect(self.source1.sources, self.sink.sinks.request_vector())
+    self.test_net2 = self.connect(self.source2.sources, self.sink.sinks.request_vector())
 
 
 class ArrayAllocatedConnectProtoTestCase(unittest.TestCase):

--- a/edg_core/test_generator_portvector.py
+++ b/edg_core/test_generator_portvector.py
@@ -11,7 +11,7 @@ class GeneratorInnerBlock(GeneratorBlock):
   def __init__(self) -> None:
     super().__init__()
     self.ports = self.Port(Vector(TestPortSink()))
-    self.generator(self.generate, self.ports.allocated())
+    self.generator(self.generate, self.ports.requested())
 
   def generate(self, elements: List[str]) -> None:
     assert elements == ['0', 'named', '1'], f"bad elements {elements}"
@@ -28,9 +28,9 @@ class TestGeneratorElements(Block):
     self.source0 = self.Block(TestBlockSource(1.0))
     self.source1 = self.Block(TestBlockSource(1.0))
     self.source2 = self.Block(TestBlockSource(1.0))
-    self.connect(self.source0.port, self.block.ports.allocate())
-    self.connect(self.source1.port, self.block.ports.allocate('named'))
-    self.connect(self.source2.port, self.block.ports.allocate())
+    self.connect(self.source0.port, self.block.ports.request())
+    self.connect(self.source1.port, self.block.ports.request('named'))
+    self.connect(self.source2.port, self.block.ports.request())
 
 
 class TestGeneratorPortVector(unittest.TestCase):
@@ -55,7 +55,7 @@ class GeneratorInnerBlockInvalid(GeneratorBlock):
   def __init__(self) -> None:
     super().__init__()
     self.ports = self.Port(Vector(TestPortSink()))
-    self.generator(self.generate, self.ports.allocated())
+    self.generator(self.generate, self.ports.requested())
 
   def generate(self, elements: List[str]) -> None:
     self.ports.append_elt(TestPortSink(), 'haha')
@@ -67,7 +67,7 @@ class TestGeneratorElementsInvalid(Block):
     self.block = self.Block(GeneratorInnerBlockInvalid())
 
     self.source0 = self.Block(TestBlockSource(1.0))
-    self.connect(self.source0.port, self.block.ports.allocate('nope'))
+    self.connect(self.source0.port, self.block.ports.request('nope'))
 
 
 class TestGeneratorPortVectorInvalid(unittest.TestCase):
@@ -91,9 +91,9 @@ class GeneratorWrapperTest(Block):  # same as TestGeneratorElements, but creatin
     self.source0 = self.Block(TestBlockSource(1.0))
     self.source1 = self.Block(TestBlockSource(1.0))
     self.source2 = self.Block(TestBlockSource(1.0))
-    self.connect(self.source0.port, self.block.ports.allocate())
-    self.connect(self.source1.port, self.block.ports.allocate('named'))
-    self.connect(self.source2.port, self.block.ports.allocate())
+    self.connect(self.source0.port, self.block.ports.request())
+    self.connect(self.source1.port, self.block.ports.request('named'))
+    self.connect(self.source2.port, self.block.ports.request())
 
 
 class TestGeneratorWrapper(unittest.TestCase):
@@ -137,7 +137,7 @@ class GeneratorArrayParamTop(Block):
 
     self.source = self.Block(TestBlockSource(1.0))
     self.connect(self.source.port,
-                 self.block.ports.allocate(), self.block.ports.allocate(), self.block.ports.allocate())
+                 self.block.ports.request(), self.block.ports.request(), self.block.ports.request())
 
 
 class TestGeneratorArrayParam(unittest.TestCase):

--- a/edg_core/test_multipack.py
+++ b/edg_core/test_multipack.py
@@ -127,8 +127,8 @@ class TopMultipackArrayDesign(DesignTop):
 
   def multipack(self):
     self.packed = self.Block(MultipackArrayBlockSink())
-    self.pack(self.packed.sinks.allocate('1'), ['sink1'])
-    self.pack(self.packed.sinks.allocate('2'), ['sink2', 'inner'])
+    self.pack(self.packed.sinks.request('1'), ['sink1'])
+    self.pack(self.packed.sinks.request('2'), ['sink2', 'inner'])
 
 
 class TopMultipackArrayDesignTestCase(unittest.TestCase):

--- a/electronics_abstract_parts/AbstractLed.py
+++ b/electronics_abstract_parts/AbstractLed.py
@@ -234,9 +234,9 @@ class IndicatorSinkPackedRgbLed(Light, MultipackBlock):
     self.blue_pwr = self.PackedExport(self.blue.pwr)
 
     self.pwr = self.Block(PackedVoltageSource())
-    self.connect(self.pwr.pwr_ins.allocate('red'), self.red_pwr)
-    self.connect(self.pwr.pwr_ins.allocate('green'), self.green_pwr)
-    self.connect(self.pwr.pwr_ins.allocate('blue'), self.blue_pwr)
+    self.connect(self.pwr.pwr_ins.request('red'), self.red_pwr)
+    self.connect(self.pwr.pwr_ins.request('green'), self.green_pwr)
+    self.connect(self.pwr.pwr_ins.request('blue'), self.blue_pwr)
 
     self.red_current = self.PackedParameter(self.red.current_draw)
     self.green_current = self.PackedParameter(self.green.current_draw)
@@ -245,6 +245,6 @@ class IndicatorSinkPackedRgbLed(Light, MultipackBlock):
 
     self.device = self.Block(IndicatorSinkRgbLed(target_current))
     self.connect(self.device.pwr, self.pwr.pwr_out)
-    self.connect(self.device.signals.allocate('red'), self.red_sig)
-    self.connect(self.device.signals.allocate('green'), self.green_sig)
-    self.connect(self.device.signals.allocate('blue'), self.blue_sig)
+    self.connect(self.device.signals.request('red'), self.red_sig)
+    self.connect(self.device.signals.request('green'), self.green_sig)
+    self.connect(self.device.signals.request('blue'), self.blue_sig)

--- a/electronics_abstract_parts/AbstractResistorArray.py
+++ b/electronics_abstract_parts/AbstractResistorArray.py
@@ -89,10 +89,10 @@ class TableResistorArray(ResistorArrayStandardPinning, PartsTableFootprint, Gene
   @init_in_parent
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
-    self.generator(self.select_part, self.count, self.a.allocated(), self.b.allocated(),
+    self.generator(self.select_part, self.count, self.a.requested(), self.b.requested(),
                    self.resistances, self.powers, self.part, self.footprint_spec)
 
-  def select_part(self, count: int, a_allocations: List[str], b_allocations: List[str],
+  def select_part(self, count: int, a_requests: List[str], b_requests: List[str],
                   resistances: List[Range], power_dissipations: List[Range],
                   part_spec: str, footprint_spec: str) -> None:
     # TODO some kind of range intersect construct?
@@ -106,12 +106,12 @@ class TableResistorArray(ResistorArrayStandardPinning, PartsTableFootprint, Gene
     powers_hull = Range(powers_min, powers_max)
 
     parts = self._get_table().filter(lambda row: (
-        (not part_spec or part_spec == row[self.PART_NUMBER_COL]) and
-        (not footprint_spec or footprint_spec == row[self.KICAD_FOOTPRINT]) and
-        (count == 0 or count == row[self.COUNT]) and
-        (row[self.COUNT] >= len(a_allocations) and row[self.COUNT] >= len(b_allocations)) and
-        row[self.RESISTANCE].fuzzy_in(resistance_intersect) and
-        powers_hull.fuzzy_in(row[self.POWER_RATING])
+            (not part_spec or part_spec == row[self.PART_NUMBER_COL]) and
+            (not footprint_spec or footprint_spec == row[self.KICAD_FOOTPRINT]) and
+            (count == 0 or count == row[self.COUNT]) and
+            (row[self.COUNT] >= len(a_requests) and row[self.COUNT] >= len(b_requests)) and
+            row[self.RESISTANCE].fuzzy_in(resistance_intersect) and
+            powers_hull.fuzzy_in(row[self.POWER_RATING])
     ))
     part = parts.first(f"no resistors in {resistance_intersect} Ohm, {powers_hull} W")
 

--- a/electronics_abstract_parts/DummyDevices.py
+++ b/electronics_abstract_parts/DummyDevices.py
@@ -59,22 +59,22 @@ class MergedVoltageSource(DummyDevice, NetBlock, GeneratorBlock):
       voltage_out=RangeExpr(),
       current_limits=RangeExpr.ALL
     ))
-    self.generator(self.generate, self.pwr_ins.allocated())
+    self.generator(self.generate, self.pwr_ins.requested())
 
-  def generate(self, in_allocates: List[str]):
+  def generate(self, in_requests: List[str]):
     self.pwr_ins.defined()
-    for in_allocate in in_allocates:
+    for in_request in in_requests:
       self.pwr_ins.append_elt(VoltageSink(
         voltage_limits=RangeExpr.ALL,
         current_draw=self.pwr_out.link().current_drawn
-      ), in_allocate)
+      ), in_request)
 
     self.assign(self.pwr_out.voltage_out,
                 self.pwr_ins.hull(lambda x: x.link().voltage))
 
   def connected_from(self, *pwr_ins: Port[VoltageLink]) -> 'MergedVoltageSource':
     for pwr_in in pwr_ins:
-      cast(Block, builder.get_enclosing_block()).connect(pwr_in, self.pwr_ins.allocate())
+      cast(Block, builder.get_enclosing_block()).connect(pwr_in, self.pwr_ins.request())
     return self
 
 
@@ -89,16 +89,16 @@ class MergedAnalogSource(DummyDevice, NetBlock, GeneratorBlock):
     ))
     self.inputs = self.Port(Vector(AnalogSink.empty()))
 
-    self.generator(self.generate, self.inputs.allocated())
+    self.generator(self.generate, self.inputs.requested())
 
-  def generate(self, inputs_allocates: List[str]):
+  def generate(self, in_requests: List[str]):
     self.inputs.defined()
-    for input_allocate in inputs_allocates:
+    for in_request in in_requests:
       self.inputs.append_elt(AnalogSink(
         voltage_limits=RangeExpr.ALL,
         current_draw=self.output.link().current_drawn,
         impedance=self.output.link().sink_impedance
-      ), input_allocate)
+      ), in_request)
 
     self.assign(self.output.voltage_out,
                 self.inputs.hull(lambda x: x.link().voltage))
@@ -108,7 +108,7 @@ class MergedAnalogSource(DummyDevice, NetBlock, GeneratorBlock):
 
   def connected_from(self, *inputs: Port[AnalogLink]) -> 'MergedAnalogSource':
     for input in inputs:
-      cast(Block, builder.get_enclosing_block()).connect(input, self.inputs.allocate())
+      cast(Block, builder.get_enclosing_block()).connect(input, self.inputs.request())
     return self
 
 

--- a/electronics_lib/Lcd_Qt096t_if09.py
+++ b/electronics_lib/Lcd_Qt096t_if09.py
@@ -10,11 +10,11 @@ class Qt096t_if09_Device(DiscreteChip):
     self.conn = self.Block(Fpc050(length=8))
 
     # both Vdd and VddI
-    self.vdd = self.Export(self.conn.pins.allocate('7').adapt_to(VoltageSink(
+    self.vdd = self.Export(self.conn.pins.request('7').adapt_to(VoltageSink(
       voltage_limits=(2.5, 4.8) * Volt,  # 2.75v typ
       current_draw=(0.02, 2.02) * mAmp  # ST7735S Table 7.3, IDDI + IDD, typ - max
     )))
-    self.gnd = self.Export(self.conn.pins.allocate('2').adapt_to(Ground()))
+    self.gnd = self.Export(self.conn.pins.request('2').adapt_to(Ground()))
 
     io_model = DigitalSink.from_supply(
       self.gnd, self.vdd,
@@ -22,17 +22,17 @@ class Qt096t_if09_Device(DiscreteChip):
       current_draw=0*mAmp(tol=0),
       input_threshold_factor=(0.3, 0.7),
     )
-    self.reset = self.Export(self.conn.pins.allocate('3').adapt_to(io_model))
+    self.reset = self.Export(self.conn.pins.request('3').adapt_to(io_model))
     # data / command selection pin
-    self.rs = self.Export(self.conn.pins.allocate('4').adapt_to(io_model))
-    self.cs = self.Export(self.conn.pins.allocate('8').adapt_to(io_model))
+    self.rs = self.Export(self.conn.pins.request('4').adapt_to(io_model))
+    self.cs = self.Export(self.conn.pins.request('8').adapt_to(io_model))
 
     self.spi = self.Port(SpiSlave.empty())
-    self.connect(self.spi.sck, self.conn.pins.allocate('6').adapt_to(io_model))  # scl
-    self.connect(self.spi.mosi, self.conn.pins.allocate('5').adapt_to(io_model))  # sda
+    self.connect(self.spi.sck, self.conn.pins.request('6').adapt_to(io_model))  # scl
+    self.connect(self.spi.mosi, self.conn.pins.request('5').adapt_to(io_model))  # sda
     self.spi.miso.not_connected()
 
-    self.leda = self.Export(self.conn.pins.allocate('1'))  # TODO maybe something else?
+    self.leda = self.Export(self.conn.pins.request('1'))  # TODO maybe something else?
 
 
 class Qt096t_if09(Lcd, Block):

--- a/electronics_lib/Microcontroller_Esp.py
+++ b/electronics_lib/Microcontroller_Esp.py
@@ -15,11 +15,11 @@ class EspProgrammingHeader(ProgrammingConnector):
     self.uart = self.Port(UartPort.empty(), [Output])
 
     self.conn = self.Block(PassiveConnector())
-    self.connect(self.pwr, self.conn.pins.allocate('1').adapt_to(VoltageSink()))
+    self.connect(self.pwr, self.conn.pins.request('1').adapt_to(VoltageSink()))
     # RXD, TXD reversed to reflect the programmer's side view
-    self.connect(self.uart.rx, self.conn.pins.allocate('2').adapt_to(DigitalSink()))
-    self.connect(self.uart.tx, self.conn.pins.allocate('3').adapt_to(DigitalSource()))
-    self.connect(self.gnd, self.conn.pins.allocate('4').adapt_to(Ground()))
+    self.connect(self.uart.rx, self.conn.pins.request('2').adapt_to(DigitalSink()))
+    self.connect(self.uart.tx, self.conn.pins.request('3').adapt_to(DigitalSource()))
+    self.connect(self.gnd, self.conn.pins.request('4').adapt_to(Ground()))
 
 
 class PulldownJumper(Block):
@@ -30,5 +30,5 @@ class PulldownJumper(Block):
     self.io = self.Port(DigitalSource.empty(), [Output])
 
     self.conn = self.Block(PassiveConnector())
-    self.connect(self.io, self.conn.pins.allocate('1').adapt_to(DigitalSource()))
-    self.connect(self.gnd, self.conn.pins.allocate('2').adapt_to(VoltageSink()))
+    self.connect(self.io, self.conn.pins.request('1').adapt_to(DigitalSource()))
+    self.connect(self.gnd, self.conn.pins.request('2').adapt_to(VoltageSink()))

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -65,9 +65,9 @@ class Esp32_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, Foot
     # TODO add JTAG support
 
     self.generator(self.generate, self.pin_assigns,
-                   self.gpio.allocated(), self.adc.allocated(), self.dac.allocated(),
-                   self.spi.allocated(), self.i2c.allocated(), self.uart.allocated(),
-                   self.can.allocated())
+                   self.gpio.requested(), self.adc.requested(), self.dac.requested(),
+                   self.spi.requested(), self.i2c.requested(), self.uart.requested(),
+                   self.can.requested())
 
   @staticmethod
   def mappable_ios(dio_model: DigitalBidir, sdio_model: DigitalBidir,
@@ -145,9 +145,9 @@ class Esp32_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, Foot
   RESOURCE_PIN_REMAP: Dict[str, str]  # resource name in base -> pin name
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               can_allocates: List[str]) -> None: ...
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               can_requests: List[str]) -> None: ...
 
 
 class Esp32_Wroom_32_Device(Esp32_Device, FootprintBlock, JlcPart):
@@ -196,15 +196,15 @@ class Esp32_Wroom_32_Device(Esp32_Device, FootprintBlock, JlcPart):
   }
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               can_allocates: List[str]) -> None:
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               can_requests: List[str]) -> None:
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
-      (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates), (UartPort, uart_allocates),
-      (CanControllerPort, can_allocates),
-      (AnalogSink, adc_allocates), (AnalogSource, dac_allocates), (DigitalBidir, gpio_allocates),
+      (SpiMaster, spi_requests), (I2cMaster, i2c_requests), (UartPort, uart_requests),
+      (CanControllerPort, can_requests),
+      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -57,9 +57,9 @@ class Esp32c3_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, Fo
     # TODO add JTAG support
 
     self.generator(self.generate, self.pin_assigns,
-                   self.gpio.allocated(), self.adc.allocated(),
-                   self.spi.allocated(), self.i2c.allocated(), self.uart.allocated(),
-                   self.usb.allocated())
+                   self.gpio.requested(), self.adc.requested(),
+                   self.spi.requested(), self.i2c.requested(), self.uart.requested(),
+                   self.usb.requested())
 
   @staticmethod
   def mappable_ios(dio_model: DigitalBidir) -> PinMapUtil:
@@ -108,9 +108,9 @@ class Esp32c3_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, Fo
   RESOURCE_PIN_REMAP: Dict[str, str]  # resource name in base -> pin name
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str]) -> None: ...
+               gpio_requests: List[str], adc_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str]) -> None: ...
 
 
 class Esp32c3_Wroom02_Device(Esp32c3_Device, FootprintBlock, JlcPart):
@@ -143,15 +143,15 @@ class Esp32c3_Wroom02_Device(Esp32c3_Device, FootprintBlock, JlcPart):
   }
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str]) -> None:
+               gpio_requests: List[str], adc_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str]) -> None:
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
-      (UsbDevicePort, usb_allocates), (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates),
-      (UartPort, uart_allocates),
-      (AnalogSink, adc_allocates), (DigitalBidir, gpio_allocates),
+      (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
+      (UartPort, uart_requests),
+      (AnalogSink, adc_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -22,9 +22,9 @@ class Lpc1549Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock
     self.swd = self.Port(SwdTargetPort().empty())
 
     self.generator(self.generate, self.pin_assigns,
-                   self.gpio.allocated(), self.adc.allocated(), self.dac.allocated(),
-                   self.spi.allocated(), self.i2c.allocated(), self.uart.allocated(),
-                   self.usb.allocated(), self.can.allocated(), self.swd.is_connected())
+                   self.gpio.requested(), self.adc.requested(), self.dac.requested(),
+                   self.spi.requested(), self.i2c.requested(), self.uart.requested(),
+                   self.usb.requested(), self.can.requested(), self.swd.is_connected())
 
   def contents(self) -> None:
     super().contents()
@@ -173,16 +173,16 @@ class Lpc1549Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock
   PART: str  # part name for footprint(...)
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str], can_allocates: List[str], swd_connected: bool) -> None:
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str], can_requests: List[str], swd_connected: bool) -> None:
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
-      (UsbDevicePort, usb_allocates), (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates),
-      (UartPort, uart_allocates), (CanControllerPort, can_allocates),
-      (AnalogSink, adc_allocates), (AnalogSource, dac_allocates), (DigitalBidir, gpio_allocates),
+      (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
+      (UartPort, uart_requests), (CanControllerPort, can_requests),
+      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 
@@ -345,7 +345,7 @@ class Lpc1549Base(PinMappable, Microcontroller, IoController, GeneratorBlock):
 
   def __init__(self, **kwargs):
     super().__init__(**kwargs)
-    self.generator(self.generate, self.can.allocated(), self.usb.allocated())
+    self.generator(self.generate, self.can.requested(), self.usb.requested())
 
   def contents(self):
     super().contents()
@@ -378,8 +378,8 @@ class Lpc1549Base(PinMappable, Microcontroller, IoController, GeneratorBlock):
                                                 imp.Block(Lpc1549SwdPull()),
                                                 self.ic.swd)
 
-  def generate(self, can_allocated: List[str], usb_allocated: List[str]) -> None:
-    if can_allocated or usb_allocated:  # tighter frequency tolerances from CAN and USB usage require a crystal
+  def generate(self, can_requested: List[str], usb_requested: List[str]) -> None:
+    if can_requested or usb_requested:  # tighter frequency tolerances from CAN and USB usage require a crystal
       self.crystal = self.Block(OscillatorCrystal(frequency=12 * MHertz(tol=0.005)))
       self.connect(self.crystal.gnd, self.gnd)
       self.connect(self.crystal.crystal, self.ic.xtal)

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -30,9 +30,9 @@ class Stm32f103Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBlo
     self.swd = self.Port(SwdTargetPort().empty())
 
     self.generator(self.generate, self.pin_assigns,
-                   self.gpio.allocated(), self.adc.allocated(), self.dac.allocated(),
-                   self.spi.allocated(), self.i2c.allocated(), self.uart.allocated(),
-                   self.usb.allocated(), self.can.allocated(), self.swd.is_connected())
+                   self.gpio.requested(), self.adc.requested(), self.dac.requested(),
+                   self.spi.requested(), self.i2c.requested(), self.uart.requested(),
+                   self.usb.requested(), self.can.requested(), self.swd.is_connected())
 
   def contents(self) -> None:
     super().contents()
@@ -173,16 +173,16 @@ class Stm32f103Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBlo
   JLC_BASIC_PART: bool
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str], can_allocates: List[str], swd_connected: bool) -> None:
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str], can_requests: List[str], swd_connected: bool) -> None:
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
-      (UsbDevicePort, usb_allocates), (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates),
-      (UartPort, uart_allocates), (CanControllerPort, can_allocates),
-      (AnalogSink, adc_allocates), (AnalogSource, dac_allocates), (DigitalBidir, gpio_allocates),
+      (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
+      (UartPort, uart_requests), (CanControllerPort, can_requests),
+      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 
@@ -278,7 +278,7 @@ class Stm32f103Base(PinMappable, Microcontroller, IoController, GeneratorBlock):
 
   def __init__(self, **kwargs):
     super().__init__(**kwargs)
-    self.generator(self.generate, self.can.allocated(), self.usb.allocated())
+    self.generator(self.generate, self.can.requested(), self.usb.requested())
 
   def contents(self):
     super().contents()
@@ -304,21 +304,23 @@ class Stm32f103Base(PinMappable, Microcontroller, IoController, GeneratorBlock):
       (self.swd, ), _ = self.chain(imp.Block(SwdCortexTargetWithTdiConnector()),
                                    self.ic.swd)
 
-  def generate(self, can_allocated: List[str], usb_allocated: List[str]) -> None:
-    if can_allocated or usb_allocated:  # tighter frequency tolerances from CAN and USB usage require a crystal
+  def generate(self, can_requests: List[str], usb_requests: List[str]) -> None:
+    if can_requests or usb_requests:  # tighter frequency tolerances from CAN and USB usage require a crystal
       self.crystal = self.Block(OscillatorCrystal(frequency=12 * MHertz(tol=0.005)))
       self.connect(self.crystal.gnd, self.gnd)
       self.connect(self.crystal.crystal, self.ic.osc)
 
-    if usb_allocated:
-      assert len(usb_allocated) == 1
-      usb_allocated_name = usb_allocated[0]
-      usb_port = self.usb.append_elt(UsbDevicePort.empty(), usb_allocated_name)
-      self.connect(usb_port, self.ic.usb.allocate(usb_allocated_name))
+    if usb_requests:
+      assert len(usb_requests) == 1
+      usb_request_name = usb_requests[0]
+      usb_port = self.usb.append_elt(UsbDevicePort.empty(), usb_request_name)
+      self.connect(usb_port, self.ic.usb.request(usb_request_name))
 
       self.usb_pull = self.Block(UsbDpPullUp(resistance=1.5*kOhm(tol=0.01)))  # required by datasheet Table 44  # TODO proper tolerancing?
       self.connect(self.usb_pull.pwr, self.pwr)
       self.connect(usb_port, self.usb_pull.usb)
+    else:
+      self.usb.defined()
 
 
 class Stm32f103_48(Stm32f103Base):

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -191,14 +191,14 @@ class Nucleo_F303k8(PinMappable, BaseIoController, GeneratorBlock, FootprintBloc
     self.gnd = self.Port(GroundSource(), optional=True)
 
     self.generator(self.generate, self.pin_assigns,
-                   self.gpio.allocated(), self.adc.allocated(), self.dac.allocated(),
-                   self.spi.allocated(), self.i2c.allocated(), self.uart.allocated(),
-                   self.can.allocated())
+                   self.gpio.requested(), self.adc.requested(), self.dac.requested(),
+                   self.spi.requested(), self.i2c.requested(), self.uart.requested(),
+                   self.can.requested())
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               can_allocates: List[str]) -> None:
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               can_requests: List[str]) -> None:
     system_pins = {
       '16': self.pwr_in,
       '19': self.pwr_5v,
@@ -209,9 +209,9 @@ class Nucleo_F303k8(PinMappable, BaseIoController, GeneratorBlock, FootprintBloc
 
     allocated = Stm32f303Base_Device.mappable_ios(self.gnd, self.pwr_3v3, self.pwr_3v3)\
       .remap_pins(self.RESOURCE_PIN_REMAP).allocate([
-        (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates),
-        (UartPort, uart_allocates), (CanControllerPort, can_allocates),
-        (AnalogSink, adc_allocates), (AnalogSource, dac_allocates), (DigitalBidir, gpio_allocates),
+        (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
+        (UartPort, uart_requests), (CanControllerPort, can_requests),
+        (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -30,9 +30,9 @@ class Nrf52840Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBloc
     self.swd = self.Port(SwdTargetPort().empty())
 
     self.generator(self.generate, self.pin_assigns,
-                   self.gpio.allocated(), self.adc.allocated(), self.dac.allocated(),
-                   self.spi.allocated(), self.i2c.allocated(), self.uart.allocated(),
-                   self.usb.allocated(), self.swd.is_connected())
+                   self.gpio.requested(), self.adc.requested(), self.dac.requested(),
+                   self.spi.requested(), self.i2c.requested(), self.uart.requested(),
+                   self.usb.requested(), self.swd.is_connected())
 
   def contents(self) -> None:
     super().contents()
@@ -176,9 +176,9 @@ class Nrf52840Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBloc
   RESOURCE_PIN_REMAP: Dict[str, str]  # resource name in base -> pin name
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str], swd_connected: bool) -> None: ...
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str], swd_connected: bool) -> None: ...
 
 
 class Holyiot_18010_Device(Nrf52840Base_Device, FootprintBlock):
@@ -225,16 +225,16 @@ class Holyiot_18010_Device(Nrf52840Base_Device, FootprintBlock):
   }
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str], swd_connected: bool) -> None:
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str], swd_connected: bool) -> None:
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
-      (UsbDevicePort, usb_allocates), (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates),
-      (UartPort, uart_allocates),
-      (AnalogSink, adc_allocates), (AnalogSource, dac_allocates), (DigitalBidir, gpio_allocates),
+      (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
+      (UartPort, uart_requests),
+      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 
@@ -334,16 +334,16 @@ class Mdbt50q_1mv2_Device(Nrf52840Base_Device, FootprintBlock):
   }
 
   def generate(self, assignments: List[str],
-               gpio_allocates: List[str], adc_allocates: List[str], dac_allocates: List[str],
-               spi_allocates: List[str], i2c_allocates: List[str], uart_allocates: List[str],
-               usb_allocates: List[str], swd_connected: bool) -> None:
+               gpio_requests: List[str], adc_requests: List[str], dac_requests: List[str],
+               spi_requests: List[str], i2c_requests: List[str], uart_requests: List[str],
+               usb_requests: List[str], swd_connected: bool) -> None:
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
-      (UsbDevicePort, usb_allocates), (SpiMaster, spi_allocates), (I2cMaster, i2c_allocates),
-      (UartPort, uart_allocates),
-      (AnalogSink, adc_allocates), (AnalogSource, dac_allocates), (DigitalBidir, gpio_allocates),
+      (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
+      (UartPort, uart_requests),
+      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 
@@ -377,9 +377,9 @@ class Mdbt50q_1mv2(PinMappable, Microcontroller, IoController, GeneratorBlock):
     self.ic = self.Block(Mdbt50q_1mv2_Device(pin_assigns=self.pin_assigns))
     self.pwr_usb = self.Export(self.ic.pwr_usb, optional=True)
 
-    self.generator(self.generate, self.usb.allocated())
+    self.generator(self.generate, self.usb.requested())
 
-  def generate(self, usb_allocated: List[str]) -> None:
+  def generate(self, usb_requests: List[str]) -> None:
     self.connect(self.pwr, self.ic.pwr)
     self.connect(self.gnd, self.ic.gnd)
     self._export_ios_from(self.ic, excludes=[self.usb])
@@ -394,10 +394,12 @@ class Mdbt50q_1mv2(PinMappable, Microcontroller, IoController, GeneratorBlock):
                                    self.ic.swd)
       self.vcc_cap = imp.Block(DecouplingCapacitor(10 * uFarad(tol=0.2)))
 
-    if usb_allocated:
-      assert len(usb_allocated) == 1
-      usb_allocated_name = usb_allocated[0]
-      usb_port = self.usb.append_elt(UsbDevicePort.empty(), usb_allocated_name)
+    if usb_requests:
+      assert len(usb_requests) == 1
+      usb_request_name = usb_requests[0]
+      usb_port = self.usb.append_elt(UsbDevicePort.empty(), usb_request_name)
       self.usb_res = self.Block(Mdbt50q_UsbSeriesResistor())
-      self.connect(self.ic.usb.allocate(usb_allocated_name), self.usb_res.usb_inner)
+      self.connect(self.ic.usb.request(usb_request_name), self.usb_res.usb_inner)
       self.connect(self.usb_res.usb_outer, usb_port)
+    else:
+      self.usb.defined()

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -11,11 +11,11 @@ class Er_Oled_091_3_Device(DiscreteChip):
 
         self.conn = self.Block(Fpc050(length=15))
 
-        self.vcc = self.Export(self.conn.pins.allocate('15').adapt_to(VoltageSource(
+        self.vcc = self.Export(self.conn.pins.request('15').adapt_to(VoltageSource(
             voltage_out=(6.4, 9),
             current_limits=0*mAmp(tol=0)  # external draw not allowed, probably does 10-16mA
         )))
-        self.vdd = self.Export(self.conn.pins.allocate('7').adapt_to(VoltageSink(
+        self.vdd = self.Export(self.conn.pins.request('7').adapt_to(VoltageSink(
             voltage_limits=(1.65, 4)*Volt,  # use the absolute maximum upper limit to allow tolerance on 3.3v
             current_draw=(1, 300)*uAmp
         )))
@@ -23,11 +23,11 @@ class Er_Oled_091_3_Device(DiscreteChip):
         # and is needed to drive both Vbat and Vdd off of a common 3.3v supply
         # default of 3.3 is using SSD1306 datasheet v1.6, the panel datasheet is more restrictive
         self.vbat_min = self.Parameter(FloatExpr(3.3*Volt))
-        self.vbat = self.Export(self.conn.pins.allocate('5').adapt_to(VoltageSink(
+        self.vbat = self.Export(self.conn.pins.request('5').adapt_to(VoltageSink(
             voltage_limits=(self.vbat_min, 4.2*Volt),
             current_draw=(23, 29)*mAmp
         )))
-        self.vss = self.Export(self.conn.pins.allocate('6').adapt_to(Ground()), [Common])
+        self.vss = self.Export(self.conn.pins.request('6').adapt_to(Ground()), [Common])
 
         din_model = DigitalSink.from_supply(
             self.vss, self.vdd,
@@ -36,20 +36,20 @@ class Er_Oled_091_3_Device(DiscreteChip):
         )
 
         self.spi = self.Port(SpiSlave.empty())
-        self.connect(self.spi.sck, self.conn.pins.allocate('11').adapt_to(din_model))
-        self.connect(self.spi.mosi, self.conn.pins.allocate('12').adapt_to(din_model))
+        self.connect(self.spi.sck, self.conn.pins.request('11').adapt_to(din_model))
+        self.connect(self.spi.mosi, self.conn.pins.request('12').adapt_to(din_model))
         self.spi.miso.not_connected()
 
-        self.dc = self.Export(self.conn.pins.allocate('10').adapt_to(din_model))
-        self.res = self.Export(self.conn.pins.allocate('9').adapt_to(din_model))
-        self.cs = self.Export(self.conn.pins.allocate('8').adapt_to(din_model))
+        self.dc = self.Export(self.conn.pins.request('10').adapt_to(din_model))
+        self.res = self.Export(self.conn.pins.request('9').adapt_to(din_model))
+        self.cs = self.Export(self.conn.pins.request('8').adapt_to(din_model))
 
-        self.vcomh = self.Export(self.conn.pins.allocate('14'))
-        self.iref = self.Export(self.conn.pins.allocate('13'))
-        self.c2p = self.Export(self.conn.pins.allocate('1'))
-        self.c2n = self.Export(self.conn.pins.allocate('2'))
-        self.c1p = self.Export(self.conn.pins.allocate('3'))
-        self.c1n = self.Export(self.conn.pins.allocate('4'))
+        self.vcomh = self.Export(self.conn.pins.request('14'))
+        self.iref = self.Export(self.conn.pins.request('13'))
+        self.c2p = self.Export(self.conn.pins.request('1'))
+        self.c2n = self.Export(self.conn.pins.request('2'))
+        self.c1p = self.Export(self.conn.pins.request('3'))
+        self.c1n = self.Export(self.conn.pins.request('4'))
 
 
 class Er_Oled_091_3(Lcd, Block):

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -19,7 +19,7 @@ class PassiveConnector(Connector, GeneratorBlock, FootprintBlock):
     self.pins = self.Port(Vector(Passive().empty()))
     self.actual_length = self.Parameter(IntExpr())
 
-    self.generator(self.generate, length, self.pins.allocated())
+    self.generator(self.generate, length, self.pins.requested())
 
   def part_footprint_mfr_name(self, length: int) -> Tuple[str, str, str]:
     """Returns the part footprint, manufacturer, and name given the number of pins (length).

--- a/electronics_lib/Speakers.py
+++ b/electronics_lib/Speakers.py
@@ -209,9 +209,9 @@ class ConnectorSpeaker(Speaker):
 
     self.conn = self.Block(PassiveConnector())
 
-    self.connect(self.input.a, self.conn.pins.allocate('1').adapt_to(AnalogSink(
+    self.connect(self.input.a, self.conn.pins.request('1').adapt_to(AnalogSink(
       impedance=impedance)
     ))
-    self.connect(self.input.b, self.conn.pins.allocate('2').adapt_to(AnalogSink(
+    self.connect(self.input.b, self.conn.pins.request('2').adapt_to(AnalogSink(
       impedance=impedance)
     ))

--- a/electronics_model/CircuitPackingBlock.py
+++ b/electronics_model/CircuitPackingBlock.py
@@ -26,16 +26,16 @@ class PackedVoltageSource(NetPackingBlock, GeneratorBlock):
       voltage_out=RangeExpr(),
       current_limits=RangeExpr.ALL
     ))
-    self.generator(self.generate, self.pwr_ins.allocated())
+    self.generator(self.generate, self.pwr_ins.requested())
     self.packed(self.pwr_ins, self.pwr_out)
 
-  def generate(self, in_allocates: List[str]):
+  def generate(self, in_requests: List[str]):
     self.pwr_ins.defined()
-    for in_allocate in in_allocates:
+    for in_request in in_requests:
       self.pwr_ins.append_elt(VoltageSink(
         voltage_limits=RangeExpr.ALL,
-        current_draw=self.pwr_out.link().current_drawn / len(in_allocates)
-      ), in_allocate)
+        current_draw=self.pwr_out.link().current_drawn / len(in_requests)
+      ), in_request)
 
     self.assign(self.pwr_out.voltage_out,
                 self.pwr_ins.hull(lambda x: x.link().voltage))

--- a/electronics_model/test_multipack_netlist.py
+++ b/electronics_model/test_multipack_netlist.py
@@ -47,8 +47,8 @@ class TestPackedDevices(DesignTop):
 
   def multipack(self) -> None:
     self.sink = self.PackedBlock(TestPackedSink())
-    self.pack(self.sink.elements.allocate('1'), ['sink1'])
-    self.pack(self.sink.elements.allocate('2'), ['sink2'])
+    self.pack(self.sink.elements.request('1'), ['sink1'])
+    self.pack(self.sink.elements.request('2'), ['sink2'])
 
 
 class TestInvalidPackedDevices(DesignTop):
@@ -67,8 +67,8 @@ class TestInvalidPackedDevices(DesignTop):
 
   def multipack(self) -> None:
       self.sink = self.PackedBlock(TestPackedSink())
-      self.pack(self.sink.elements.allocate('1'), ['sink1'])
-      self.pack(self.sink.elements.allocate('2'), ['sink2'])
+      self.pack(self.sink.elements.request('1'), ['sink1'])
+      self.pack(self.sink.elements.request('2'), ['sink2'])
 
 
 class NetlistTestCase(unittest.TestCase):

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -12,7 +12,7 @@ class TestBlinkyBasic(BoardTop):
 
     self.led = self.Block(IndicatorLed())
     self.connect(self.mcu.gnd, self.led.gnd)
-    self.connect(self.mcu.gpio.allocate(), self.led.signal)
+    self.connect(self.mcu.gpio.request(), self.led.signal)
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
@@ -32,8 +32,8 @@ class TestBlinkySimple(BoardTop):
       self.led = imp.Block(IndicatorLed())
       self.sw = imp.Block(DigitalSwitch())
 
-    self.connect(self.mcu.gpio.allocate(), self.led.signal)
-    self.connect(self.sw.out, self.mcu.gpio.allocate())
+    self.connect(self.mcu.gpio.request(), self.led.signal)
+    self.connect(self.sw.out, self.mcu.gpio.request())
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
@@ -50,8 +50,8 @@ class TestBlinkySimpleChain(BoardTop):
     with self.implicit_connect(
         ImplicitConnect(self.mcu.gnd, [Common]),
     ) as imp:
-      (self.led, ), _ = self.chain(self.mcu.gpio.allocate(), imp.Block(IndicatorLed()))
-      (self.sw, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate())
+      (self.led, ), _ = self.chain(self.mcu.gpio.request(), imp.Block(IndicatorLed()))
+      (self.sw, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request())
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
@@ -100,8 +100,8 @@ class TestBlinkyFlattened(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.led, ), _ = self.chain(self.mcu.gpio.allocate(), imp.Block(IndicatorLed()))
-      (self.sw, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate())
+      (self.led, ), _ = self.chain(self.mcu.gpio.request(), imp.Block(IndicatorLed()))
+      (self.sw, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request())
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
@@ -183,10 +183,10 @@ class TestBlinkyComplete(BoardTop):
 
       self.led = ElementDict[IndicatorLed]()
       for i in range(8):
-        (self.led[i], ), _ = self.chain(self.mcu.gpio.allocate(), imp.Block(IndicatorLed()))
+        (self.led[i], ), _ = self.chain(self.mcu.gpio.request(), imp.Block(IndicatorLed()))
 
-      (self.sw, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate())
-      (self.temp, ), _ = self.chain(imp.Block(Mcp9700()), self.mcu.adc.allocate())
+      (self.sw, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request())
+      (self.temp, ), _ = self.chain(imp.Block(Mcp9700()), self.mcu.adc.request())
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(

--- a/examples/test_blinky_new.py
+++ b/examples/test_blinky_new.py
@@ -9,7 +9,7 @@ class NewBlinkyOvervolt(BoardTop):
 
     self.mcu = self.Block(IoController())
     self.led = self.Block(IndicatorLed())
-    self.connect(self.mcu.gpio.allocate(), self.led.signal)
+    self.connect(self.mcu.gpio.request(), self.led.signal)
     self.connect(self.mcu.gnd, self.led.gnd)
     self.jack = self.Block(Pj_102a(voltage_out=5*Volt(tol=0.1)))
     self.connect(self.jack.pwr, self.mcu.pwr)
@@ -28,7 +28,7 @@ class NewBlinkyBuck(BoardTop):
 
     self.mcu = self.Block(IoController())
     self.led = self.Block(IndicatorLed())
-    self.connect(self.mcu.gpio.allocate(), self.led.signal)
+    self.connect(self.mcu.gpio.request(), self.led.signal)
     self.connect(self.mcu.gnd, self.led.gnd)
     self.jack = self.Block(Pj_102a(voltage_out=5*Volt(tol=0.1)))
     self.connect(self.mcu.gnd, self.jack.gnd)
@@ -68,7 +68,7 @@ class NewBlinkyRefactored(BoardTop):
       self.led = ElementDict[IndicatorLed]()
       for i in range(4):
         self.led[i] = imp.Block(IndicatorLed())
-        self.connect(self.mcu.gpio.allocate(), self.led[i].signal)
+        self.connect(self.mcu.gpio.request(), self.led[i].signal)
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
@@ -165,10 +165,10 @@ class NewBlinkyMagsense(BoardTop):
       self.led = ElementDict[IndicatorLed]()
       for i in range(4):
         self.led[i] = imp.Block(IndicatorLed())
-        self.connect(self.mcu.gpio.allocate(), self.led[i].signal)
+        self.connect(self.mcu.gpio.request(), self.led[i].signal)
 
       self.sens = imp.Block(Ref_Lf21215tmr())
-      self.connect(self.mcu.gpio.allocate(), self.sens.out)
+      self.connect(self.mcu.gpio.request(), self.sens.out)
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
@@ -199,24 +199,24 @@ class NewBlinkyLightsense(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
       self.esd = imp.Block(UsbEsdDiode())
-      self.connect(self.usb.usb, self.mcu.usb.allocate(), self.esd.usb)
+      self.connect(self.usb.usb, self.mcu.usb.request(), self.esd.usb)
 
       self.led = ElementDict[IndicatorLed]()
       for i in range(4):
         self.led[i] = imp.Block(IndicatorLed())
-        self.connect(self.mcu.gpio.allocate(), self.led[i].signal)
+        self.connect(self.mcu.gpio.request(), self.led[i].signal)
 
       self.als = imp.Block(Ref_Bh1620fvc(20000, (2.7, 3.0)*Volt))
       self.amp = imp.Block(OpampFollower())  # "optional", output impedance is "only" 2x larger than MCU's input
       self.connect(self.als.vout, self.amp.input)
-      self.connect(self.amp.output, self.mcu.adc.allocate())
+      self.connect(self.amp.output, self.mcu.adc.request())
 
       self.lcd = imp.Block(Qt096t_if09())
-      self.connect(self.mcu.spi.allocate(), self.lcd.spi)
-      self.connect(self.mcu.gpio.allocate(), self.lcd.cs)
-      self.connect(self.mcu.gpio.allocate(), self.lcd.rs)
-      self.connect(self.mcu.gpio.allocate(), self.lcd.reset)
-      self.connect(self.mcu.gpio.allocate(), self.lcd.led)
+      self.connect(self.mcu.spi.request(), self.lcd.spi)
+      self.connect(self.mcu.gpio.request(), self.lcd.cs)
+      self.connect(self.mcu.gpio.request(), self.lcd.rs)
+      self.connect(self.mcu.gpio.request(), self.lcd.reset)
+      self.connect(self.mcu.gpio.request(), self.lcd.led)
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(

--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -29,25 +29,25 @@ class CanAdapter(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.allocate())
-      (self.xcvr, ), self.can_chain = self.chain(self.mcu.can.allocate('can'), imp.Block(Iso1050dub()))
+      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+      (self.xcvr, ), self.can_chain = self.chain(self.mcu.can.request('can'), imp.Block(Iso1050dub()))
 
-      (self.sw_usb, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw_usb'))
-      (self.sw_can, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw_can'))
+      (self.sw_usb, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw_usb'))
+      (self.sw_can, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw_can'))
 
       self.lcd = imp.Block(Qt096t_if09())
 
       self.rgb_usb = imp.Block(IndicatorSinkRgbLed())
       self.rgb_can = imp.Block(IndicatorSinkRgbLed())
 
-    self.connect(self.mcu.gpio.allocate('lcd_led'), self.lcd.led)
-    self.connect(self.mcu.gpio.allocate('lcd_reset'), self.lcd.reset)
-    self.connect(self.mcu.gpio.allocate('lcd_rs'), self.lcd.rs)
-    self.connect(self.mcu.spi.allocate('lcd_spi'), self.lcd.spi)  # MISO unused
-    self.connect(self.mcu.gpio.allocate('lcd_cs'), self.lcd.cs)
+    self.connect(self.mcu.gpio.request('lcd_led'), self.lcd.led)
+    self.connect(self.mcu.gpio.request('lcd_reset'), self.lcd.reset)
+    self.connect(self.mcu.gpio.request('lcd_rs'), self.lcd.rs)
+    self.connect(self.mcu.spi.request('lcd_spi'), self.lcd.spi)  # MISO unused
+    self.connect(self.mcu.gpio.request('lcd_cs'), self.lcd.cs)
 
-    self.connect(self.mcu.gpio.allocate_vector('rgb_usb'), self.rgb_usb.signals)
-    self.connect(self.mcu.gpio.allocate_vector('rgb_can'), self.rgb_can.signals)
+    self.connect(self.mcu.gpio.request_vector('rgb_usb'), self.rgb_usb.signals)
+    self.connect(self.mcu.gpio.request_vector('rgb_can'), self.rgb_can.signals)
 
     # Isolated CAN Domain
     # self.can = self.Block(M12CanConnector())  # probably not a great idea for this particular application

--- a/examples/test_datalogger.py
+++ b/examples/test_datalogger.py
@@ -50,9 +50,9 @@ class TestDatalogger(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      self.connect(self.mcu.usb.allocate(), self.usb_conn.usb)
+      self.connect(self.mcu.usb.request(), self.usb_conn.usb)
 
-      (self.can, ), _ = self.chain(self.mcu.can.allocate('can'), imp.Block(CalSolCanBlock()))
+      (self.can, ), _ = self.chain(self.mcu.can.request('can'), imp.Block(CalSolCanBlock()))
 
       # TODO need proper support for exported unconnected ports
       self.can_gnd_load = self.Block(VoltageLoad())
@@ -60,66 +60,66 @@ class TestDatalogger(BoardTop):
       self.can_pwr_load = self.Block(VoltageLoad())
       self.connect(self.can.can_pwr, self.can_pwr_load.pwr)
 
-      # mcu_i2c = self.mcu.i2c.allocate()  # no devices, ignored for now
+      # mcu_i2c = self.mcu.i2c.request()  # no devices, ignored for now
       # self.i2c_pullup = imp.Block(I2cPullup())
       # self.connect(self.i2c_pullup.i2c, mcu_i2c)
 
       self.sd = imp.Block(SdSocket())
-      self.connect(self.mcu.spi.allocate('sd_spi'), self.sd.spi)
-      self.connect(self.mcu.gpio.allocate('sd_cs'), self.sd.cs)
+      self.connect(self.mcu.spi.request('sd_spi'), self.sd.spi)
+      self.connect(self.mcu.gpio.request('sd_cs'), self.sd.cs)
       (self.cd_pull, ), _ = self.chain(
-        self.mcu.gpio.allocate('sd_cd_pull'),
+        self.mcu.gpio.request('sd_cd_pull'),
         imp.Block(PullupResistor(4.7 * kOhm(tol=0.05))),
         self.sd.cd)
 
       self.xbee = imp.Block(Xbee_S3b())
-      self.connect(self.mcu.uart.allocate('xbee_uart'), self.xbee.data)
+      self.connect(self.mcu.uart.request('xbee_uart'), self.xbee.data)
       (self.xbee_assoc, ), _ = self.chain(
         self.xbee.associate,
         imp.Block(IndicatorLed(current_draw=(0.5, 2)*mAmp)))  # XBee DIO current is -2 -> 2 mA
 
-      aux_spi = self.mcu.spi.allocate('aux_spi')
+      aux_spi = self.mcu.spi.request('aux_spi')
       self.rtc = imp.Block(Pcf2129())
       self.connect(aux_spi, self.rtc.spi)
-      self.connect(self.mcu.gpio.allocate('rtc_cs'), self.rtc.cs)
+      self.connect(self.mcu.gpio.request('rtc_cs'), self.rtc.cs)
       self.connect(self.bat.pwr, self.rtc.pwr_bat)
 
       self.eink = imp.Block(E2154fs091())
       self.connect(aux_spi, self.eink.spi)
-      self.connect(self.mcu.gpio.allocate('eink_busy'), self.eink.busy)
-      self.connect(self.mcu.gpio.allocate('eink_reset'), self.eink.reset)
-      self.connect(self.mcu.gpio.allocate('eink_dc'), self.eink.dc)
-      self.connect(self.mcu.gpio.allocate('eink_cs'), self.eink.cs)
+      self.connect(self.mcu.gpio.request('eink_busy'), self.eink.busy)
+      self.connect(self.mcu.gpio.request('eink_reset'), self.eink.reset)
+      self.connect(self.mcu.gpio.request('eink_dc'), self.eink.dc)
+      self.connect(self.mcu.gpio.request('eink_cs'), self.eink.cs)
 
       self.ext = imp.Block(BlueSmirf())
-      self.connect(self.mcu.uart.allocate('ext_uart'), self.ext.data)
-      self.connect(self.mcu.gpio.allocate('ext_cts'), self.ext.cts)
-      self.connect(self.mcu.gpio.allocate('ext_rts'), self.ext.rts)
+      self.connect(self.mcu.uart.request('ext_uart'), self.ext.data)
+      self.connect(self.mcu.gpio.request('ext_cts'), self.ext.cts)
+      self.connect(self.mcu.gpio.request('ext_rts'), self.ext.rts)
 
       self.rgb1 = imp.Block(IndicatorSinkRgbLed())  # system RGB 1
-      self.connect(self.mcu.gpio.allocate_vector('rgb1'), self.rgb1.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb1'), self.rgb1.signals)
 
       self.rgb2 = imp.Block(IndicatorSinkRgbLed())  # sd card RGB
-      self.connect(self.mcu.gpio.allocate_vector('rgb2'), self.rgb2.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb2'), self.rgb2.signals)
 
       self.rgb3 = imp.Block(IndicatorSinkRgbLed())
-      self.connect(self.mcu.gpio.allocate_vector('rgb3'), self.rgb3.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb3'), self.rgb3.signals)
 
       sw_pull_model = PullupResistor(4.7 * kOhm(tol=0.05))
       (self.sw1, self.sw1_pull), _ = self.chain(imp.Block(DigitalSwitch()),
                                                 imp.Block(sw_pull_model),
-                                                self.mcu.gpio.allocate('sw1'))
+                                                self.mcu.gpio.request('sw1'))
       (self.sw2, self.sw2_pull), _ = self.chain(imp.Block(DigitalSwitch()),
                                                 imp.Block(sw_pull_model),
-                                                self.mcu.gpio.allocate('sw2'))
+                                                self.mcu.gpio.request('sw2'))
 
     with self.implicit_connect(
         ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       div_model = VoltageDivider(output_voltage=3 * Volt(tol=0.15), impedance=(100, 1000) * Ohm)
-      (self.v12sense, ), _ = self.chain(self.vin, imp.Block(div_model), self.mcu.adc.allocate('v12sense'))
-      (self.v5sense, ), _ = self.chain(self.v5, imp.Block(div_model), self.mcu.adc.allocate('v5sense'))
-      (self.vscsense, ), _ = self.chain(self.buffer.sc_out, imp.Block(div_model), self.mcu.adc.allocate('vscsense'))
+      (self.v12sense, ), _ = self.chain(self.vin, imp.Block(div_model), self.mcu.adc.request('v12sense'))
+      (self.v5sense, ), _ = self.chain(self.v5, imp.Block(div_model), self.mcu.adc.request('v5sense'))
+      (self.vscsense, ), _ = self.chain(self.buffer.sc_out, imp.Block(div_model), self.mcu.adc.request('vscsense'))
 
     self.hole = ElementDict[MountingHole]()
     for i in range(3):

--- a/examples/test_debugger.py
+++ b/examples/test_debugger.py
@@ -85,27 +85,27 @@ class Debugger(BoardTop):
       self.rgb_usb = imp.Block(IndicatorSinkRgbLed())
       self.rgb_tgt = imp.Block(IndicatorSinkRgbLed())
 
-    self.connect(self.mcu.usb.allocate(), self.usb.usb)
+    self.connect(self.mcu.usb.request(), self.usb.usb)
 
-    self.connect(self.mcu.gpio.allocate('target_reg_en'), self.target_reg.en)
+    self.connect(self.mcu.gpio.request('target_reg_en'), self.target_reg.en)
 
-    self.connect(self.mcu.gpio.allocate('target_swclk'), self.target_drv.swclk_in)  # TODO BMP uses pin 15
-    self.connect(self.mcu.gpio.allocate('target_swdio_out'), self.target_drv.swdio_out)
-    self.connect(self.mcu.gpio.allocate('target_swdio_in'), self.target_drv.swdio_in)
-    self.connect(self.mcu.gpio.allocate('target_reset'), self.target_drv.reset_in)
-    self.connect(self.mcu.gpio.allocate('target_swo'), self.target_drv.swo_out)
-    self.connect(self.mcu.gpio.allocate('target_tdi'), self.tdi_res.a.adapt_to(DigitalSource()))
+    self.connect(self.mcu.gpio.request('target_swclk'), self.target_drv.swclk_in)  # TODO BMP uses pin 15
+    self.connect(self.mcu.gpio.request('target_swdio_out'), self.target_drv.swdio_out)
+    self.connect(self.mcu.gpio.request('target_swdio_in'), self.target_drv.swdio_in)
+    self.connect(self.mcu.gpio.request('target_reset'), self.target_drv.reset_in)
+    self.connect(self.mcu.gpio.request('target_swo'), self.target_drv.swo_out)
+    self.connect(self.mcu.gpio.request('target_tdi'), self.tdi_res.a.adapt_to(DigitalSource()))
 
-    self.connect(self.mcu.gpio.allocate('lcd_led'), self.lcd.led)
-    self.connect(self.mcu.gpio.allocate('lcd_reset'), self.lcd.reset)
-    self.connect(self.mcu.gpio.allocate('lcd_rs'), self.lcd.rs)
-    self.connect(self.mcu.spi.allocate('lcd_spi'), self.lcd.spi)  # MISO unused
-    self.connect(self.mcu.gpio.allocate('lcd_cs'), self.lcd.cs)
+    self.connect(self.mcu.gpio.request('lcd_led'), self.lcd.led)
+    self.connect(self.mcu.gpio.request('lcd_reset'), self.lcd.reset)
+    self.connect(self.mcu.gpio.request('lcd_rs'), self.lcd.rs)
+    self.connect(self.mcu.spi.request('lcd_spi'), self.lcd.spi)  # MISO unused
+    self.connect(self.mcu.gpio.request('lcd_cs'), self.lcd.cs)
 
-    self.connect(self.mcu.gpio.allocate_vector('rgb_usb'), self.rgb_usb.signals)
-    self.connect(self.mcu.gpio.allocate_vector('rgb_tgt'), self.rgb_tgt.signals)
+    self.connect(self.mcu.gpio.request_vector('rgb_usb'), self.rgb_usb.signals)
+    self.connect(self.mcu.gpio.request_vector('rgb_tgt'), self.rgb_tgt.signals)
 
-    self.connect(self.mcu.gpio.allocate('sw_usb'), self.sw_usb.out)
+    self.connect(self.mcu.gpio.request('sw_usb'), self.sw_usb.out)
 
     # Misc board
     self.duck = self.Block(DuckLogo())

--- a/examples/test_high_switch.py
+++ b/examples/test_high_switch.py
@@ -87,7 +87,7 @@ class TestHighSwitch(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.can, ), self.can_chain = self.chain(self.mcu.can.allocate('can'), imp.Block(CalSolCanBlock()))
+      (self.can, ), self.can_chain = self.chain(self.mcu.can.request('can'), imp.Block(CalSolCanBlock()))
 
       # TODO need proper support for exported unconnected ports
       self.can_gnd_load = self.Block(VoltageLoad())
@@ -98,13 +98,13 @@ class TestHighSwitch(BoardTop):
       (self.vsense, ), _ = self.chain(
         self.vin,
         imp.Block(VoltageDivider(output_voltage=3 * Volt(tol=0.15), impedance=(100, 1000) * Ohm)),
-        self.mcu.adc.allocate('vsense'))
+        self.mcu.adc.request('vsense'))
 
       self.rgb1 = imp.Block(IndicatorSinkRgbLed())  # CAN RGB
-      self.connect(self.mcu.gpio.allocate_vector('rgb1'), self.rgb1.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb1'), self.rgb1.signals)
 
       self.rgb2 = imp.Block(IndicatorSinkRgbLed())  # system RGB 2
-      self.connect(self.mcu.gpio.allocate_vector('rgb2'), self.rgb2.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb2'), self.rgb2.signals)
 
     self.limit_light_current = self.Block(ForcedVoltageCurrentDraw((0, 2.5) * Amp))
     self.connect(self.vin, self.limit_light_current.pwr_in)
@@ -115,13 +115,13 @@ class TestHighSwitch(BoardTop):
       self.light = ElementDict[LightsDriver]()
       for i in range(4):
         light = self.light[i] = imp.Block(LightsDriver((0, 0.5) * Amp))
-        self.connect(self.mcu.gpio.allocate(f'light_{i}0'), light.control[0])
-        self.connect(self.mcu.gpio.allocate(f'light_{i}1'), light.control[1])
+        self.connect(self.mcu.gpio.request(f'light_{i}0'), light.control[0])
+        self.connect(self.mcu.gpio.request(f'light_{i}1'), light.control[1])
 
       for i in range(4, 6):
         light = self.light[i] = imp.Block(LightsDriver((0, 3) * Amp))
-        self.connect(self.mcu.gpio.allocate(f'light_{i}0'), light.control[0])
-        self.connect(self.mcu.gpio.allocate(f'light_{i}1'), light.control[1])
+        self.connect(self.mcu.gpio.request(f'light_{i}0'), light.control[0])
+        self.connect(self.mcu.gpio.request(f'light_{i}1'), light.control[1])
 
     self.hole = ElementDict[MountingHole]()
     for i in range(4):

--- a/examples/test_ledmatrix.py
+++ b/examples/test_ledmatrix.py
@@ -114,12 +114,12 @@ class LedMatrixTest(JlcBoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw1'))
+      (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw1'))
 
       # maximum current draw that is still within the column sink capability of the ESP32
       self.matrix = imp.Block(CharlieplexedLedMatrix(6, 5, current_draw=(3.5, 5)*mAmp, color=Led.Yellow))
-      self.connect(self.mcu.gpio.allocate_vector('led'), self.matrix.ios)
-      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.allocate())
+      self.connect(self.mcu.gpio.request_vector('led'), self.matrix.ios)
+      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
 
     # Misc board
     self.duck = self.Block(DuckLogo())
@@ -128,13 +128,13 @@ class LedMatrixTest(JlcBoardTop):
 
   def multipack(self) -> None:
     self.matrix_res1 = self.PackedBlock(ResistorArray())
-    self.pack(self.matrix_res1.elements.allocate('0'), ['matrix', 'res[0]'])
-    self.pack(self.matrix_res1.elements.allocate('1'), ['matrix', 'res[1]'])
-    self.pack(self.matrix_res1.elements.allocate('2'), ['matrix', 'res[2]'])
+    self.pack(self.matrix_res1.elements.request('0'), ['matrix', 'res[0]'])
+    self.pack(self.matrix_res1.elements.request('1'), ['matrix', 'res[1]'])
+    self.pack(self.matrix_res1.elements.request('2'), ['matrix', 'res[2]'])
 
     self.matrix_res2 = self.PackedBlock(ResistorArray())
-    self.pack(self.matrix_res2.elements.allocate('0'), ['matrix', 'res[3]'])
-    self.pack(self.matrix_res2.elements.allocate('1'), ['matrix', 'res[4]'])
+    self.pack(self.matrix_res2.elements.request('0'), ['matrix', 'res[3]'])
+    self.pack(self.matrix_res2.elements.request('1'), ['matrix', 'res[4]'])
 
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -27,11 +27,11 @@ class ResistorMux(GeneratorBlock):
     for i, resistance in enumerate(resistances):
       if resistance.upper == float('inf'):  # open circuit for this step
         self.dummy = self.Block(DummyPassive())
-        self.connect(self.dummy.io, self.switch.inputs.allocate(str(i)))
+        self.connect(self.dummy.io, self.switch.inputs.request(str(i)))
       else:
         res = self.res[i] = self.Block(Resistor(resistance))
         self.connect(res.a, self.input)
-        self.connect(res.b, self.switch.inputs.allocate(str(i)))
+        self.connect(res.b, self.switch.inputs.request(str(i)))
 
 
 class MultimeterAnalog(Block):
@@ -141,7 +141,7 @@ class MultimeterCurrentDriver(Block):
         [fet_source_node, self.amp.out],
         self.fet.gate.adapt_to(AnalogSink())
       )
-      self.connect(self.enable, self.sw.control.allocate())
+      self.connect(self.enable, self.sw.control.request())
 
     self.diode = self.Block(Diode(
       reverse_voltage=self.voltage_rating,  # protect against positive overvoltage
@@ -296,34 +296,34 @@ class MultimeterTest(JlcBoardTop):
 
       (self.vbatsense, ), _ = self.chain(self.gate.pwr_out,
                                          imp.Block(VoltageDivider(output_voltage=(0.6, 3)*Volt, impedance=(100, 1000)*Ohm)),
-                                         self.mcu.adc.allocate('vbatsense'))
+                                         self.mcu.adc.request('vbatsense'))
 
-      (self.usb_esd, ), _ = self.chain(self.data_usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.allocate())
+      (self.usb_esd, ), _ = self.chain(self.data_usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
       self.connect(self.mcu.pwr_usb, self.data_usb.pwr)
 
-      self.chain(self.gate.btn_out, self.mcu.gpio.allocate('sw0'))
-      self.chain(self.mcu.gpio.allocate('gate_control'), self.gate.control)
+      self.chain(self.gate.btn_out, self.mcu.gpio.request('sw0'))
+      self.chain(self.mcu.gpio.request('gate_control'), self.gate.control)
 
       self.rgb = imp.Block(IndicatorSinkRgbLed())
-      self.connect(self.mcu.gpio.allocate_vector('rgb'), self.rgb.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb'), self.rgb.signals)
 
-      (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw1'))
-      (self.sw2, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw2'))
+      (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw1'))
+      (self.sw2, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw2'))
 
-      lcd_spi = self.mcu.spi.allocate('lcd_spi')
+      lcd_spi = self.mcu.spi.request('lcd_spi')
       self.lcd = imp.Block(Qt096t_if09())
       self.connect(self.reg_3v3.pwr_out.as_digital_source(), self.lcd.led)
-      self.connect(self.mcu.gpio.allocate('lcd_reset'), self.lcd.reset)
-      self.connect(self.mcu.gpio.allocate('lcd_rs'), self.lcd.rs)
+      self.connect(self.mcu.gpio.request('lcd_reset'), self.lcd.reset)
+      self.connect(self.mcu.gpio.request('lcd_rs'), self.lcd.rs)
       self.connect(lcd_spi, self.lcd.spi)  # MISO unused
-      self.connect(self.mcu.gpio.allocate('lcd_cs'), self.lcd.cs)
+      self.connect(self.mcu.gpio.request('lcd_cs'), self.lcd.cs)
 
     # SPEAKER DOMAIN
     with self.implicit_connect(
         ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       (self.spk_dac, self.spk_tp, self.spk_drv, self.spk), self.spk_chain = self.chain(
-        self.mcu.gpio.allocate('spk'),
+        self.mcu.gpio.request('spk'),
         imp.Block(LowPassRcDac(1*kOhm(tol=0.05), 5*kHertz(tol=0.5))),
         self.Block(AnalogTestPoint()),
         imp.Block(Tpa2005d1(gain=Range.from_tolerance(10, 0.2))),
@@ -365,7 +365,7 @@ class MultimeterTest(JlcBoardTop):
       self.inn_merge = self.Block(MergedAnalogSource()).connected_from(
         self.inn_mux.out, self.inn.port.adapt_to(AnalogSource()))
 
-      self.connect(self.mcu.gpio.allocate_vector('inn_control'), self.inn_mux.control)
+      self.connect(self.mcu.gpio.request_vector('inn_control'), self.inn_mux.control)
 
       # POSITIVE PORT
       self.inp = self.Block(BananaSafetyJack())
@@ -376,7 +376,7 @@ class MultimeterTest(JlcBoardTop):
       ))
 
       # MEASUREMENT / SIGNAL CONDITIONING CIRCUITS
-      adc_spi = self.mcu.spi.allocate('adc_spi')
+      adc_spi = self.mcu.spi.request('adc_spi')
       self.measure = imp.Block(MultimeterAnalog())
       self.connect(self.measure.input_positive, inp_port)
       self.connect(self.measure.input_negative, self.inn_merge.output)
@@ -389,10 +389,10 @@ class MultimeterTest(JlcBoardTop):
         adc_spi)
       self.connect(self.adc.pwr, self.v3v3)
       self.connect(self.adc.pwra, self.vanalog)
-      self.connect(self.adc.vins.allocate('0'), self.measure_buffer.output)
-      self.connect(self.adc.vins.allocate('1'), self.inn_merge.output)
-      self.connect(self.mcu.gpio.allocate_vector('measure_select'), self.measure.select)
-      self.connect(self.mcu.gpio.allocate('adc_cs'), self.adc.cs)
+      self.connect(self.adc.vins.request('0'), self.measure_buffer.output)
+      self.connect(self.adc.vins.request('1'), self.inn_merge.output)
+      self.connect(self.mcu.gpio.request_vector('measure_select'), self.measure.select)
+      self.connect(self.mcu.gpio.request('adc_cs'), self.adc.cs)
 
       self.adc_vref = self.connect(self.adc.vref)
       (self.tp_vref, ), _ = self.chain(
@@ -405,11 +405,11 @@ class MultimeterTest(JlcBoardTop):
       ))
       self.connect(self.driver.output, inp_port)
       (self.driver_dac, ), _ = self.chain(
-        self.mcu.gpio.allocate('driver_control'),
+        self.mcu.gpio.request('driver_control'),
         imp.Block(LowPassRcDac(1*kOhm(tol=0.05), 100*Hertz(tol=0.5))),
         self.driver.control)
-      self.connect(self.mcu.gpio.allocate_vector('driver_select'), self.driver.select)
-      self.connect(self.mcu.gpio.allocate('driver_enable'), self.driver.enable)
+      self.connect(self.mcu.gpio.request_vector('driver_select'), self.driver.select)
+      self.connect(self.mcu.gpio.request('driver_enable'), self.driver.enable)
 
     # Misc board
     self.duck = self.Block(DuckLogo())

--- a/examples/test_simon.py
+++ b/examples/test_simon.py
@@ -45,7 +45,7 @@ class TestSimon(BoardTop):
         ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       (self.spk_drv, self.spk), _ = self.chain(
-        self.mcu.dac.allocate('spk'),
+        self.mcu.dac.request('spk'),
         imp.Block(Lm4871()),
         self.Block(Speaker()))
 
@@ -54,11 +54,11 @@ class TestSimon(BoardTop):
       ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       self.rgb = imp.Block(IndicatorSinkRgbLed())  # status RGB
-      self.connect(self.mcu.gpio.allocate_vector('rgb'), self.rgb.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb'), self.rgb.signals)
 
       (self.sw, self.sw_pull), _ = self.chain(
         imp.Block(DigitalSwitch()), imp.Block(PullupResistor(10 * kOhm(tol=0.05))),
-        self.mcu.gpio.allocate('sw'))
+        self.mcu.gpio.request('sw'))
 
       self.btn = ElementDict[DomeButtonConnector]()
       self.btn_pull = ElementDict[PullupResistor]()
@@ -67,7 +67,7 @@ class TestSimon(BoardTop):
       for i in range(4):
         conn = self.btn[i] = imp.Block(DomeButtonConnector())
         pull = self.btn_pull[i] = imp.Block(PullupResistor(10 * kOhm(tol=0.05)))
-        self.connect(pull.io, conn.sw1, self.mcu.gpio.allocate(f'btn_sw{i}'))
+        self.connect(pull.io, conn.sw1, self.mcu.gpio.request(f'btn_sw{i}'))
 
     self.pwr = self.Block(Ap3012(output_voltage=12*Volt(tol=0.1)))
     self.connect(self.v5v, self.pwr.pwr_in)
@@ -79,7 +79,7 @@ class TestSimon(BoardTop):
     ) as imp:
       for i in range(4):
         driver = self.btn_drv[i] = imp.Block(HighSideSwitch(frequency=(0.1, 1) * kHertz))
-        self.connect(self.mcu.gpio.allocate(f'btn_drv{i}'), driver.control)
+        self.connect(self.mcu.gpio.request(f'btn_drv{i}'), driver.control)
         if i == 0:  # only one draws current, since we assume only one will be lit at any point in time
           self.connect(driver.output, self.btn[i].led_a)
         else:

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -332,28 +332,28 @@ class UsbSourceMeasureTest(JlcBoardTop):
 
       self.mcu = imp.Block(IoController())
 
-      (self.usb_esd, ), _ = self.chain(self.data_usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.allocate())
+      (self.usb_esd, ), _ = self.chain(self.data_usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
 
-      (self.i2c_pull, ), _ = self.chain(self.mcu.i2c.allocate(), imp.Block(I2cPullup()), self.pd.i2c)
-      self.connect(self.mcu.gpio.allocate('pd_int'), self.pd.int)
+      (self.i2c_pull, ), _ = self.chain(self.mcu.i2c.request(), imp.Block(I2cPullup()), self.pd.i2c)
+      self.connect(self.mcu.gpio.request('pd_int'), self.pd.int)
 
       self.rgb = imp.Block(IndicatorSinkRgbLed())
-      self.connect(self.mcu.gpio.allocate_vector('rgb'), self.rgb.signals)
+      self.connect(self.mcu.gpio.request_vector('rgb'), self.rgb.signals)
 
-      (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw1'))
-      (self.sw2, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw2'))
-      (self.sw3, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.allocate('sw3'))
+      (self.sw1, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw1'))
+      (self.sw2, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw2'))
+      (self.sw3, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw3'))
 
       # TODO next revision: Blackberry trackball UI, speakers?
 
-      shared_spi = self.mcu.spi.allocate('spi')
+      shared_spi = self.mcu.spi.request('spi')
 
       self.lcd = imp.Block(Qt096t_if09())
       self.connect(self.reg_3v3.pwr_out.as_digital_source(), self.lcd.led)
-      self.connect(self.mcu.gpio.allocate('lcd_reset'), self.lcd.reset)
-      self.connect(self.mcu.gpio.allocate('lcd_rs'), self.lcd.rs)
+      self.connect(self.mcu.gpio.request('lcd_reset'), self.lcd.reset)
+      self.connect(self.mcu.gpio.request('lcd_rs'), self.lcd.rs)
       self.connect(shared_spi, self.lcd.spi)  # MISO unused
-      self.connect(self.mcu.gpio.allocate('lcd_cs'), self.lcd.cs)
+      self.connect(self.mcu.gpio.request('lcd_cs'), self.lcd.cs)
 
       (self.dac_v, ), _ = self.chain(shared_spi, imp.Block(Mcp4921()),
                                      self.control.control_voltage)
@@ -371,16 +371,16 @@ class UsbSourceMeasureTest(JlcBoardTop):
                    self.dac_v.ref, self.dac_ip.ref, self.dac_in.ref,
                    self.adc_v.ref, self.adc_i.ref)
 
-      self.connect(self.mcu.gpio.allocate('dac_v_cs'), self.dac_v.cs)
-      self.connect(self.mcu.gpio.allocate('dac_ip_cs'), self.dac_ip.cs)
-      self.connect(self.mcu.gpio.allocate('dac_in_cs'), self.dac_in.cs)
-      self.connect(self.mcu.gpio.allocate('adc_v_cs'), self.adc_v.cs)
-      self.connect(self.mcu.gpio.allocate('adc_i_cs'), self.adc_i.cs)
-      self.connect(self.mcu.gpio.allocate('dac_ldac'),
+      self.connect(self.mcu.gpio.request('dac_v_cs'), self.dac_v.cs)
+      self.connect(self.mcu.gpio.request('dac_ip_cs'), self.dac_ip.cs)
+      self.connect(self.mcu.gpio.request('dac_in_cs'), self.dac_in.cs)
+      self.connect(self.mcu.gpio.request('adc_v_cs'), self.adc_v.cs)
+      self.connect(self.mcu.gpio.request('adc_i_cs'), self.adc_i.cs)
+      self.connect(self.mcu.gpio.request('dac_ldac'),
                    self.dac_v.ldac, self.dac_ip.ldac, self.dac_in.ldac)
 
-      self.connect(self.mcu.gpio.allocate('high_en'), self.control.high_en)
-      self.connect(self.mcu.gpio.allocate('low_en'), self.control.low_en)
+      self.connect(self.mcu.gpio.request('high_en'), self.control.high_en)
+      self.connect(self.mcu.gpio.request('low_en'), self.control.low_en)
 
     self.outn = self.Block(BananaSafetyJack())
     self.connect(self.gnd, self.outn.port.adapt_to(Ground()))


### PR DESCRIPTION
As part of #155, and updated now so the tutorial updates can use the new terminology. Adds a deprecation to the old ones.

Also fixes a bug where some microcontroller blocks fail if USB is not used.