### PR TITLE
Improve setup documentation and debuggability

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Runs natively on Windows, Linux, and Mac.
 
 The packages can be installed using `pip`:
 ```python
-pip install protobuf kinparse Deperecated
+pip install protobuf kinparse Deprecated
 ```
 On Ubuntu, you may need to select a particular version of Python for pip, using `python3.8 -m pip` instead of `pip` directly.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ Layout Integration Features
 
 
 ## Setup
-You will need a Python 3.7+ installation with the `protobuf`, `kinparse`, and `Deprecated` packages and a recent Java JRE or JDK.
+You will need a Python 3.7+ installation with the `protobuf`, `kinparse`, and `Deprecated` packages and a recent Java JRE or JDK (version 8 or later _may_ work, version 11 or later probably will work).
 Runs natively on Windows, Linux, and Mac.
+
+<!--JDK compatibility from https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html-->
 
 The packages can be installed using `pip`:
 ```python

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ Layout Integration Features
 
 
 ## Setup
-You will need a Python 3.7+ installation with the `protobuf` and `kinparse` packages and a recent Java JRE or JDK.
+You will need a Python 3.7+ installation with the `protobuf`, `kinparse`, and `Deprecated` packages and a recent Java JRE or JDK.
+Runs natively on Windows, Linux, and Mac.
 
 The packages can be installed using `pip`:
 ```python
-pip install protobuf kinparse
+pip install protobuf kinparse Deperecated
 ```
 On Ubuntu, you may need to select a particular version of Python for pip, using `python3.8 -m pip` instead of `pip` directly.
 
@@ -80,6 +81,12 @@ The test suite includes both unit level tests and example boards.
 
 ```
 python -m unittest discover
+```
+
+If a bunch of things are failing but it isn't clear why from excessive console spam, consider just running one test:
+
+```python
+python -m unittest examples.test_blinky.BlinkyTestCase.test_design_complete
 ```
 
 ### Getting Started Tutorial

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -25,12 +25,19 @@ class ProtobufStdioSubprocess
     [RequestType <: scalapb.GeneratedMessage, ResponseType <: scalapb.GeneratedMessage](
     responseType: scalapb.GeneratedMessageCompanion[ResponseType],
     args: Seq[String]) {
-  protected val process = new ProcessBuilder(args: _*).start()
+  protected val process: Either[Process, Throwable] = try {
+    Left(new ProcessBuilder(args: _*).start())
+  } catch {
+    case e: Throwable => Right(e)  // if it fails store the exception to be thrown when we can 
+  }
 
   // this provides a consistent Stream interface for both stdout and stderr
   // don't use PipedInputStream since it has a non-expanding buffer and is not single-thread safe
   val outputStream = new QueueStream()
-  val errorStream = process.getErrorStream  // the raw error stream from the process
+  val errorStream: InputStream = process match {  // the raw error stream from the process
+    case Left(process) => process.getErrorStream
+    case Right(_) => new QueueStream()  // empty queue if the process never started
+  }
 
   protected def readStreamAvailable(stream: InputStream): String = {
     var available = stream.available()
@@ -45,55 +52,63 @@ class ProtobufStdioSubprocess
   }
 
   def write(message: RequestType): Unit = {
-    if (!process.isAlive) {  // quick check before we try to write to a dead process
-      throw new ProtobufSubprocessException("process died" +
-          s"buffered out=${readStreamAvailable(outputStream)}, err=${readStreamAvailable(errorStream)}")
+    process match {
+      case Right(err) =>
+        throw err
+      case Left(process) if !process.isAlive =>
+        throw new ProtobufSubprocessException("process died, " +
+            s"buffered out=${readStreamAvailable(outputStream)}, err=${readStreamAvailable(errorStream)}")
+      case Left(process) =>
+        process.getOutputStream.write(ProtobufStdioSubprocess.kHeaderMagicByte)
+        message.writeDelimitedTo(process.getOutputStream)
+        process.getOutputStream.flush()
     }
-
-    process.getOutputStream.write(ProtobufStdioSubprocess.kHeaderMagicByte)
-    message.writeDelimitedTo(process.getOutputStream)
-    process.getOutputStream.flush()
   }
 
   def read(): ResponseType = {
-    var doneReadingStdout: Boolean = false
-    while (!doneReadingStdout) {
-      val nextByte = process.getInputStream.read()
-      if (nextByte == ProtobufStdioSubprocess.kHeaderMagicByte) {
-        doneReadingStdout = true
-      } else if (nextByte < 0) {
-        throw new ProtobufSubprocessException(s"unexpected end of stream, got $nextByte, " +
+    process match {
+      case Right(err) =>
+        throw err
+      case Left(process) if !process.isAlive =>
+        throw new ProtobufSubprocessException("process died, " +
             s"buffered out=${readStreamAvailable(outputStream)}, err=${readStreamAvailable(errorStream)}")
-      } else {
-       outputStream.write(nextByte)
-      }
+      case Left(process) =>
+        var doneReadingStdout: Boolean = false
+        while (!doneReadingStdout) {
+          val nextByte = process.getInputStream.read()
+          if (nextByte == ProtobufStdioSubprocess.kHeaderMagicByte) {
+            doneReadingStdout = true
+          } else if (nextByte < 0) {
+            throw new ProtobufSubprocessException(s"unexpected end of stream, got $nextByte, " +
+                s"buffered out=${readStreamAvailable(outputStream)}, err=${readStreamAvailable(errorStream)}")
+          } else {
+            outputStream.write(nextByte)
+          }
+        }
+        responseType.parseDelimitedFrom(process.getInputStream).get
     }
-
-    val responseOpt = responseType.parseDelimitedFrom(process.getInputStream)
-
-    if (!process.isAlive) {
-      throw new ProtobufSubprocessException("process died" +
-          s"buffered out=${readStreamAvailable(outputStream)}, err=${readStreamAvailable(errorStream)}")
-    }
-    responseOpt.get
   }
 
   // Shuts down the stream and returns the exit value
   def shutdown(): Int = {
-    process.getOutputStream.close()
-    var doneReadingStdout: Boolean = false
-    while (!doneReadingStdout) {
-      val nextByte = process.getInputStream.read()
-      require(nextByte != ProtobufStdioSubprocess.kHeaderMagicByte)
-      if (nextByte < 0) {
-        doneReadingStdout = true
-      } else {
-        outputStream.write(nextByte)
-      }
-    }
+    process match {
+      case Right(_) => -1  // give a generic failed value, otherwise doesn't need to do anything
+      case Left(process) =>
+        process.getOutputStream.close()
+        var doneReadingStdout: Boolean = false
+        while (!doneReadingStdout) {
+          val nextByte = process.getInputStream.read()
+          require(nextByte != ProtobufStdioSubprocess.kHeaderMagicByte)
+          if (nextByte < 0) {
+            doneReadingStdout = true
+          } else {
+            outputStream.write(nextByte)
+          }
+        }
 
-    process.waitFor()
-    process.exitValue()
+        process.waitFor()
+        process.exitValue()
+    }
   }
 }
 
@@ -102,7 +117,7 @@ class ProtobufStdioSubprocess
   * them down to IR.
   * The underlying Python HDL should not change while this is open. This will not reload updated Python HDL files.
   */
-class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
+class PythonInterface(serverFile: File, pythonInterpreter: String = "pythonx") {
   protected val process = new ProtobufStdioSubprocess[edgrpc.HdlRequest, edgrpc.HdlResponse](
     edgrpc.HdlResponse,
     Seq(pythonInterpreter, "-u", serverFile.getAbsolutePath))  // in unbuffered mode

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -117,7 +117,7 @@ class ProtobufStdioSubprocess
   * them down to IR.
   * The underlying Python HDL should not change while this is open. This will not reload updated Python HDL files.
   */
-class PythonInterface(serverFile: File, pythonInterpreter: String = "pythonx") {
+class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
   protected val process = new ProtobufStdioSubprocess[edgrpc.HdlRequest, edgrpc.HdlResponse](
     edgrpc.HdlResponse,
     Seq(pythonInterpreter, "-u", serverFile.getAbsolutePath))  // in unbuffered mode

--- a/getting-started.md
+++ b/getting-started.md
@@ -80,6 +80,7 @@ However, you can't do both (since they would duplicate the same results), but yo
 
 ## IDE Setup
 _Recommended (but optional), to use the IDE._
+_Runs natively on Windows, Linux, and Mac._
 
 1. Download [sbt](https://www.scala-sbt.org/download.html), the Scala build tool.
 2. If you do not have a Java JDK installed, download and install one.
@@ -107,10 +108,12 @@ _Recommended (but optional), to use the IDE._
 
 ## HDL-only Setup
 _This isn't necessary if you did the IDE setup above._
+_Runs natively on Windows, Linux, and Mac._
 
 1. Make sure you are using Python 3.7 (or later).
 2. Install the needed dependencies.
    If using pip: `pip install protobuf kinparse Deprecated`
+3. If on Linux and you get an error along the lines of `python: command not found`, you may need to `apt install python-is-python3`.
 
 
 ## A top-level design: Blinky

--- a/getting-started.md
+++ b/getting-started.md
@@ -91,7 +91,10 @@ _Runs natively on Windows, Linux, and Mac._
 4. In the `edg-ide` directory, run `sbt runIDE`.
    sbt will automatically fetch dependencies, compile the plugin, and start the IDE with the plugin enabled.
    - The first run may take a while. 
-   - If you get an error along the lines of `not found: [...]\compiler_2.13\0.1.0-SNAPSHOT\ivys\ivy.xml` or `[error] sbt.librarymanagement.ResolveException: Error downloading compiler:compiler_2.13:0.1.0-SNAPSHOT`, this is because the PolymorphicBlock submodule hasn't been cloned.
+   - If you get an error along the lines of  
+     `sbt.librarymanagement.ResolveException: Error downloading edgcompiler:edgcompiler_2.13:0.1.0-SNAPSHOT`  
+     or `not found: [...]/edgcompiler/edgcompiler_2.13/0.1.0-SNAPSHOT/edgcompiler_2.13-0.1.0-SNAPSHOT.pom`,  
+     this is because the PolymorphicBlocks submodule hasn't been cloned.
      See the section above for instructions.
      The IDE plugin includes the HDL compiler as part of its build and requires the PolymorphicBlocks codebase.
 5. In the IDE, **open the `PolymorphicBlocks` folder as a project**.


### PR DESCRIPTION
- catches and stores errors if the Python subprocess fails to start, so errors can be reported through the normal flow instead of just crashing immediately - in particular for unit tests, this means the error message is reported, instead of directly printed and immediately clobbered by the test failure spam that doesn't include useful diagnostics
- add Deprecated pip package to README
- update the submodule not cloned error to use the new sub-project name
- add python-is-python3 issue and solution for Linux
- suggest debugging with just one test instead of all of them
- suggest JRE/JDK versions
- runs natively on major OSes