### PR TITLE
Capacitor voltage-rating derating

### DIFF
--- a/edg_core/Generator.py
+++ b/edg_core/Generator.py
@@ -152,6 +152,9 @@ class GeneratorBlock(Block):
     Registers a generator function
     :param fn: function (of self) to invoke, where the parameter list lines up with reqs
     :param reqs: required parameters, the value of which are passed to the generator function
+
+    Note, generator parameters must be __init__ parameters because the block is not traversed before generation,
+    and any internal constraints (like parameter assignments from within) are not evaluated.
     """
     assert callable(fn), f"fn {fn} must be a method (callable)"
     assert self._generator is None, f"redefinition of generator, multiple generators not allowed"

--- a/electronics_abstract_parts/AbstractCapacitor.py
+++ b/electronics_abstract_parts/AbstractCapacitor.py
@@ -22,7 +22,8 @@ class UnpolarizedCapacitor(PassiveComponent):
     self.voltage = self.ArgParameter(voltage)  # defined as operating voltage range
 
     # this is the scaling derating factor applied to the rated voltage spec
-    # eg, a value of 2 would mean the labeled rated voltage must be 2x the actual voltage
+    # eg, a value of 0.5 would mean the labeled rated voltage must be 2x the actual voltage
+    # 0.5 is the general rule of thumb for ceramic capacitors: https://www.sparkfun.com/news/1271
     # this does not apply to capacitance derating, which is handled separately
     self.voltage_rating_derating = self.ArgParameter(voltage_rating_derating)
 
@@ -131,7 +132,7 @@ class TableDeratingCapacitor(CapacitorStandardPinning, TableCapacitor, PartsTabl
 
   def select_part(self, capacitance: Range, voltage: Range, single_nominal_capacitance: Range,
                   voltage_rating_derating: float, part_spec: str, footprint_spec: str) -> None:
-    derated_voltage = voltage * voltage_rating_derating
+    derated_voltage = voltage / voltage_rating_derating
     # Pre-filter out by the static parameters
     # Note that we can't filter out capacitance before derating
     prefiltererd_parts = self._get_table().filter(lambda row: (

--- a/electronics_abstract_parts/AbstractCapacitor.py
+++ b/electronics_abstract_parts/AbstractCapacitor.py
@@ -15,7 +15,7 @@ class UnpolarizedCapacitor(PassiveComponent):
   """Base type for a capacitor, that defines its parameters and without ports (since capacitors can be polarized)"""
   @init_in_parent
   def __init__(self, capacitance: RangeLike, voltage: RangeLike, *,
-               voltage_rating_derating: FloatLike = 1.0) -> None:
+               voltage_rating_derating: FloatLike = 0.5) -> None:
     super().__init__()
 
     self.capacitance = self.ArgParameter(capacitance)

--- a/examples/test_bldc.py
+++ b/examples/test_bldc.py
@@ -275,6 +275,10 @@ class BldcDriverBoard(JlcBoardTop):
         (PassiveConnector, JstPhKVertical),  # default connector series unless otherwise specified
         (TestPoint, CompactKeystone5015),
       ],
+      class_values=[
+        # for compatibility, this board was manufactured before derating was supported and does not compile otherwise
+        (Capacitor, ["voltage_rating_derating"], 1.0),
+      ],
     )
 
 


### PR DESCRIPTION
General rule of thumb for ceramic capacitors is to specify a voltage rating of twice the operating voltage. This adds that functionality.

This doesn't change the current hacktastic capacitance derating (where if the capacitor is operating under high voltage, more nameplate capacitance is requested to offset capacitance derating).

In practice this doesn't have seemed to changed any of the part selections, perhaps because the default capacitors are already pretty high voltage.

Also adds a note about why generators only take arg-params.