### PR TITLE
Compiler edge case fixes

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -1076,8 +1076,12 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
       constProp.addAssignEqual(record.target, record.source,
         record.containerPath, "array connect link ELEMENTS from block-side ELEMENTS")
     }
-    if (constProp.getValue(record.target).get != constProp.getValue(record.source).get) {
-      errors.append(CompilerError.InconsistentLinkArrayElements(record.containerPath, record.target, record.source))
+    val linkElements = constProp.getValue(record.target).get.asInstanceOf[ArrayValue[TextValue]]
+    val blockPortElements = constProp.getValue(record.source).get.asInstanceOf[ArrayValue[TextValue]]
+    if (linkElements.values.toSet != blockPortElements.values.toSet) {
+      errors.append(CompilerError.InconsistentLinkArrayElements(record.containerPath,
+        record.target, linkElements,
+        record.source, blockPortElements))
     }
   }
 

--- a/compiler/src/main/scala/edg/compiler/CompilerError.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerError.scala
@@ -60,10 +60,12 @@ object CompilerError {
       s"Unevaluated assertion: $root.$constrName (${ExprToString.apply(value)}), missing ${missing.mkString(", ")}"
   }
 
-  case class InconsistentLinkArrayElements(root: DesignPath, linkElements: IndirectDesignPath,
-                                           blockPortElements: IndirectDesignPath) extends CompilerError {
+  case class InconsistentLinkArrayElements(root: DesignPath,
+                                           linkPath: IndirectDesignPath, linkElements: ArrayValue[TextValue],
+                                           blockPortPath: IndirectDesignPath, blockPortElements: ArrayValue[TextValue]
+                                          ) extends CompilerError {
     override def toString: String =
-      s"Inconsistent link array elements: $linkElements, $blockPortElements"
+      s"Inconsistent link array elements: $linkPath ($linkElements), $blockPortPath ($blockPortElements)"
   }
 
   // TODO should this be an error? Currently a debugging tool


### PR DESCRIPTION
Additionally fixes:
- False-positive late forced-set when a forced value and lower priority assign have the same target expr - fixed by recording and checking the constraint name.
- Unintentional order-sensitivity in comparison of link-array elements and connected port array elements.
- Updates the JAR from #170