### PR TITLE
Clean up mypy instructions

### DIFF
--- a/developing.md
+++ b/developing.md
@@ -23,7 +23,7 @@ mypy .
 
 Or faster, with mypy in daemon mode:
 ```
-dmypy run -- --follow-imports=error .
+dmypy run .
 ```
 
 Or, using the [Mypy plugin for Intellij](https://plugins.jetbrains.com/plugin/13348-mypy-official-).


### PR DESCRIPTION
`--follow-imports=error` seems to break with protobuf under more recent version of Python

and also the mypy configs are moved to mypy.ini, and though `follow_imports = error` could be in mypy.ini it also breaks things (as expected?)