### PR TITLE
Set Zener protection voltage limits to reflect actual limits

### DIFF
--- a/electronics_abstract_parts/AbstractDiodes.py
+++ b/electronics_abstract_parts/AbstractDiodes.py
@@ -199,7 +199,7 @@ class ProtectionZenerDiode(DiscreteApplication):
     super().contents()
     self.diode = self.Block(ZenerDiode(zener_voltage=self.voltage))
     self.connect(self.diode.cathode.adapt_to(VoltageSink(
-      voltage_limits=(0, self.voltage.lower()),
+      voltage_limits=(0, self.diode.actual_zener_voltage.lower()),
       current_draw=(0, 0)*Amp  # TODO should be leakage current
     )), self.pwr)
     self.connect(self.diode.anode.adapt_to(Ground()), self.gnd)


### PR DESCRIPTION
Prior, it was using the spec limits which are loose (wider) than the limits of the actual selected part. This allows voltage_limits to more accurately reflect actual limits.