### PR TITLE
Support inline SI prefix notation

### DIFF
--- a/electronics_abstract_parts/AbstractCapacitor.py
+++ b/electronics_abstract_parts/AbstractCapacitor.py
@@ -33,9 +33,9 @@ class UnpolarizedCapacitor(PassiveComponent):
 @abstract_block
 class Capacitor(UnpolarizedCapacitor, KiCadInstantiableBlock):
   """Polarized capacitor, which we assume will be the default"""
-  CAPACITOR_REGEX = re.compile("^" + f"([\d.]+\s*[{PartParserUtil.SI_PREFIXES}]?)F?" +
+  CAPACITOR_REGEX = re.compile("^" + f"([\d.{PartParserUtil.SI_PREFIXES}]+(?:\s*[{PartParserUtil.SI_PREFIXES}])?)\s*F?" +
                                "\s*" + "((?:\+-|\+/-|±)?\s*[\d.]+\s*%)?" +
-                               "\s*" + f"([\d.]+\s*[{PartParserUtil.SI_PREFIXES}]?\s*V)" + "$")
+                               "\s*" + f"([\d.{PartParserUtil.SI_PREFIXES}]+(?:\s*[{PartParserUtil.SI_PREFIXES}])?\s*V)" + "$")
   CAPACITOR_DEFAULT_TOL = 0.20  # TODO this should be unified elsewhere
 
   def symbol_pinning(self, symbol_name: str) -> Dict[str, BasePort]:

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -10,7 +10,7 @@ from .StandardPinningFootprint import StandardPinningFootprint
 
 @abstract_block
 class Resistor(PassiveComponent, KiCadInstantiableBlock):
-  RESISTOR_REGEX = re.compile("^" + f"([\d.]+\s*[{PartParserUtil.SI_PREFIXES}]?)[RΩ]?" +
+  RESISTOR_REGEX = re.compile("^" + f"([\d.{PartParserUtil.SI_PREFIXES}]+(?:\s*[{PartParserUtil.SI_PREFIXES}])?)\s*[RΩ]?" +
                               "\s*" + "((?:\+-|\+/-|±)?\s*[\d.]+\s*%?)?" + "$")
   RESISTOR_DEFAULT_TOL = 0.05  # TODO this should be unified elsewhere
 

--- a/electronics_abstract_parts/test_kicad_part_parsing.py
+++ b/electronics_abstract_parts/test_kicad_part_parsing.py
@@ -11,10 +11,14 @@ class KicadPartParsingTest(unittest.TestCase):
     self.assertEqual(Resistor.parse_resistor("22kR"), Range.from_tolerance(22000, 0.05))
     self.assertEqual(Resistor.parse_resistor("22k"), Range.from_tolerance(22000, 0.05))
     self.assertEqual(Resistor.parse_resistor("22 k"), Range.from_tolerance(22000, 0.05))
+    self.assertEqual(Resistor.parse_resistor("22k0"), Range.from_tolerance(22000, 0.05))
+    self.assertEqual(Resistor.parse_resistor("2k2"), Range.from_tolerance(2200, 0.05))
 
     self.assertEqual(Resistor.parse_resistor("22k 10%"), Range.from_tolerance(22000, 0.1))
     self.assertEqual(Resistor.parse_resistor("22k ±10%"), Range.from_tolerance(22000, 0.1))
     self.assertEqual(Resistor.parse_resistor("22k 5%"), Range.from_tolerance(22000, 0.05))
+    self.assertEqual(Resistor.parse_resistor("22k0 5%"), Range.from_tolerance(22000, 0.05))
+    self.assertEqual(Resistor.parse_resistor("2k2 5%"), Range.from_tolerance(2200, 0.05))
 
   def test_capacitor(self):
     self.assertEqual(Capacitor.parse_capacitor("0.1uF 6.3V"), (Range.from_tolerance(0.1e-6, 0.20),

--- a/electronics_model/PartParserUtil.py
+++ b/electronics_model/PartParserUtil.py
@@ -36,7 +36,7 @@ class PartParserUtil:
   @classmethod
   def parse_value(cls, value: str, units: str, default: Union[Type[ParseError], DefaultType] = ParseError) -> Union[DefaultType, float]:
     """Parses a value with unit and SI prefixes, for example '20 nF' would be parsed as 20e-9.
-    Additionally supports fractional notation, eg 1/16W
+    Supports inline prefix notation (eg, 2k2R) and fractional notation (eg, 1/16W)
     If the input is not a value:
       if default is not specified, raises a ParseError.
       if default is specified, returns the default."""

--- a/electronics_model/test_part_parser.py
+++ b/electronics_model/test_part_parser.py
@@ -10,8 +10,10 @@ class PartsTableUtilsTest(unittest.TestCase):
     self.assertEqual(PartParserUtil.parse_value('20F', 'F'), 20)
     self.assertEqual(PartParserUtil.parse_value('50 kV', 'V'), 50e3)
     self.assertEqual(PartParserUtil.parse_value('49.9 GΩ', 'Ω'), 49.9e9)
-    self.assertEqual(PartParserUtil.parse_value('49.9 GΩ', 'Ω'), 49.9e9)
+    self.assertEqual(PartParserUtil.parse_value('49G9 Ω', 'Ω'), 49.9e9)
 
+    with self.assertRaises(PartParserUtil.ParseError):
+      self.assertEqual(PartParserUtil.parse_value('50 k V', 'V'), None)
     with self.assertRaises(PartParserUtil.ParseError):
       self.assertEqual(PartParserUtil.parse_value('50 kA', 'V'), None)
     with self.assertRaises(PartParserUtil.ParseError):
@@ -20,6 +22,8 @@ class PartsTableUtilsTest(unittest.TestCase):
       self.assertEqual(PartParserUtil.parse_value('50 k', 'V'), None)
     with self.assertRaises(PartParserUtil.ParseError):
       self.assertEqual(PartParserUtil.parse_value('ducks', 'V'), None)
+    with self.assertRaises(PartParserUtil.ParseError):
+      self.assertEqual(PartParserUtil.parse_value('50k1 kV', 'V'), None)
     with self.assertRaises(PartParserUtil.ParseError):
       self.assertEqual(PartParserUtil.parse_value('50.1.2 V', 'V'), None)
     with self.assertRaises(PartParserUtil.ParseError):


### PR DESCRIPTION
eg, '4k7' - in the underlying parsing infrastructure that supports both the parts table and kicad import