### PR TITLE
Internal API changes

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -1319,6 +1319,7 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
   // Primarily used for unit tests, TODO clean up this API?
   private[edg] def getValue(path: IndirectDesignPath): Option[ExprValue] = constProp.getValue(path)
 
+  def getParamType(param: IndirectDesignPath): Option[Class[_ <: ExprValue]] = constProp.getType(param)
   def getParamValue(param: IndirectDesignPath): Option[ExprValue] = constProp.getValue(param)
   def getAllSolved: Map[IndirectDesignPath, ExprValue] = constProp.getAllSolved
   def getConnectedLink(port: DesignPath): Option[DesignPath] = constProp.getConnectedLink(port)

--- a/compiler/src/main/scala/edg/wir/DesignPath.scala
+++ b/compiler/src/main/scala/edg/wir/DesignPath.scala
@@ -21,19 +21,19 @@ object IndirectStep {  // namespace
       ref.LocalStep(step = ref.LocalStep.Step.Name(name))
     }
   }
-  object IsConnected extends IndirectStep {
+  case object IsConnected extends IndirectStep {
     override def toString: String = "IS_CONNECTED"
     override def asLocalStep: ref.LocalStep = {
       ref.LocalStep(step = ref.LocalStep.Step.ReservedParam(ref.Reserved.IS_CONNECTED))
     }
   }
-  object Length extends IndirectStep {
+  case object Length extends IndirectStep {
     override def toString: String = "LENGTH"
     override def asLocalStep: ref.LocalStep = {
       ref.LocalStep(step = ref.LocalStep.Step.ReservedParam(ref.Reserved.LENGTH))
     }
   }
-  object Elements extends IndirectStep {
+  case object Elements extends IndirectStep {
     override def toString: String = "ELEMENTS"
     override def asLocalStep: ref.LocalStep = {
       ref.LocalStep(step = ref.LocalStep.Step.ReservedParam(ref.Reserved.ELEMENTS))
@@ -45,19 +45,19 @@ object IndirectStep {  // namespace
       ref.LocalStep(step = ref.LocalStep.Step.Allocate(suggestedName.getOrElse("")))
     }
   }
-  object Allocated extends IndirectStep {
+  case object Allocated extends IndirectStep {
     override def toString: String = "ALLOCATED"
     override def asLocalStep: ref.LocalStep = {
       ref.LocalStep(step = ref.LocalStep.Step.ReservedParam(ref.Reserved.ALLOCATED))
     }
   }
-  object Name extends IndirectStep {
+  case object Name extends IndirectStep {
     override def toString: String = "NAME"
     override def asLocalStep: ref.LocalStep = {
       ref.LocalStep(step = ref.LocalStep.Step.ReservedParam(ref.Reserved.NAME))
     }
   }
-  object ConnectedLink extends IndirectStep {  // block-side port -> link
+  case object ConnectedLink extends IndirectStep {  // block-side port -> link
     override def toString: String = "CONNECTED_LINK"
     override def asLocalStep: ref.LocalStep = {
       ref.LocalStep(step = ref.LocalStep.Step.ReservedParam(ref.Reserved.CONNECTED_LINK))

--- a/compiler/src/test/scala/edg/compiler/ConstPropTypeTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropTypeTest.scala
@@ -18,24 +18,24 @@ class ConstPropTypeTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "b", ValInit.Integer)
     constProp.addDeclaration(DesignPath() + "c", ValInit.Integer)
     constProp.getUnsolved should equal(Set(
-      DesignPath() + "a",
-      DesignPath() + "b",
-      DesignPath() + "c",
+      IndirectDesignPath() + "a",
+      IndirectDesignPath() + "b",
+      IndirectDesignPath() + "c",
     ))
 
     constProp.addAssignExpr(IndirectDesignPath() + "a",
       ValueExpr.Literal(1)
     )
     constProp.getUnsolved should equal(Set(
-      DesignPath() + "b",
-      DesignPath() + "c",
+      IndirectDesignPath() + "b",
+      IndirectDesignPath() + "c",
     ))
 
     constProp.addAssignExpr(IndirectDesignPath() + "b",
       ValueExpr.Literal(1)
     )
     constProp.getUnsolved should equal(Set(
-      DesignPath() + "c",
+      IndirectDesignPath() + "c",
     ))
 
     constProp.addAssignExpr(IndirectDesignPath() + "c",
@@ -70,23 +70,23 @@ class ConstPropTypeTest extends AnyFlatSpec {
     constProp2.getType(IndirectDesignPath() + "float") should equal(None)
 
     constProp1.getUnsolved should equal(Set(
-      DesignPath() + "int",
-      DesignPath() + "float",
+      IndirectDesignPath() + "int",
+      IndirectDesignPath() + "float",
     ))
     constProp2.getUnsolved should equal(Set(
-      DesignPath() + "int",
-      DesignPath() + "boolean",
+      IndirectDesignPath() + "int",
+      IndirectDesignPath() + "boolean",
     ))
 
     constProp1.addAssignExpr(IndirectDesignPath() + "int",  // unsolved should be independent
       ValueExpr.Literal(1)
     )
     constProp1.getUnsolved should equal(Set(
-      DesignPath() + "float",
+      IndirectDesignPath() + "float",
     ))
     constProp2.getUnsolved should equal(Set(
-      DesignPath() + "int",
-      DesignPath() + "boolean",
+      IndirectDesignPath() + "int",
+      IndirectDesignPath() + "boolean",
     ))
   }
 }

--- a/compiler/src/test/scala/edg/compiler/ConstPropTypeTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropTypeTest.scala
@@ -50,9 +50,9 @@ class ConstPropTypeTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "float", ValInit.Floating)
     constProp.addDeclaration(DesignPath() + "boolean", ValInit.Boolean)
 
-    constProp.getType(DesignPath() + "int") should equal(Some(classOf[IntValue]))
-    constProp.getType(DesignPath() + "float") should equal(Some(classOf[FloatValue]))
-    constProp.getType(DesignPath() + "boolean") should equal(Some(classOf[BooleanValue]))
+    constProp.getType(IndirectDesignPath() + "int") should equal(Some(classOf[IntValue]))
+    constProp.getType(IndirectDesignPath() + "float") should equal(Some(classOf[FloatValue]))
+    constProp.getType(IndirectDesignPath() + "boolean") should equal(Some(classOf[BooleanValue]))
   }
 
   it should "track types of clones separately" in {
@@ -61,13 +61,13 @@ class ConstPropTypeTest extends AnyFlatSpec {
 
     val constProp2 = new ConstProp()
     constProp2.initFrom(constProp1)
-    constProp1.getType(DesignPath() + "int") should equal(Some(classOf[IntValue]))
-    constProp2.getType(DesignPath() + "int") should equal(Some(classOf[IntValue]))  // track common types
+    constProp1.getType(IndirectDesignPath() + "int") should equal(Some(classOf[IntValue]))
+    constProp2.getType(IndirectDesignPath() + "int") should equal(Some(classOf[IntValue]))  // track common types
 
     constProp1.addDeclaration(DesignPath() + "float", ValInit.Floating)  // add different types
     constProp2.addDeclaration(DesignPath() + "boolean", ValInit.Boolean)
-    constProp1.getType(DesignPath() + "boolean") should equal(None)  // types should be independent
-    constProp2.getType(DesignPath() + "float") should equal(None)
+    constProp1.getType(IndirectDesignPath() + "boolean") should equal(None)  // types should be independent
+    constProp2.getType(IndirectDesignPath() + "float") should equal(None)
 
     constProp1.getUnsolved should equal(Set(
       DesignPath() + "int",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 protobuf >= 3.20.0
 typing_extensions
-sexpdata
+sexpdata==0.0.3
 Deprecated


### PR DESCRIPTION
For IDE changes.

- Add Compiler.getParamType to inspect parameter types
- Change ConstProp paramTypes to use IndirectDesignPath, to support things like names (not currently implemented)
- Change IndirectStep to case objects, to allow serialization
- Pin sexpdata dependency to version 0.0.3, since 0.0.4 is API-incompatible