### PR TITLE
gitignore generated PDF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.edg
 *.net
 *.lib
+*.pdf
 
 *.raw
 *.plt


### PR DESCRIPTION
Since we now have generated .pdf files, they probably shouldn't be committed just like the generated .net (and other) files.