### PR TITLE
Refactor internal microcontrollers to use BaseIoController

### DIFF
--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Set, Type
+from typing import List, Dict
 
 from electronics_model import *
 from .PinMappable import AllocatedResource
@@ -8,7 +8,9 @@ from .PinMappable import AllocatedResource
 class BaseIoController(Block):
   """An abstract IO controller block, that takes power input and provides a grab-bag of common IOs.
   A base interface for microcontrollers and microcontroller-like devices (eg, FPGAs).
-  Pin assignments are handled via refinements and can be assigned to pins' allocated names."""
+  Pin assignments are handled via refinements and can be assigned to pins' allocated names.
+
+  This should not be instantiated as a generic block."""
   def __init__(self) -> None:
     super().__init__()
 
@@ -86,7 +88,7 @@ class BaseIoController(Block):
 
 @abstract_block
 class IoController(BaseIoController):
-  """An IO controller that takes input power."""
+  """An abstract, generic IO controller with common IOs and power ports."""
   def __init__(self) -> None:
     super().__init__()
 

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -7,7 +7,7 @@ from .Microcontroller_Esp import EspProgrammingHeader
 
 
 @abstract_block
-class Esp32_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, FootprintBlock):
+class Esp32_Device(PinMappable, BaseIoController, DiscreteChip, GeneratorBlock, FootprintBlock):
   """Base class for ESP32 series microcontrollrs with WiFi and Bluetooth (classic and LE)
 
   Chip datasheet: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
@@ -15,12 +15,12 @@ class Esp32_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, Foot
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.pwr.init_from(VoltageSink(
+    self.pwr = self.Port(VoltageSink(
       voltage_limits=(3.0, 3.6)*Volt,  # section 5.2, table 14, most restrictive limits
       current_draw=(0.001, 370) * mAmp  # from power off (table 8) to RF working (WRROM datasheet table 9)
       # # TODO propagate current consumption from IO ports
-    ))
-    self.gnd.init_from(Ground())
+    ), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     self.dio_model = dio_model = DigitalBidir.from_supply(  # section 5.2, table 15
       self.gnd, self.pwr,
@@ -227,19 +227,18 @@ class Esp32_Wroom_32(PinMappable, Microcontroller, IoController, Block):
   """
   def __init__(self, **kwargs):
     super().__init__(**kwargs)
-    self.ic = self.Block(Esp32_Wroom_32_Device(pin_assigns=self.pin_assigns))
 
   def contents(self) -> None:
     super().contents()
-    self.connect(self.pwr, self.ic.pwr)
-    self.connect(self.gnd, self.ic.gnd)
-    self._export_ios_from(self.ic)
-    self.assign(self.actual_pin_assigns, self.ic.actual_pin_assigns)
 
     with self.implicit_connect(
         ImplicitConnect(self.pwr, [Power]),
         ImplicitConnect(self.gnd, [Common])
     ) as imp:
+      self.ic = imp.Block(Esp32_Wroom_32_Device(pin_assigns=self.pin_assigns))
+      self._export_ios_from(self.ic)
+      self.assign(self.actual_pin_assigns, self.ic.actual_pin_assigns)
+
       self.vcc_cap0 = imp.Block(DecouplingCapacitor(22 * uFarad(tol=0.2)))  # C1
       self.vcc_cap1 = imp.Block(DecouplingCapacitor(0.1 * uFarad(tol=0.2)))  # C2
 

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -7,7 +7,7 @@ from .Microcontroller_Esp import EspProgrammingHeader
 
 
 @abstract_block
-class Esp32c3_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, FootprintBlock):
+class Esp32c3_Device(PinMappable, BaseIoController, DiscreteChip, GeneratorBlock, FootprintBlock):
   """Base class for ESP32-C3 series devices, with RISC-V core, 2.4GHz WiF,i, BLE5, and USB.
   PlatformIO: use board ID esp32-c3-devkitm-1
 
@@ -16,12 +16,12 @@ class Esp32c3_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, Fo
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.pwr.init_from(VoltageSink(
+    self.pwr = self.Port(VoltageSink(
       voltage_limits=(3.0, 3.6)*Volt,  # section 4.2
       current_draw=(0.001, 335) * mAmp  # section 4.6, from power off to RF active
       # TODO propagate current consumption from IO ports
-    ))
-    self.gnd.init_from(Ground())
+    ), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     self.dio_model = dio_model = DigitalBidir.from_supply(  # table 4.4
       self.gnd, self.pwr,
@@ -172,19 +172,18 @@ class Esp32c3_Wroom02(PinMappable, Microcontroller, IoController, Block):
   """Wrapper around Esp32c3_Wroom02 with external capacitors and UART programming header."""
   def __init__(self, **kwargs):
     super().__init__(**kwargs)
-    self.ic = self.Block(Esp32c3_Wroom02_Device(pin_assigns=self.pin_assigns))
 
   def contents(self) -> None:
     super().contents()
-    self.connect(self.pwr, self.ic.pwr)
-    self.connect(self.gnd, self.ic.gnd)
-    self._export_ios_from(self.ic)
-    self.assign(self.actual_pin_assigns, self.ic.actual_pin_assigns)
 
     with self.implicit_connect(
         ImplicitConnect(self.pwr, [Power]),
         ImplicitConnect(self.gnd, [Common])
     ) as imp:
+      self.ic = imp.Block(Esp32c3_Wroom02_Device(pin_assigns=self.pin_assigns))
+      self._export_ios_from(self.ic)
+      self.assign(self.actual_pin_assigns, self.ic.actual_pin_assigns)
+
       self.vcc_cap0 = imp.Block(DecouplingCapacitor(10 * uFarad(tol=0.2)))  # C1
       self.vcc_cap1 = imp.Block(DecouplingCapacitor(0.1 * uFarad(tol=0.2)))  # C2
 

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -6,9 +6,17 @@ from electronics_lib import OscillatorCrystal
 
 
 @abstract_block
-class Lpc1549Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock, FootprintBlock):
+class Lpc1549Base_Device(PinMappable, BaseIoController, DiscreteChip, GeneratorBlock, FootprintBlock):
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
+
+    # Ports with shared references
+    self.pwr = self.Port(VoltageSink(
+      voltage_limits=(2.4, 3.6) * Volt,
+      current_draw=(0, 19)*mAmp,  # rough guesstimate from Figure 11.1 for supply Idd (active mode)
+      # TODO propagate current consumption from IO ports
+    ), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     # Additional ports (on top of IoController)
     # Crystals from table 15, 32, 33
@@ -28,14 +36,6 @@ class Lpc1549Base_Device(PinMappable, IoController, DiscreteChip, GeneratorBlock
 
   def contents(self) -> None:
     super().contents()
-
-    # Ports with shared references
-    self.pwr.init_from(VoltageSink(
-      voltage_limits=(2.4, 3.6) * Volt,
-      current_draw=(0, 19)*mAmp,  # rough guesstimate from Figure 11.1 for supply Idd (active mode)
-      # TODO propagate current consumption from IO ports
-    ))
-    self.gnd.init_from(Ground())
 
     # Port models
     dio_5v_model = DigitalBidir.from_supply(


### PR DESCRIPTION
... so the IoController subclass list is clean for application-level subcircuits instead of bare chips

Also changes the compiler so that bad array references will not lower (and cause an error in structural validation) instead of crashing the compiler