### PR TITLE
Fix bug with refdesing empty design; deduplicate error output

### DIFF
--- a/HdlInterfaceService.py
+++ b/HdlInterfaceService.py
@@ -118,6 +118,7 @@ if __name__ == '__main__':
 
         refinement_results = refinement_pass.run(CompiledDesign.from_request(
           request.run_refinement.design, request.run_refinement.solvedValues))
+        response.run_refinement.SetInParent()
         for path, refinement_result in refinement_results:
           new_value = response.run_refinement.newValues.add()
           new_value.path.CopyFrom(path)
@@ -129,6 +130,7 @@ if __name__ == '__main__':
 
         backend_results = backend.run(CompiledDesign.from_request(
           request.run_backend.design, request.run_backend.solvedValues))
+        response.run_backend.SetInParent()
         for path, backend_result in backend_results:
           response_result = response.run_backend.results.add()
           response_result.path.CopyFrom(path)

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -241,9 +241,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
           DesignPath() ++ result.getPath -> ExprValue.fromValueLit(result.getValue)
         }.toMap)
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while running refinement $refinementPass: ${err.error}")
+        Errorable.Error(s"while running refinement ${refinementPass.toSimpleString}: ${err.error}")
       case _ =>
-        Errorable.Error(s"while running refinement $refinementPass: invalid response")
+        Errorable.Error(s"while running refinement ${refinementPass.toSimpleString}: invalid response")
     }
     onRunRefinementPassComplete(refinementPass, result)
     result
@@ -271,9 +271,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
           DesignPath() ++ result.getPath -> result.getText
         }.toMap)
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while running backend $backend: ${err.error}")
+        Errorable.Error(s"while running backend ${backend.toSimpleString}: ${err.error}")
       case _ =>
-        Errorable.Error(s"while running backend $backend: invalid response")
+        Errorable.Error(s"while running backend ${backend.toSimpleString}: invalid response")
     }
     onRunBackendComplete(backend, result)
     result

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -241,9 +241,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
           DesignPath() ++ result.getPath -> ExprValue.fromValueLit(result.getValue)
         }.toMap)
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while running backend $refinementPass: ${err.error}")
+        Errorable.Error(s"while running refinement $refinementPass: ${err.error}")
       case _ =>
-        Errorable.Error(s"while running backend $refinementPass: invalid response")
+        Errorable.Error(s"while running refinement $refinementPass: invalid response")
     }
     onRunRefinementPassComplete(refinementPass, result)
     result

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -171,9 +171,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
       case edgrpc.HdlResponse.Response.GetLibraryElement(result) =>
         Errorable.Success((result.getElement, result.refinements))
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while elaborating ${element.toSimpleString}: ${err.error}")
+        Errorable.Error(err.error)
       case _ =>
-        Errorable.Error(s"while elaborating ${element.toSimpleString}: invalid response")
+        Errorable.Error("invalid response")
     }
     onLibraryRequestComplete(element, result)
     result
@@ -201,9 +201,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
       case edgrpc.HdlResponse.Response.ElaborateGenerator(result) =>
         Errorable.Success(result.getGenerated)
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while generating ${element.toSimpleString}: ${err.error}")
+        Errorable.Error(err.error)
       case _ =>
-        Errorable.Error(s"while generating ${element.toSimpleString}: invalid response")
+        Errorable.Error("invalid response")
     }
     onElaborateGeneratorRequestComplete(element, values, result)
     result
@@ -241,9 +241,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
           DesignPath() ++ result.getPath -> ExprValue.fromValueLit(result.getValue)
         }.toMap)
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while running refinement ${refinementPass.toSimpleString}: ${err.error}")
+        Errorable.Error(err.error)
       case _ =>
-        Errorable.Error(s"while running refinement ${refinementPass.toSimpleString}: invalid response")
+        Errorable.Error(s"invalid response")
     }
     onRunRefinementPassComplete(refinementPass, result)
     result
@@ -271,9 +271,9 @@ class PythonInterface(serverFile: File, pythonInterpreter: String = "python") {
           DesignPath() ++ result.getPath -> result.getText
         }.toMap)
       case edgrpc.HdlResponse.Response.Error(err) =>
-        Errorable.Error(s"while running backend ${backend.toSimpleString}: ${err.error}")
+        Errorable.Error(err.error)
       case _ =>
-        Errorable.Error(s"while running backend ${backend.toSimpleString}: invalid response")
+        Errorable.Error("invalid response")
     }
     onRunBackendComplete(backend, result)
     result

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -3,6 +3,10 @@ import unittest
 from edg import *
 
 
+class TestBlinkyEmpty(SimpleBoardTop):
+  pass
+
+
 class TestBlinkyIncomplete(SimpleBoardTop):
   def contents(self) -> None:
     super().contents()
@@ -389,6 +393,9 @@ class TestBlinkyPacked(SimpleBoardTop):
 
 
 class BlinkyTestCase(unittest.TestCase):
+  def test_design_empty(self) -> None:
+    compile_board_inplace(TestBlinkyEmpty)
+
   def test_design_incomplete(self) -> None:
     with self.assertRaises(CompilerCheckError):
       compile_board_inplace(TestBlinkyIncomplete)


### PR DESCRIPTION
Prior, when refdesing an empty design, it returns an empty proto because the message type doesn't get set. This adds an explicit SetInParent.

For error output: this removes the "while running ...", pushing that onto the upper level UI.