### PR TITLE
More categories cleanup

### DIFF
--- a/HdlInterfaceService.py
+++ b/HdlInterfaceService.py
@@ -32,7 +32,7 @@ class LibraryElementIndexer:
       if inspect.ismodule(member):  # recurse into visible modules
         self._search_module(member)
 
-      if inspect.isclass(member) and issubclass(member, LibraryElement) \
+      if inspect.isclass(member) and issubclass(member, LibraryElement) and not issubclass(member, DesignTop) \
           and member not in self.seen_elements \
           and (member, 'non_library') not in member._elt_properties:  # process elements
         self.seen_elements.add(member)

--- a/electronics_abstract_parts/AbstractDevices.py
+++ b/electronics_abstract_parts/AbstractDevices.py
@@ -3,7 +3,7 @@ from .Categories import *
 
 
 @abstract_block
-class Battery(DiscreteApplication):
+class Battery(PowerSource):
   @init_in_parent
   def __init__(self, voltage: RangeLike,
                current: RangeLike = Default(RangeExpr.ZERO), *,

--- a/electronics_abstract_parts/AbstractDiodes.py
+++ b/electronics_abstract_parts/AbstractDiodes.py
@@ -183,7 +183,7 @@ class TableZenerDiode(ZenerDiode, BaseDiodeStandardPinning, PartsTableFootprint,
     )
 
 
-class ProtectionZenerDiode(DiscreteApplication):
+class ProtectionZenerDiode(Protection):
   """Zener diode reversed across a power rail to provide transient overvoltage protection (and become an incandescent
   indicator on a reverse voltage)"""
   @init_in_parent

--- a/electronics_abstract_parts/AbstractFuse.py
+++ b/electronics_abstract_parts/AbstractFuse.py
@@ -8,7 +8,7 @@ from .StandardPinningFootprint import StandardPinningFootprint
 
 
 @abstract_block
-class Fuse(DiscreteComponent, DiscreteApplication):
+class Fuse(InternalSubcircuit, Block):
   @init_in_parent
   def __init__(self, trip_current: RangeLike, *, hold_current: RangeLike = Default(RangeExpr.ALL),
                voltage: RangeLike = Default(RangeExpr.EMPTY_ZERO)) -> None:
@@ -107,7 +107,7 @@ class TableFuse(FuseStandardPinning, PartsTableFootprint, GeneratorBlock):
     )
 
 
-class SeriesPowerPptcFuse(DiscreteApplication):
+class SeriesPowerPptcFuse(Protection):
   """Series fuse for power applications"""
   @init_in_parent
   def __init__(self, trip_current: RangeLike) -> None:

--- a/electronics_abstract_parts/AbstractJumper.py
+++ b/electronics_abstract_parts/AbstractJumper.py
@@ -1,9 +1,9 @@
 from electronics_model import *
-from .Categories import Testing, TypedJumper
+from .Categories import InternalSubcircuit, TypedJumper
 
 
 @abstract_block
-class Jumper(Testing, Block):
+class Jumper(InternalSubcircuit, Block):
   """A two-ported passive-typed jumper (a disconnect-able connection), though is treated
   as always connected for model purposes.
 

--- a/electronics_abstract_parts/AbstractOpamp.py
+++ b/electronics_abstract_parts/AbstractOpamp.py
@@ -1,10 +1,11 @@
 from typing import Mapping
 
 from electronics_model import *
+from .Categories import Analog
 
 
 @abstract_block
-class Opamp(KiCadInstantiableBlock, Block):
+class Opamp(Analog, KiCadInstantiableBlock, Block):
   """Base class for opamps. Parameters need to be more restricted in subclasses.
   """
   def symbol_pinning(self, symbol_name: str) -> Mapping[str, BasePort]:

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -166,7 +166,7 @@ class PulldownResistor(DiscreteApplication):
     return self
 
 
-class SeriesPowerResistor(DiscreteApplication):
+class SeriesPowerResistor(InternalSubcircuit, DiscreteApplication):
   """Series resistor for power applications"""
   @init_in_parent
   def __init__(self, resistance: RangeLike) -> None:
@@ -203,7 +203,7 @@ class SeriesPowerResistor(DiscreteApplication):
     return self
 
 
-class CurrentSenseResistor(DiscreteApplication, GeneratorBlock):
+class CurrentSenseResistor(InternalSubcircuit, DiscreteApplication, GeneratorBlock):
   """Current sense resistor with a power passthrough resistor and positive and negative sense temrinals."""
   @init_in_parent
   def __init__(self, resistance: RangeLike, sense_in_reqd: BoolLike = True) -> None:

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -166,7 +166,7 @@ class PulldownResistor(DiscreteApplication):
     return self
 
 
-class SeriesPowerResistor(InternalSubcircuit, DiscreteApplication):
+class SeriesPowerResistor(DiscreteApplication):
   """Series resistor for power applications"""
   @init_in_parent
   def __init__(self, resistance: RangeLike) -> None:
@@ -203,7 +203,7 @@ class SeriesPowerResistor(InternalSubcircuit, DiscreteApplication):
     return self
 
 
-class CurrentSenseResistor(InternalSubcircuit, DiscreteApplication, GeneratorBlock):
+class CurrentSenseResistor(DiscreteApplication, GeneratorBlock):
   """Current sense resistor with a power passthrough resistor and positive and negative sense temrinals."""
   @init_in_parent
   def __init__(self, resistance: RangeLike, sense_in_reqd: BoolLike = True) -> None:

--- a/electronics_abstract_parts/AbstractSwitch.py
+++ b/electronics_abstract_parts/AbstractSwitch.py
@@ -21,7 +21,7 @@ class Switch(KiCadImportableBlock, DiscreteComponent):
     self.voltage = self.ArgParameter(voltage)
 
 
-class DigitalSwitch(DiscreteApplication):
+class DigitalSwitch(HumanInterface):
   def __init__(self) -> None:
     super().__init__()
 

--- a/electronics_abstract_parts/AbstractTestPoint.py
+++ b/electronics_abstract_parts/AbstractTestPoint.py
@@ -7,7 +7,7 @@ from .Categories import *
 
 
 @abstract_block
-class TestPoint(Testing, Block):
+class TestPoint(InternalSubcircuit, Block):
   """Abstract test point that can take a name as a string, used as the footprint value.
   """
   @init_in_parent

--- a/electronics_abstract_parts/Categories.py
+++ b/electronics_abstract_parts/Categories.py
@@ -8,8 +8,14 @@ class DiscreteApplication(Block):
 
 
 @abstract_block
-class TvsDiode(DiscreteApplication):
-  """Any kind of TVS diode, including multiple channel configurations."""
+class Analog(Block):
+  """Analog blocks that don't fit into one of the other categories"""
+  pass
+
+
+@abstract_block
+class OpampApplication(Analog):
+  """Opamp-based circuits, typically one that perform some function on signals"""
   pass
 
 
@@ -120,13 +126,19 @@ class Connector(Block):
 
 
 @abstract_block
-class Optoelectronic(Block):
-  """Optoelectronic components."""
+class PowerSource(Block):
+  """Power sources, including connectors that also supply power."""
   pass
 
 
 @abstract_block
-class Display(Optoelectronic):
+class HumanInterface(Block):
+  """Devices for human interface, eg switches, displays, LEDs"""
+  pass
+
+
+@abstract_block
+class Display(HumanInterface):
   """Pixel displays."""
   pass
 
@@ -150,7 +162,7 @@ class EInk(Display):
 
 
 @abstract_block
-class Light(Optoelectronic):
+class Light(HumanInterface):
   """Discrete lights."""
   pass
 
@@ -184,6 +196,18 @@ class DistanceSensor(Sensor):
 @abstract_block
 class Mechanical(Block):
   """Nonelectrical footprint, including plated and NPTH mounting holes."""
+  pass
+
+
+@abstract_block
+class Protection(Block):
+  """Circuit protection elements, eg TVS diodes, fuses"""
+  pass
+
+
+@abstract_block
+class TvsDiode(Protection):
+  """Any kind of TVS diode, including multiple channel configurations."""
   pass
 
 

--- a/electronics_abstract_parts/I2cPullup.py
+++ b/electronics_abstract_parts/I2cPullup.py
@@ -3,7 +3,7 @@ from .Categories import *
 from .AbstractResistor import PullupResistor
 
 
-class I2cPullup(DiscreteApplication):
+class I2cPullup(Interface, Block):
   def __init__(self) -> None:
     super().__init__()
 

--- a/electronics_abstract_parts/OpampCircuits.py
+++ b/electronics_abstract_parts/OpampCircuits.py
@@ -4,11 +4,11 @@ from typing import List, Tuple, Dict
 from electronics_model import *
 from electronics_abstract_parts import Resistor, Capacitor
 from .AbstractOpamp import Opamp
-from .Categories import AnalogFilter
+from .Categories import AnalogFilter, OpampApplication
 from .ESeriesUtil import ESeriesRatioUtil, ESeriesUtil, ESeriesRatioValue
 
 
-class OpampFollower(AnalogFilter, KiCadSchematicBlock):
+class OpampFollower(OpampApplication, KiCadSchematicBlock):
   """Opamp follower circuit, outputs the same signal as the input (but probably stronger)."""
   def __init__(self):
     super().__init__()
@@ -52,7 +52,7 @@ class AmplifierValues(ESeriesRatioValue):
            self.parallel_impedance.intersects(spec.parallel_impedance)
 
 
-class Amplifier(AnalogFilter, KiCadSchematicBlock, KiCadImportableBlock, GeneratorBlock):
+class Amplifier(OpampApplication, KiCadSchematicBlock, KiCadImportableBlock, GeneratorBlock):
   """Opamp non-inverting amplifier, outputs a scaled-up version of the input signal.
 
   From https://en.wikipedia.org/wiki/Operational_amplifier_applications#Non-inverting_amplifier:
@@ -163,7 +163,7 @@ class DifferentialValues(ESeriesRatioValue):
            self.input_impedance.intersects(spec.input_impedance)
 
 
-class DifferentialAmplifier(AnalogFilter, KiCadSchematicBlock, KiCadImportableBlock, GeneratorBlock):
+class DifferentialAmplifier(OpampApplication, KiCadSchematicBlock, KiCadImportableBlock, GeneratorBlock):
   """Opamp differential amplifier, outputs the difference between the input nodes, scaled by some factor,
   and offset from some reference node.
   This implementation uses the same resistance for the two input resistors (R1, R2),
@@ -289,7 +289,7 @@ class IntegratorValues(ESeriesRatioValue):
            self.capacitance.intersects(spec.capacitance)
 
 
-class IntegratorInverting(AnalogFilter, KiCadSchematicBlock, KiCadImportableBlock, GeneratorBlock):
+class IntegratorInverting(OpampApplication, KiCadSchematicBlock, KiCadImportableBlock, GeneratorBlock):
   """Opamp integrator, outputs the negative integral of the input signal, relative to some reference signal.
   Will clip to the input voltage rails.
 

--- a/electronics_abstract_parts/PassiveFilters.py
+++ b/electronics_abstract_parts/PassiveFilters.py
@@ -107,7 +107,7 @@ class DigitalLowPassRcArray(DigitalFilter, GeneratorBlock):
       self.connect(self.gnd, elt.gnd)
 
 
-class LowPassRcDac(AnalogFilter, Block):
+class LowPassRcDac(DigitalToAnalog, Block):
   """Low-pass RC filter used as a simple DAC by filtering out a PWM signal.
   The cutoff frequency of the filter should be sufficiently beneath the PWM frequency,
   but enough above baseband to not distort the signal.

--- a/electronics_abstract_parts/ResistiveDivider.py
+++ b/electronics_abstract_parts/ResistiveDivider.py
@@ -4,7 +4,7 @@ from math import log10, ceil
 from typing import List, Tuple
 
 from electronics_model import *
-from . import AnalogFilter, Resistor, Filter
+from . import Analog, Resistor, Filter
 from .Categories import InternalSubcircuit, DiscreteApplication
 from .ESeriesUtil import ESeriesUtil, ESeriesRatioUtil, ESeriesRatioValue
 
@@ -112,7 +112,7 @@ class ResistiveDivider(InternalSubcircuit, GeneratorBlock):
 
 
 @non_library
-class BaseVoltageDivider(Filter, Block):
+class BaseVoltageDivider(Block):
   """Base class that defines a resistive divider that takes in a voltage source and ground, and outputs
   an analog constant-voltage signal.
   The actual output voltage is defined as a ratio of the input voltage, and the divider is specified by
@@ -144,7 +144,7 @@ class BaseVoltageDivider(Filter, Block):
     self.actual_series_impedance = self.Parameter(RangeExpr(self.div.actual_series_impedance))
 
 
-class VoltageDivider(DiscreteApplication, BaseVoltageDivider):
+class VoltageDivider(Analog, BaseVoltageDivider):
   """Voltage divider that takes in an output voltage and parallel impedance spec, and produces an output analog signal
   of the appropriate magnitude (as a fraction of the input voltage)"""
   @init_in_parent
@@ -160,7 +160,7 @@ class VoltageDivider(DiscreteApplication, BaseVoltageDivider):
     self.assign(self.ratio, (ratio_lower, ratio_upper))
 
 
-class VoltageSenseDivider(DiscreteApplication, BaseVoltageDivider):
+class VoltageSenseDivider(Analog, BaseVoltageDivider):
   """Voltage divider that takes in an output voltage and parallel impedance spec, and produces an output analog signal
   of the appropriate magnitude (as a fraction of the input voltage).
   Unlike the normal VoltageDivider, the output is defined in terms of full scale voltage - that is, the voltage
@@ -181,7 +181,7 @@ class VoltageSenseDivider(DiscreteApplication, BaseVoltageDivider):
     self.assign(self.ratio, (ratio_lower, ratio_upper))
 
 
-class FeedbackVoltageDivider(DiscreteApplication, BaseVoltageDivider):
+class FeedbackVoltageDivider(Analog, BaseVoltageDivider):
   """Voltage divider that takes in a ratio and parallel impedance spec, and produces an output analog signal
   of the appropriate magnitude (as a fraction of the input voltage)"""
   @init_in_parent
@@ -209,7 +209,7 @@ class FeedbackVoltageDivider(DiscreteApplication, BaseVoltageDivider):
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.impedance, "Ω"))
 
 
-class SignalDivider(AnalogFilter, Block):
+class SignalDivider(Analog, Block):
   """Specialization of ResistiveDivider for Analog signals"""
   @init_in_parent
   def __init__(self, ratio: RangeLike, impedance: RangeLike) -> None:

--- a/electronics_abstract_parts/UsbBitBang.py
+++ b/electronics_abstract_parts/UsbBitBang.py
@@ -5,7 +5,7 @@ from .Categories import *
 from .AbstractResistor import Resistor
 
 
-class UsbBitBang(DiscreteApplication):
+class UsbBitBang(Interface, Block):
   """Bit-bang circuit for USB, from the UPduino3.0 circuit and for 3.3v.
   Presumably generalizes to any digital pin that can be driven fast enough.
 

--- a/electronics_abstract_parts/UsbConnectors.py
+++ b/electronics_abstract_parts/UsbConnectors.py
@@ -1,5 +1,5 @@
 from electronics_model import *
-from .Categories import Connector, TvsDiode
+from .Categories import Connector, TvsDiode, PowerSource
 
 
 @abstract_block
@@ -22,7 +22,7 @@ class UsbHostConnector(UsbConnector):
 
 
 @abstract_block
-class UsbDeviceConnector(UsbConnector):
+class UsbDeviceConnector(UsbConnector, PowerSource):
   """Abstract base class for a USB 2.0 device-side port connector"""
   def __init__(self) -> None:
     super().__init__()

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -7,12 +7,13 @@ from .PartsTablePart import PartsTablePart, PartsTableFootprint
 from .Categories import DummyDevice
 from .Categories import DiscreteComponent, DiscreteSemiconductor, PassiveComponent
 from .Categories import DiscreteApplication, TvsDiode
+from .Categories import Analog, OpampApplication
 from .Categories import Filter, AnalogFilter, DigitalFilter
 from .Categories import Microcontroller, Fpga, Memory, RealtimeClock, Radiofrequency
 from .Categories import Interface, AnalogToDigital, DigitalToAnalog
 from .Categories import PowerConditioner, PowerSwitch, MotorDriver, BrushedMotorDriver, BldcDriver
-from .Categories import Connector, ProgrammingConnector
-from .Categories import Optoelectronic, Display, Lcd, Oled, EInk, Light
+from .Categories import PowerSource, Connector, ProgrammingConnector
+from .Categories import HumanInterface, Display, Lcd, Oled, EInk, Light
 from .Categories import Sensor, Accelerometer, Gyroscope, Magnetometer, DistanceSensor
 from .Categories import Label, Testing, TypedJumper, TypedTestPoint, InternalSubcircuit, Mechanical
 

--- a/electronics_lib/PassiveConnector.py
+++ b/electronics_lib/PassiveConnector.py
@@ -4,7 +4,7 @@ from .JlcPart import JlcPart
 
 
 @abstract_block
-class PassiveConnector(Connector, GeneratorBlock, FootprintBlock):
+class PassiveConnector(InternalSubcircuit, GeneratorBlock, FootprintBlock):
   """A base Block that is an elastic n-ported connector with passive type.
   Intended as an infrastructural block where a particular connector series is not fixed,
   but can be selected through the refinements system.

--- a/electronics_lib/PowerConnectors.py
+++ b/electronics_lib/PowerConnectors.py
@@ -2,7 +2,7 @@ from electronics_abstract_parts import *
 
 
 @abstract_block
-class PowerBarrelJack(Connector, Block):
+class PowerBarrelJack(Connector, PowerSource, Block):
   """Barrel jack that models a configurable voltage / max current power supply."""
   @init_in_parent
   def __init__(self,

--- a/electronics_lib/Speakers.py
+++ b/electronics_lib/Speakers.py
@@ -194,7 +194,7 @@ class Tpa2005d1(Interface, GeneratorBlock):
 
 
 @abstract_block
-class Speaker(DiscreteApplication):
+class Speaker(HumanInterface):
   """Abstract speaker part with speaker input port."""
   def __init__(self):
     super().__init__()

--- a/electronics_model/ConnectedGenerator.py
+++ b/electronics_model/ConnectedGenerator.py
@@ -5,18 +5,24 @@ from .VoltagePorts import VoltageLink, VoltageSink, VoltageSource
 from .DigitalPorts import DigitalLink, DigitalSink, DigitalSource
 
 
-OutputType = TypeVar('OutputType', bound=Port)
-InputsType = TypeVar('InputsType', bound=Port)
-LinkType = TypeVar('LinkType', bound=Link)
-SelfType = TypeVar('SelfType', bound='BaseConnectedGenerator')
-@non_library  # this can't be instantiated
-class BaseConnectedGenerator(GeneratorBlock, Generic[OutputType, InputsType, LinkType]):
-  """A template for a utility block that takes in an input port that may be connected
+@abstract_block  # really this is just a category
+class DefaultConnectionBlock(InternalBlock):
+  """A utility block that takes in an input port that may be connected
   and an output port that is required, and if the input is not present, connects the
   output to a default port.
   If the input is present, the default port presents an 'ideal' port. - TODO can this be a true disconnect?
   If the input is not present, the default port is connected to the output.
   """
+  pass
+
+
+OutputType = TypeVar('OutputType', bound=Port)
+InputsType = TypeVar('InputsType', bound=Port)
+LinkType = TypeVar('LinkType', bound=Link)
+SelfType = TypeVar('SelfType', bound='BaseConnectedGenerator')
+@non_library  # this can't be instantiated
+class BaseConnectedGenerator(DefaultConnectionBlock, GeneratorBlock, Generic[OutputType, InputsType, LinkType]):
+  """The template actually lives here"""
   INPUTS_TYPE: Type[Port]
   OUTPUT_TYPE: Type[Port]
 
@@ -52,11 +58,11 @@ class BaseConnectedGenerator(GeneratorBlock, Generic[OutputType, InputsType, Lin
     return self
 
 
-class VoltageSourceConnected(InternalBlock, BaseConnectedGenerator[VoltageSource, VoltageSink, VoltageLink]):
+class VoltageSourceConnected(BaseConnectedGenerator[VoltageSource, VoltageSink, VoltageLink]):
   OUTPUT_TYPE = VoltageSource
   INPUTS_TYPE = VoltageSink
 
 
-class DigitalSourceConnected(InternalBlock, BaseConnectedGenerator[DigitalSource, DigitalSink, DigitalLink]):
+class DigitalSourceConnected(BaseConnectedGenerator[DigitalSource, DigitalSink, DigitalLink]):
   OUTPUT_TYPE = DigitalSource
   INPUTS_TYPE = DigitalSink


### PR DESCRIPTION
Adds a few more categories, focusing on what a system designer might look for in terms of categories instead of implementation details. In particular moves a lot of DiscreteApplication into functional categories (eg, protection, analog).

Also don't index DesignTop, since it both clutters the library panel and causes an IDE check to fail.