### PR TITLE
Class-value partial compilation

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -288,7 +288,13 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
   // Called for each param declaration, currently just registers the declaration and type signature.
   protected def processParamDeclarations(path: DesignPath, hasParams: wir.HasParams): Unit = {
     for ((paramName, param) <- hasParams.getParams) {
-      elaboratePending.addNode(ElaborateRecord.Parameter(path + paramName, param), Seq())
+      val paramPath = path + paramName
+      if (!partial.params.contains(paramPath)) {
+        // uniformly using ElaborateRecord craters performance, so this fast path is added here
+        constProp.addDeclaration(paramPath, param)
+      } else {
+        elaboratePending.addNode(ElaborateRecord.Parameter(paramPath, param), Seq())
+      }
     }
   }
 

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -302,14 +302,12 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
     // this is done here to delay it as much as possible, since class-based refinement can be added later
     // note that this operates on the post-refinement class
     blockClass.foreach { blockClass =>
-      refinements.classValues.foreach { case (refinementClass, refinements) =>
-        if (library.isSubclassOf(blockClass, refinementClass)) {
-          refinements.collect { case (refinementPostfix, value) if refinementPostfix == postfix =>
-            val paramPath = root ++ postfix
-            if (!refinementInstanceValuePaths.contains(paramPath)) { // instance values supersede class values
-              constProp.setForcedValue(paramPath, value,
-                s"${refinementClass.toSimpleString} class refinement")
-            }
+      refinements.classValues.foreach { case ((refinementClass, refinementPostfix), value) =>
+        if (library.isSubclassOf(blockClass, refinementClass) && refinementPostfix == postfix) {
+          val paramPath = root ++ postfix
+          if (!refinementInstanceValuePaths.contains(paramPath)) { // instance values supersede class values
+            constProp.setForcedValue(paramPath, value,
+              s"${refinementClass.toSimpleString} class refinement")
           }
         }
       }

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -113,7 +113,7 @@ class AssignNamer() {
   * This expansion triggers when the link-side port is fully elaborated, as its parameters are used.
   * CONNECTED_LINK is a symlink that is resolved by ConstProp.
   */
-class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
+class Compiler private (inputDesignPb: schema.Design, val library: edg.wir.Library,
                         val refinements: Refinements, val partial: PartialCompile,
                         initialize: Boolean) {
   // public constructor that does not expose init, which is internal only
@@ -162,7 +162,7 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
                                   classValuesByClass: Map[ref.LibraryPath, Map[(ref.LibraryPath, ref.LocalPath), ExprValue]],
                                  ): Seq[((ref.LibraryPath, ref.LocalPath), ExprValue)] = {
     classValuesByClass.collect {
-      case (refinementClass, refinementClassValues) if library.isSubclassOf(blockClass, refinementClass) =>
+      case (refinementClass, refinementClassValues) if library.blockIsSubclassOf(blockClass, refinementClass) =>
         refinementClassValues
     }.flatten.toSeq
   }
@@ -320,7 +320,7 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
     blockClass match {
       case Some(blockClass) =>
         partial.classParams.exists { case (partialClass, partialPostfix) =>
-          library.isSubclassOf(blockClass, partialClass) && partialPostfix == postfix
+          library.blockIsSubclassOf(blockClass, partialClass) && partialPostfix == postfix
         }
       case None => false
     }
@@ -483,7 +483,7 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
 
     // additional processing needed for the refinement case
     if (unrefinedType.isDefined) {
-      if (!library.isSubclassOf(refinedLibraryPath, libraryPath)) {  // check refinement validity
+      if (!library.blockIsSubclassOf(refinedLibraryPath, libraryPath)) {  // check refinement validity
         errors += CompilerError.RefinementSubclassError(path, refinedLibraryPath, libraryPath)
       }
 

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -195,10 +195,6 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
     errors.toSeq ++ constProp.getErrors ++ pendingErrors
   }
 
-  // Hook method to be overridden, eg for status
-  //
-  def onElaborate(record: ElaborateRecord): Unit = { }
-
   // Actual compilation methods
   //
 
@@ -1275,7 +1271,6 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
     do  {
       readyList = elaboratePending.getReady -- partialCompileIgnoredRecords
       readyList.foreach { elaborateRecord =>
-        onElaborate(elaborateRecord)
         try {
           elaborateRecord match {
             case elaborateRecord@ElaborateRecord.ExpandBlock(blockPath) =>

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -84,10 +84,11 @@ case class PartialCompile(
   classParams: Seq[(ref.LibraryPath, ref.LocalPath)] = Seq()  // do not propagate values into params of these classes
 ) {
   def ++(that: PartialCompile): PartialCompile = {  // concatenates two partial compilation rules
-    PartialCompile(blocks ++ that.blocks, params ++ that.params)
+    PartialCompile(blocks ++ that.blocks, params ++ that.params,
+      classes ++ that.classes, classParams ++ that.classParams)
   }
 
-  def isEmpty = blocks.isEmpty && params.isEmpty
+  def isEmpty = blocks.isEmpty && params.isEmpty && classes.isEmpty && classParams.isEmpty
 }
 
 
@@ -283,8 +284,7 @@ class Compiler private (inputDesignPb: schema.Design, library: edg.wir.Library,
   }
 
   protected def paramMatchesPartial(root: DesignPath, rootClass: Option[ref.LibraryPath], postfix: ref.LocalPath): Boolean = {
-    val paramPath = root ++ postfix
-    if (partial.params.contains(paramPath)) {
+    if (partial.params.contains(root ++ postfix)) {
       return true
     }
     rootClass match {

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -193,6 +193,7 @@ class ConstProp() {
     forcedParams.get(target) match { // check for overassign based on forced status
       case Some(expr) if expr == (constrName, targetExpr) => // this is the forced param
         require(!params.valueDefinedAt(target), s"forced value must be set before value is resolved, prior ${paramSource(target)}")
+        params.addNode(target, Seq(), overwrite = true) // forced can overwrite other records
       case Some(expr) =>
         return // ignore forced params - discard the new assign
       case None => // non-forced, check for and record over-assigns
@@ -201,8 +202,8 @@ class ConstProp() {
           record.assigns.add(paramSourceRecord)
           return // first set "wins"
         }
+        params.addNode(target, Seq())
     }
-    params.addNode(target, Seq()) // first add is not update=True, actual processing happens in update()
 
     val assign = AssignRecord(target, root, targetExpr)
     paramAssign.put(target, assign)

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -139,7 +139,7 @@ class ConstProp(frozenParams: Set[IndirectDesignPath] = Set()) {
                 case ConnectedLinkResult.MissingConnectedLink(portPath) => portPath.asIndirect + IndirectStep.ConnectedLink
               }
             }
-            params.addNode(constrTarget, missingCorrected.toSeq, update = true)
+            params.addNode(constrTarget, missingCorrected.toSeq, overwrite = true)
         }
       }
     } while (readyList.nonEmpty)
@@ -200,7 +200,7 @@ class ConstProp(frozenParams: Set[IndirectDesignPath] = Set()) {
     forcedParams.get(target) match {  // check for overassign based on forced status
       case Some(expr) if expr == (constrName, targetExpr) =>  // this is the forced param
         require(!params.valueDefinedAt(target), s"forced value must be set before value is resolved, prior ${paramSource(target)}")
-        params.addNode(target, Seq(), update=true)  // allow updating and overwriting prior param record
+        params.addNode(target, Seq(), overwrite=true)  // allow updating and overwriting prior param record
       case Some(expr) =>
         return  // ignore forced params - discard the new assign
       case None =>  // non-forced, check for and record over-assigns

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -237,6 +237,7 @@ class ConstProp() {
   def setForcedValue(target: DesignPath, value: ExprValue, constrName: String): Unit = {
     val targetIndirect = target.asIndirect
     val expr = ExprBuilder.ValueExpr.Literal(value.toLit)
+    require(!paramTypes.contains(targetIndirect), "must set forced value before param declaration processed")
     forcedParams.put(targetIndirect, (constrName, expr))
     addAssignExpr(targetIndirect, expr, DesignPath(), constrName)
   }

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -201,7 +201,8 @@ class ConstProp(frozenParams: Set[IndirectDesignPath] = Set()) {
       case Some(expr) if expr == (constrName, targetExpr) =>  // this is the forced param
         require(!params.valueDefinedAt(target), s"forced value must be set before value is resolved, prior ${paramSource(target)}")
         params.addNode(target, Seq(), update=true)  // allow updating and overwriting prior param record
-      case Some(expr) => return  // ignore forced params - discard the new assign
+      case Some(expr) =>
+        return  // ignore forced params - discard the new assign
       case None =>  // non-forced, check for and record over-assigns
         if (params.nodeDefinedAt(target)) {
           val record = discardOverassigns.getOrElseUpdate(target, OverassignRecord())

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -50,7 +50,9 @@ class ConstProp() {
   // This is the authoritative source for the state of any param - in the graph (and its dependencies), or value solved
   // CONNECTED_LINK has an empty value but indicates that the path was resolved in that data structure
   private val params = DependencyGraph[IndirectDesignPath, ExprValue]()
-  private val paramTypes = mutable.HashMap[IndirectDesignPath, Class[_ <: ExprValue]]()  // only record types of authoritative elements
+  // Parameter types are used to track declared parameters
+  // Undeclared parameters cannot have values set, but can be forced (though the value is not effective until declared)
+  private val paramTypes = mutable.HashMap[IndirectDesignPath, Class[_ <: ExprValue]]()
 
   private val connectedLink = DependencyGraph[ConnectedLinkRecord, DesignPath]()  // tracks the port -> link paths
 
@@ -73,7 +75,6 @@ class ConstProp() {
     connectedLink.initFrom(that.connectedLink)
     forcedParams.addAll(that.forcedParams)
     discardOverassigns.addAll(that.discardOverassigns)
-    update() // for when frozenParams changes
   }
 
   //

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -237,7 +237,8 @@ class ConstProp() {
   def setForcedValue(target: DesignPath, value: ExprValue, constrName: String): Unit = {
     val targetIndirect = target.asIndirect
     val expr = ExprBuilder.ValueExpr.Literal(value.toLit)
-    require(!paramTypes.contains(targetIndirect), "must set forced value before param declaration processed")
+    require(!paramTypes.contains(targetIndirect),
+      f"must set forced value before param declaration processed at $target <= ${value.toStringValue}")
     forcedParams.put(targetIndirect, (constrName, expr))
     addAssignExpr(targetIndirect, expr, DesignPath(), constrName)
   }

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -369,7 +369,7 @@ class PythonInterfaceLibrary() extends Library {
   override def getBlock(path: ref.LibraryPath): Errorable[elem.HierarchyBlock] = {
     getLibraryPartialMapped(path, "block") {
       case schema.Library.NS.Val.Type.HierarchyBlock(member) =>
-        require(!eltsRefinements.isDefinedAt(path))  // non-design-top blocks should not have refinements
+        require(!eltsRefinements.isDefinedAt(path), s"non-design-top ${path.toSimpleString} may not have refinements")
         member
     }
   }

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -366,10 +366,11 @@ class PythonInterfaceLibrary() extends Library {
     case (path, schema.Library.NS.Val.Type.Link(link)) => (path, link)
   }.toMap
 
-  override def getBlock(path: ref.LibraryPath): Errorable[elem.HierarchyBlock] = {
+  override protected def getBlock(path: ref.LibraryPath, ignoreRefinements: Boolean): Errorable[elem.HierarchyBlock] = {
     getLibraryPartialMapped(path, "block") {
       case schema.Library.NS.Val.Type.HierarchyBlock(member) =>
-        require(!eltsRefinements.isDefinedAt(path), s"non-design-top ${path.toSimpleString} may not have refinements")
+        require(ignoreRefinements || !eltsRefinements.isDefinedAt(path),
+          s"non-design-top ${path.toSimpleString} may not have refinements")
         member
     }
   }

--- a/compiler/src/main/scala/edg/util/DependencyGraph.scala
+++ b/compiler/src/main/scala/edg/util/DependencyGraph.scala
@@ -28,10 +28,10 @@ class DependencyGraph[KeyType, ValueType] {
   }
 
   // Adds a node in the graph. May only be called once per node.
-  def addNode(node: KeyType, dependencies: Seq[KeyType], update: Boolean = false): Unit = {
+  def addNode(node: KeyType, dependencies: Seq[KeyType], overwrite: Boolean = false): Unit = {
     deps.get(node) match {
       case Some(prevDeps) =>
-        require(update, s"reinsertion of dependency for node $node <- $dependencies without update=true")
+        require(overwrite, s"reinsertion of dependency for node $node <- $dependencies without overwrite=true")
         // TODO can this requirement be eliminated?
         require(prevDeps.subsetOf(dependencies.toSet), "update of dependencies without being a superset of prior")
       case None =>  // nothing if no previous dependencies
@@ -44,7 +44,7 @@ class DependencyGraph[KeyType, ValueType] {
       inverseDeps.getOrElseUpdate(dependency, mutable.Set()) += node
     }
 
-    if (update && ready.contains(node)) {
+    if (overwrite && ready.contains(node)) {
       ready -= node
     }
     if (remainingDeps.isEmpty && !values.isDefinedAt(node)) {

--- a/compiler/src/main/scala/edg/wir/BlockLike.scala
+++ b/compiler/src/main/scala/edg/wir/BlockLike.scala
@@ -22,7 +22,7 @@ sealed trait BlockLike extends Pathable {
   * BlockLike / LinkLike lib_elem are kept in the proto, unmodified.
   * This is to allow efficient transformation at any point in the design tree without re-writing the root.
   */
-class Block(pb: elem.HierarchyBlock, unrefinedType: Option[ref.LibraryPath]) extends BlockLike
+class Block(pb: elem.HierarchyBlock, val unrefinedType: Option[ref.LibraryPath]) extends BlockLike
     with HasMutablePorts with HasMutableBlocks with HasMutableLinks with HasMutableConstraints with HasParams {
   override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
   override protected val blocks: mutable.SeqMap[String, BlockLike] = parseBlocks(pb.blocks)

--- a/compiler/src/main/scala/edg/wir/DesignPath.scala
+++ b/compiler/src/main/scala/edg/wir/DesignPath.scala
@@ -197,13 +197,6 @@ object DesignPath {
     }
   }
 
-  def fromIndirect(indirect: IndirectDesignPath): DesignPath = {
-    DesignPath(indirect.steps.map {
-      case IndirectStep.Element(name) => name
-      case step => throw new IndirectPathException(s"Found non-direct $step when converting indirect $indirect")
-    })
-  }
-
   def apply(): DesignPath = DesignPath(Seq())
 
   def unapply(path: DesignPath): Option[Seq[String]] = Some(path.steps)

--- a/compiler/src/main/scala/edg/wir/Refinements.scala
+++ b/compiler/src/main/scala/edg/wir/Refinements.scala
@@ -9,20 +9,15 @@ import edg.util.MapUtils
 case class Refinements(
   classRefinements: Map[ref.LibraryPath, ref.LibraryPath] = Map(),
   instanceRefinements: Map[DesignPath, ref.LibraryPath] = Map(),
-  classValues: Map[ref.LibraryPath, Map[ref.LocalPath, ExprValue]] = Map(),  // class -> (internal path -> value)
+  classValues: Map[(ref.LibraryPath, ref.LocalPath), ExprValue] = Map(),  // (class, internal path -> value)
   instanceValues: Map[DesignPath, ExprValue] = Map()
 ) {
   // Append another set of refinements on top of this one, erroring out in case of a conflict
   def ++(that: Refinements): Refinements = {
-    val combinedClassValues = (classValues.toSeq ++ that.classValues.toSeq)  // this one is merge-able one level down
-        .groupBy(_._1)
-        .map { case (className, classPathValues) =>
-      className -> MapUtils.mergeMapSafe(classPathValues.map(_._2):_*)
-    }
     Refinements(
       classRefinements = MapUtils.mergeMapSafe(classRefinements, that.classRefinements),
       instanceRefinements = MapUtils.mergeMapSafe(instanceRefinements, that.instanceRefinements),
-      classValues = combinedClassValues,
+      classValues = MapUtils.mergeMapSafe(classValues, that.classValues),
       instanceValues = MapUtils.mergeMapSafe(instanceValues, that.instanceValues),
     )
   }
@@ -32,15 +27,10 @@ case class Refinements(
                   classParams: Set[(ref.LibraryPath, ref.LocalPath)]): (Refinements, Refinements) = {
     val (containsBlocks, otherBlocks) = instanceRefinements.partition { case (path, _) => blocks.contains(path) }
     val (containsParams, otherParams) = instanceValues.partition { case (path, _) => params.contains(path) }
-    val (containsClassParams, otherClassParams) = classValues.map { case (refinementClass, pathValues) =>
-      val (containsPathValues, otherPathValues) = pathValues.partition { case (path, _) =>
-        classParams.contains((refinementClass, path))
-      }
-      (refinementClass -> containsPathValues, refinementClass -> otherPathValues)
-    }.unzip
-    val containsRefinement = Refinements(Map(), containsBlocks, containsClassParams.toMap, containsParams)
+    val (containsClassParams, otherClassParams) = classValues.partition { case (classPath, _) => classParams.contains(classPath) }
+    val containsRefinement = Refinements(Map(), containsBlocks, containsClassParams, containsParams)
     val otherRefinement = Refinements(
-      classRefinements, otherBlocks, otherClassParams.toMap, otherParams
+      classRefinements, otherBlocks, otherClassParams, otherParams
     )
 
     (containsRefinement, otherRefinement)
@@ -63,14 +53,12 @@ case class Refinements(
             replacement = Some(target))
         },
       values =
-        classValues.flatMap { case (source, subpathValue) =>
-          subpathValue.map { case (subpath, value) =>
-            hdl.Refinements.Value(
-              source = hdl.Refinements.Value.Source.ClsParam(
-                hdl.Refinements.Value.ClassParamPath(cls = Some(source), paramPath = Some(subpath))
-              ),
-              value = Some(value.toLit))
-          }
+        classValues.map { case ((source, subpath), value) =>
+          hdl.Refinements.Value(
+            source = hdl.Refinements.Value.Source.ClsParam(
+              hdl.Refinements.Value.ClassParamPath(cls = Some(source), paramPath = Some(subpath))
+            ),
+            value = Some(value.toLit))
         }.toSeq ++ instanceValues.map { case (path, value) =>
           hdl.Refinements.Value(
             source = hdl.Refinements.Value.Source.Path(path.asIndirect.toLocalPath),
@@ -93,8 +81,8 @@ object Refinements {
     } }.toMap
     val classValues = pb.values.collect { value => value.source match {
       case hdl.Refinements.Value.Source.ClsParam(clsParam) =>
-        clsParam.getCls -> (clsParam.getParamPath -> ExprEvaluate.evalLiteral(value.getValue))
-    } }.groupBy(_._1).view.mapValues(_.map(_._2).toMap).toMap
+        (clsParam.getCls, clsParam.getParamPath) -> ExprEvaluate.evalLiteral(value.getValue)
+    } }.toMap
 
     val instanceValues = pb.values.collect { value => value.source match {
       case hdl.Refinements.Value.Source.Path(path) =>

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialBlockTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialBlockTest.scala
@@ -11,9 +11,9 @@ import org.scalatest.matchers.should.Matchers._
 import scala.collection.SeqMap
 
 
-/** Tests partial compilation and fork-from-partial compilation.
+/** Tests partial compilation and fork-from-partial compilation for frozen blocks.
   */
-class CompilerPartialTest extends AnyFlatSpec with CompilerTestUtil {
+class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
   val inputDesign = Design(Block.Block("topDesign",
     blocks = SeqMap(
       "source" -> Block.Library("sourceContainerBlock"),

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
@@ -26,17 +26,14 @@ class CompilerPartialParamTest extends AnyFlatSpec with CompilerTestUtil {
     compiler.compile()
     compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
   }
-//
-//  "Compiler on class-based partial design specification" should "not compile those blocks" in {
-//    val compiler = new Compiler(inputDesign, new EdgirLibrary(CompilerExpansionTest.library),
-//      partial = PartialCompile(classes = Seq(ElemBuilder.LibraryPath("sourceBlock"))))
-//    val compiled = compiler.compile()
-//    compiled should equal(referencePartialElaborated)
-//    compiler.getErrors() should contain(
-//      CompilerError.Unelaborated(ElaborateRecord.ExpandBlock(
-//        DesignPath() + "source" + "inner", ElemBuilder.LibraryPath("sourceBlock")), Set()))
-//  }
-//
+
+  "Compiler on class-based partial design specification" should "not hold back that parameter" in {
+    val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
+      partial = PartialCompile(classParams = Seq((ElemBuilder.LibraryPath("topDesign"), Ref("param")))))
+    compiler.compile()
+    compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
+  }
+
   "Compiler on partial design specification" should "fork independently" in {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
       partial = PartialCompile(params = Seq(DesignPath() + "param")))

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
@@ -4,6 +4,7 @@ import edg.ElemBuilder._
 import edg.ExprBuilder.{Ref, ValInit}
 import edg.wir.{DesignPath, EdgirLibrary, IndirectDesignPath, Refinements}
 import edg.{CompilerTestUtil, ElemBuilder, ExprBuilder}
+import edgir.elem.elem
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -20,15 +21,33 @@ class CompilerPartialParamTest extends AnyFlatSpec with CompilerTestUtil {
     )
   ))
 
-  "Compiler on path-based partial design specification" should "not hold back that parameter" in {
+  val inputDesignSubclass = Design(Block.Block("subTopDesign", superclasses=Seq("topDesign"),
+    params = SeqMap("param" -> ValInit.Integer),
+    constraints = SeqMap(
+      "assign" -> Constraint.Assign(Ref("param"), ExprBuilder.ValueExpr.Literal(1)),
+    )
+  ))
+
+  "Compiler on path-based partial design specification" should "not evaluate that parameter" in {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
       partial=PartialCompile(params=Seq(DesignPath() + "param")))
     compiler.compile()
     compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
   }
 
-  "Compiler on class-based partial design specification" should "not hold back that parameter" in {
+  "Compiler on class-based partial design specification" should "not evaluate that parameter" in {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
+      partial = PartialCompile(classParams = Seq((ElemBuilder.LibraryPath("topDesign"), Ref("param")))))
+    compiler.compile()
+    compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
+  }
+
+  "Compiler on subclass-based partial design specification" should "not evaluate that parameter" in {
+    val compiler = new Compiler(inputDesignSubclass, new EdgirLibrary(Library(
+      blocks = Seq(  // needed for subclass to resolve
+        elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(inputDesign.getContents)),
+        elem.BlockLike(`type`=elem.BlockLike.Type.Hierarchy(inputDesignSubclass.getContents))
+      ))),
       partial = PartialCompile(classParams = Seq((ElemBuilder.LibraryPath("topDesign"), Ref("param")))))
     compiler.compile()
     compiler.getValue(IndirectDesignPath() + "param") shouldEqual None

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
@@ -1,0 +1,58 @@
+package edg.compiler
+
+import edg.ElemBuilder._
+import edg.ExprBuilder.{Ref, ValInit}
+import edg.wir.{DesignPath, EdgirLibrary, IndirectDesignPath, Refinements}
+import edg.{CompilerTestUtil, ElemBuilder, ExprBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+import scala.collection.SeqMap
+
+
+/** Tests partial compilation and fork-from-partial compilation for frozen parameters.
+  */
+class CompilerPartialParamTest extends AnyFlatSpec with CompilerTestUtil {
+  val inputDesign = Design(Block.Block("topDesign",
+    params = SeqMap("param" -> ValInit.Integer),
+    constraints = SeqMap(
+      "assign" -> Constraint.Assign(Ref("param"), ExprBuilder.ValueExpr.Literal(1)),
+    )
+  ))
+
+  "Compiler on path-based partial design specification" should "not hold back that parameter" in {
+    val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
+      partial=PartialCompile(params=Seq(DesignPath() + "param")))
+    compiler.compile()
+    compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
+  }
+//
+//  "Compiler on class-based partial design specification" should "not compile those blocks" in {
+//    val compiler = new Compiler(inputDesign, new EdgirLibrary(CompilerExpansionTest.library),
+//      partial = PartialCompile(classes = Seq(ElemBuilder.LibraryPath("sourceBlock"))))
+//    val compiled = compiler.compile()
+//    compiled should equal(referencePartialElaborated)
+//    compiler.getErrors() should contain(
+//      CompilerError.Unelaborated(ElaborateRecord.ExpandBlock(
+//        DesignPath() + "source" + "inner", ElemBuilder.LibraryPath("sourceBlock")), Set()))
+//  }
+//
+  "Compiler on partial design specification" should "fork independently" in {
+    val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
+      partial = PartialCompile(params = Seq(DesignPath() + "param")))
+    compiler.compile()
+
+    val forkedCompiler = compiler.fork(Refinements(), PartialCompile())
+    forkedCompiler.compile()
+    forkedCompiler.getValue(IndirectDesignPath() + "param") shouldEqual Some(IntValue(1))
+
+    // check original was not changed
+    compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
+
+    // check that we can fork multiple times
+    val forkedCompiler2 = compiler.fork(Refinements(), PartialCompile())
+    forkedCompiler2.compile()
+
+    forkedCompiler.getValue(IndirectDesignPath() + "param") shouldEqual Some(IntValue(1))
+  }
+}

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
@@ -60,7 +60,7 @@ class CompilerPartialParamTest extends AnyFlatSpec with CompilerTestUtil {
     compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
 
     val forkedCompiler = compiler.fork(Refinements(
-      classValues=Map(ElemBuilder.LibraryPath("topDesign") -> Map(Ref("param") -> IntValue(2)))
+      classValues=Map((ElemBuilder.LibraryPath("topDesign"), Ref("param")) -> IntValue(2))
     ), PartialCompile())
     forkedCompiler.compile()
     forkedCompiler.getValue(IndirectDesignPath() + "param") shouldEqual Some(IntValue(2))

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialParamTest.scala
@@ -53,6 +53,19 @@ class CompilerPartialParamTest extends AnyFlatSpec with CompilerTestUtil {
     compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
   }
 
+  "Compiler on class-based partial design specification and refinement" should "evaluate to the refinement" in {
+    val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
+      partial = PartialCompile(classParams = Seq((ElemBuilder.LibraryPath("topDesign"), Ref("param")))))
+    compiler.compile()
+    compiler.getValue(IndirectDesignPath() + "param") shouldEqual None
+
+    val forkedCompiler = compiler.fork(Refinements(
+      classValues=Map(ElemBuilder.LibraryPath("topDesign") -> Map(Ref("param") -> IntValue(2)))
+    ), PartialCompile())
+    forkedCompiler.compile()
+    forkedCompiler.getValue(IndirectDesignPath() + "param") shouldEqual Some(IntValue(2))
+  }
+
   "Compiler on partial design specification" should "fork independently" in {
     val compiler = new Compiler(inputDesign, new EdgirLibrary(Library()),
       partial = PartialCompile(params = Seq(DesignPath() + "param")))

--- a/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
@@ -146,10 +146,8 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
       )
     ))
     val (compiler, compiled) = testCompile(inputDesign, library, refinements=Refinements(
-      classValues = Map(LibraryPath("superclassBlock") -> Map(
-        Ref("superParam") -> IntValue(5)),
-      )),
-      expectedDesign=Some(expected))
+      classValues = Map((LibraryPath("superclassBlock"), Ref("superParam")) -> IntValue(5))),
+      expectedDesign = Some(expected))
     compiler.getValue(IndirectDesignPath() + "block" + "superParam") should equal(Some(IntValue(5)))
   }
 
@@ -161,7 +159,7 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
 
   "Compiler on design with path values" should "supersede class values" in {
     val (compiler, compiled) = testCompile(inputDesign, library, refinements = Refinements(
-      classValues = Map(LibraryPath("superclassBlock") -> Map(Ref("superParam") -> IntValue(0))),
+      classValues = Map((LibraryPath("superclassBlock"), Ref("superParam")) -> IntValue(0)),
       instanceValues = Map(DesignPath() + "block" + "superParam" -> IntValue(3))))
     compiler.getValue(IndirectDesignPath() + "block" + "superParam") should equal(Some(IntValue(3)))
   }

--- a/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
@@ -136,11 +136,10 @@ class ConstPropAssignTest extends AnyFlatSpec {
     constProp1.getValue(IndirectDesignPath() + "b") should equal(Some(IntValue(5)))
   }
 
-  it should "freeze parameters properly and unfreeze on clone" in {
+  it should "freeze parameters without declaration and unfreeze when declared" in {
     import edgir.expr.expr.BinaryExpr.Op
 
-    val constProp1 = new ConstProp(Set(IndirectDesignPath() + "a"))
-    constProp1.addDeclaration(DesignPath() + "a", ValInit.Integer)
+    val constProp1 = new ConstProp()
     constProp1.addDeclaration(DesignPath() + "b", ValInit.Integer)
     constProp1.addAssignValue(IndirectDesignPath() + "a", IntValue(2))
     constProp1.addAssignExpr(IndirectDesignPath() + "b",
@@ -151,22 +150,21 @@ class ConstPropAssignTest extends AnyFlatSpec {
 
     val constProp2 = new ConstProp()
     constProp2.initFrom(constProp1)
+    constProp2.addDeclaration(DesignPath() + "a", ValInit.Integer)
     constProp2.getValue(IndirectDesignPath() + "a") should equal(Some(IntValue(2)))
     constProp2.getValue(IndirectDesignPath() + "b") should equal(Some(IntValue(5)))  // check second assign triggers
     constProp1.getValue(IndirectDesignPath() + "a") should equal(None)  // should not have changed
     constProp1.getValue(IndirectDesignPath() + "b") should equal(None)  // should not have changed
   }
 
-  it should "allow forcing frozen params" in {
-    val constProp1 = new ConstProp(Set(IndirectDesignPath() + "a"))
-    constProp1.addDeclaration(DesignPath() + "a", ValInit.Integer)
+  it should "allow forcing params before declaration" in {
+    val constProp1 = new ConstProp()
     constProp1.addAssignValue(IndirectDesignPath() + "a", IntValue(2))
     constProp1.getValue(IndirectDesignPath() + "a") should equal(None)
 
     val constProp2 = new ConstProp()
-    constProp2.initFrom(constProp1, Map(
-      DesignPath() + "a" -> (IntValue(3), "forced")
-    ))
+    constProp2.setForcedValue(DesignPath() + "a", IntValue(3), "forced")
+    constProp2.addDeclaration(DesignPath() + "a", ValInit.Integer)
     constProp2.getValue(IndirectDesignPath() + "a") should equal(Some(IntValue(3)))
   }
 }

--- a/compiler/src/test/scala/edg/util/DependencyGraphTest.scala
+++ b/compiler/src/test/scala/edg/util/DependencyGraphTest.scala
@@ -153,21 +153,21 @@ class DependencyGraphTest extends AnyFlatSpec {
   it should "allow update with explicit update" in {
     val dep = DependencyGraph[Int, Int]()
     dep.addNode(10, Seq(0))
-    dep.addNode(10, Seq(0, 1), update=true)
+    dep.addNode(10, Seq(0, 1), overwrite=true)
     dep.setValue(0, 0)
     dep.getReady should equal(Set())  // should still be blocked on 1
 
-    dep.addNode(10, Seq(1, 2), update=true)  // 0 should no longer be required
+    dep.addNode(10, Seq(1, 2), overwrite=true)  // 0 should no longer be required
 
     dep.setValue(1, 1)
     dep.getReady should equal(Set())
     dep.setValue(2, 2)
     dep.getReady should equal(Set(10))
 
-    dep.addNode(10, Seq(1, 2), update=true)  // should be a nop
+    dep.addNode(10, Seq(1, 2), overwrite=true)  // should be a nop
     dep.getReady should equal(Set(10))
 
-    dep.addNode(10, Seq(3), update=true)
+    dep.addNode(10, Seq(3), overwrite=true)
     dep.getReady should equal(Set())  // should no longer be ready
   }
 

--- a/compiler/src/test/scala/edg/wir/RefinementsTest.scala
+++ b/compiler/src/test/scala/edg/wir/RefinementsTest.scala
@@ -16,13 +16,13 @@ class RefinementsTest extends AnyFlatSpec {
     val testRefinement = Refinements(
       classRefinements=Map(ElemBuilder.LibraryPath("base1") -> ElemBuilder.LibraryPath("sub1")),
       instanceRefinements=Map(DesignPath() + "elt1" -> ElemBuilder.LibraryPath("sub1")),
-      classValues=Map(ElemBuilder.LibraryPath("base1") -> Map(ExprBuilder.Ref("param1") -> IntValue(1))),
+      classValues=Map((ElemBuilder.LibraryPath("base1"), ExprBuilder.Ref("param1")) -> IntValue(1)),
       instanceValues=Map(DesignPath() + "elt1" -> IntValue(1))
     ) ++ Refinements(
       classRefinements=Map(ElemBuilder.LibraryPath("base2") -> ElemBuilder.LibraryPath("sub1")),
       instanceRefinements=Map(DesignPath() + "elt2" -> ElemBuilder.LibraryPath("sub1")),
-      classValues = Map(ElemBuilder.LibraryPath("base1") -> Map(ExprBuilder.Ref("param2") -> IntValue(1))),
-      instanceValues = Map(DesignPath() + "elt2" -> IntValue(1))
+      classValues=Map((ElemBuilder.LibraryPath("base1"), ExprBuilder.Ref("param2")) -> IntValue(1)),
+      instanceValues=Map(DesignPath() + "elt2" -> IntValue(1))
     )
     testRefinement should equal(Refinements(
         classRefinements = Map(
@@ -34,10 +34,9 @@ class RefinementsTest extends AnyFlatSpec {
           DesignPath() + "elt2" -> ElemBuilder.LibraryPath("sub1")
         ),
         classValues = Map(
-          ElemBuilder.LibraryPath("base1") -> Map(
-            ExprBuilder.Ref("param1") -> IntValue(1),
-            ExprBuilder.Ref("param2") -> IntValue(1)
-          )),
+          (ElemBuilder.LibraryPath("base1"), ExprBuilder.Ref("param1")) -> IntValue(1),
+          (ElemBuilder.LibraryPath("base1"), ExprBuilder.Ref("param2")) -> IntValue(1),
+        ),
         instanceValues = Map(
           DesignPath() + "elt1" -> IntValue(1),
           DesignPath() + "elt2" -> IntValue(1)
@@ -59,7 +58,7 @@ class RefinementsTest extends AnyFlatSpec {
     Refinements(
       classRefinements = Map(ElemBuilder.LibraryPath("base1") -> ElemBuilder.LibraryPath("sub1")),
       instanceRefinements = Map(DesignPath() + "elt1" -> ElemBuilder.LibraryPath("sub1")),
-      classValues = Map(ElemBuilder.LibraryPath("base1") -> Map(ExprBuilder.Ref("param1") -> IntValue(1))),
+      classValues = Map((ElemBuilder.LibraryPath("base1"), ExprBuilder.Ref("param1")) -> IntValue(1)),
       instanceValues = Map(DesignPath() + "elt1" -> IntValue(1))
     ).toPb should equal(hdl.Refinements(
       subclasses = Seq(


### PR DESCRIPTION
Prior, partial compilation (prevent the compiler from compiling certain items) only supported blocks-by-path and params-by-path. This adds support for blocks-by-class and params-by-class-value (some internal parameter of all blocks of a class, eg, Resistor:resistance).

The one edge case here is that when additional refinements are added, it may need to re-visit previously elaborated classes to apply new class-value refinements. That is done now on `fork`, along with a check on new class-based subclass refinements.

Infrastructure changes
- Refactors partial compilation to happen solely in the Compiler, holding back ElaborateRecord
  - Prior, this was a bit of a mess, also having some specialized logic in ConstProp
  - Overall the frozen handling style is much more unified and consistent
- Remove frozenParams from ConstProp, instead the Compiler holds back the declaration of frozen parameters
  - New forced values are handled (consistently) with `.setForcedValue` and ensuring param declarations aren't added until after `.setForcedValue`
  - Require setForcedValue done before param declared, for consistency
  - Make parameter declarations an ElaborateRecord so it can be held back, with an optimized path if the parameter is not held back
- Library utility to get superclass defining some parameter
- General stylistic cleanup
  - Unify ready-list handling style between Compiler and const-prop
  - DependencyGraph: clearer arg name `overwrite` instead of `update`
- Make compiler library visible
- Refactors Refinements to structure class-values as class-postfix-value tuples. The compiler precomputes a grouping by class for efficiency, there's a visible performance hit otherwise.