### PR TITLE
Cleanup

### DIFF
--- a/edg_core/NotConnectablePort.py
+++ b/edg_core/NotConnectablePort.py
@@ -19,9 +19,7 @@ class NotConnectableBlock(InternalBlock, Block, Generic[NotConnectablePortType])
 class NotConnectablePort(Port):
   """Port that additionally supports not-connected() which instantiates a dummy block with a nop port
   and connects this port to it."""
-  def __init__(self) -> None:
-    super().__init__()
-    self.not_connected_type: Type[NotConnectableBlock[Port]]  # TODO type check this!
+  not_connected_type: Type[NotConnectableBlock[Port]]  # TODO type check this!
 
   def not_connected(self) -> Block:
     """Marks this port as not connected; can only be done on a boundary port (for example, when subclassing

--- a/edg_core/Ports.py
+++ b/edg_core/Ports.py
@@ -107,6 +107,9 @@ class Port(BasePort, Generic[PortLinkType]):
 
   SelfType = TypeVar('SelfType', bound='Port')
 
+  link_type: Type[PortLinkType]
+  bridge_type: Optional[Type[PortBridge]] = None
+
   @classmethod
   def empty(cls: Type[SelfType]) -> SelfType:
     """Automatically generated empty constructor, that creates a port with all parameters None."""
@@ -122,11 +125,9 @@ class Port(BasePort, Generic[PortLinkType]):
     TODO: is this a reasonable restriction?"""
     super().__init__()
 
-    self.link_type: Type[PortLinkType]
     # This needs to be lazy-initialized to avoid building ports with links with ports, and so on
     # TODO: maybe a cleaner solution is to mark port constructors in a Block context or Link context?
     self._link_instance: Optional[PortLinkType] = None
-    self.bridge_type: Optional[Type[PortBridge]] = None
     self._bridge_instance: Optional[PortBridge] = None  # internal only
 
     # TODO delete type ignore after https://github.com/python/mypy/issues/5374

--- a/edg_core/test_common.py
+++ b/edg_core/test_common.py
@@ -16,20 +16,11 @@ class TestLink(Link):
 
 
 class TestPortBase(Port[TestLink]):
-  def __init__(self) -> None:
-    super().__init__()
-    self.link_type = TestLink
+  link_type = TestLink
 
 
 class TestPortSource(TestPortBase):
-  def __init__(self) -> None:
-    super().__init__()
-
-
-class TestPortSink(TestPortBase):
-  def __init__(self) -> None:
-    super().__init__()
-    self.bridge_type = TestPortBridge
+  pass
 
 
 class TestPortBridge(PortBridge):
@@ -37,6 +28,10 @@ class TestPortBridge(PortBridge):
     super().__init__()
     self.outer_port = self.Port(TestPortSink())
     self.inner_link = self.Port(TestPortSource())
+
+
+class TestPortSink(TestPortBase):
+  bridge_type = TestPortBridge
 
 
 class TestBlockSink(Block):

--- a/edg_core/test_elaboration_common.py
+++ b/edg_core/test_elaboration_common.py
@@ -42,14 +42,6 @@ class TestPortSource(TestPortBase):
         self.range_param = self.Parameter(RangeExpr(range_param))
 
 
-class TestPortSink(TestPortBase):
-    def __init__(self, range_limit: RangeLike = RangeExpr(), float_param: FloatLike = FloatExpr()) -> None:
-        super().__init__(float_param)
-        self.bridge_type = TestPortBridge
-
-        self.range_limit = self.Parameter(RangeExpr(range_limit))
-
-
 class TestPortBridge(PortBridge):
     def __init__(self) -> None:
         super().__init__()
@@ -58,6 +50,14 @@ class TestPortBridge(PortBridge):
 
         self.assign(self.outer_port.float_param, self.inner_link.link().float_param_sink_sum)
         self.assign(self.outer_port.range_limit, self.inner_link.link().range_param_sink_common)
+
+
+class TestPortSink(TestPortBase):
+    bridge_type = TestPortBridge
+
+    def __init__(self, range_limit: RangeLike = RangeExpr(), float_param: FloatLike = FloatExpr()) -> None:
+        super().__init__(float_param)
+        self.range_limit = self.Parameter(RangeExpr(range_limit))
 
 
 class TestBlockSink(Block):

--- a/edg_core/test_elaboration_common.py
+++ b/edg_core/test_elaboration_common.py
@@ -28,10 +28,11 @@ class TestLink(TestLinkBase):
 
 
 class TestPortBase(Port[TestLink]):
+    link_type = TestLink
+
     def __init__(self, float_param: FloatLike = FloatExpr()) -> None:
         super().__init__()
         self.float_param = self.Parameter(FloatExpr(float_param))
-        self.link_type = TestLink
 
 
 class TestPortSource(TestPortBase):

--- a/edg_core/test_generator.py
+++ b/edg_core/test_generator.py
@@ -85,16 +85,18 @@ class TestLink(Link):
 
 
 class TestPortSource(Port[TestLink]):
+  link_type = TestLink
+
   def __init__(self, float_value: FloatLike = FloatExpr()) -> None:
     super().__init__()
-    self.link_type = TestLink
     self.float_param = self.Parameter(FloatExpr(float_value))
 
 
 class TestPortSink(Port[TestLink]):
+  link_type = TestLink
+
   def __init__(self, range_value: RangeLike = RangeExpr()) -> None:
     super().__init__()
-    self.link_type = TestLink
     self.range_param = self.Parameter(RangeExpr(range_value))
 
 

--- a/edg_core/test_inner_link.py
+++ b/edg_core/test_inner_link.py
@@ -20,18 +20,20 @@ class TestBundleLink(Link):
 
 
 class TestBundleSource(Bundle[TestBundleLink]):
+  link_type = TestBundleLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = TestBundleLink
 
     self.a = self.Port(TestPortSource())
     self.b = self.Port(TestPortSource())
 
 
 class TestBundleSink(Bundle[TestBundleLink]):
+  link_type = TestBundleLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = TestBundleLink
 
     self.a = self.Port(TestPortSink())
     self.b = self.Port(TestPortSink())

--- a/edg_core/test_port_adapter.py
+++ b/edg_core/test_port_adapter.py
@@ -21,9 +21,7 @@ class AdapterPortAdapter(PortAdapter[TestPortSource]):
 
 
 class AdapterPort(Port[AdapterLink]):
-  def __init__(self):
-    self.link_type = AdapterLink
-    super().__init__()
+  link_type = AdapterLink
 
   def as_test_src(self) -> TestPortSource:
     return self._convert(AdapterPortAdapter())

--- a/edg_core/test_simple_const_prop.py
+++ b/edg_core/test_simple_const_prop.py
@@ -63,9 +63,10 @@ class TestPortConstPropLink(Link):
 
 
 class TestPortConstPropPort(Port[TestPortConstPropLink]):
+  link_type = TestPortConstPropLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = TestPortConstPropLink
     self.float_param = self.Parameter(FloatExpr())
 
 
@@ -134,10 +135,10 @@ class TestPortConstPropBundleLink(Link):
 
 
 class TestPortConstPropBundle(Bundle[TestPortConstPropBundleLink]):
+  link_type = TestPortConstPropBundleLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = TestPortConstPropBundleLink
-
     self.elt1 = self.Port(TestPortConstPropPort())
     self.elt2 = self.Port(TestPortConstPropPort())
 

--- a/edg_core/test_simple_expr_eval.py
+++ b/edg_core/test_simple_expr_eval.py
@@ -35,9 +35,10 @@ class TestReductionLink(Link):
 
 
 class TestReductionPort(Port[TestReductionLink]):
+  link_type = TestReductionLink
+
   def __init__(self, range_param: RangeLike = RangeExpr()) -> None:
     super().__init__()
-    self.link_type = TestReductionLink
     self.range_param = self.Parameter(RangeExpr(range_param))
 
 

--- a/electronics_abstract_parts/AbstractCapacitor.py
+++ b/electronics_abstract_parts/AbstractCapacitor.py
@@ -30,6 +30,9 @@ class UnpolarizedCapacitor(PassiveComponent):
     self.actual_capacitance = self.Parameter(RangeExpr())
     self.actual_voltage_rating = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>capacitance:</b> ", DescriptionString.FormatUnits(self.actual_capacitance, "F"),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.capacitance, "F"), "\n",

--- a/electronics_abstract_parts/AbstractCrystal.py
+++ b/electronics_abstract_parts/AbstractCrystal.py
@@ -18,6 +18,9 @@ class Crystal(DiscreteComponent):
     self.crystal = self.Port(CrystalPort(self.actual_frequency), [InOut])  # set by subclass
     self.gnd = self.Port(Ground(), [Common])
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>frequency:</b> ", DescriptionString.FormatUnits(self.actual_frequency, "Hz"),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.frequency, "Hz"), "\n",

--- a/electronics_abstract_parts/AbstractDiodes.py
+++ b/electronics_abstract_parts/AbstractDiodes.py
@@ -70,6 +70,9 @@ class Diode(KiCadImportableBlock, BaseDiode):
     self.actual_voltage_drop = self.Parameter(RangeExpr())
     self.actual_reverse_recovery_time = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>Vr:</b> ", DescriptionString.FormatUnits(self.actual_voltage_rating, "V"),
       " <b>of operating:</b> ", DescriptionString.FormatUnits(self.reverse_voltage, "V"), "\n",
@@ -139,6 +142,9 @@ class ZenerDiode(BaseDiode, DiscreteSemiconductor):
 
     self.actual_zener_voltage = self.Parameter(RangeExpr())
     self.actual_power_rating = self.Parameter(RangeExpr())
+
+  def contents(self):
+    super().contents()
 
     self.description = DescriptionString(
       "zener voltage=", DescriptionString.FormatUnits(self.actual_zener_voltage, "V"),

--- a/electronics_abstract_parts/AbstractFerriteBead.py
+++ b/electronics_abstract_parts/AbstractFerriteBead.py
@@ -25,6 +25,9 @@ class FerriteBead(PassiveComponent):
     self.actual_hf_impedance = self.Parameter(RangeExpr())
     self.actual_dc_resistance = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>current rating:</b> ", DescriptionString.FormatUnits(self.actual_current_rating, "A"),
       " <b>of operating</b> ", DescriptionString.FormatUnits(self.current, "A"), "\n",

--- a/electronics_abstract_parts/AbstractFets.py
+++ b/electronics_abstract_parts/AbstractFets.py
@@ -62,6 +62,9 @@ class Fet(KiCadImportableBlock, DiscreteSemiconductor):
     self.actual_rds_on = self.Parameter(RangeExpr())
     self.actual_gate_charge = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>Vds:</b> ", DescriptionString.FormatUnits(self.actual_drain_voltage_rating, "V"),
       " <b>of operating:</b> ", DescriptionString.FormatUnits(self.drain_voltage, "V"), "\n",

--- a/electronics_abstract_parts/AbstractFuse.py
+++ b/electronics_abstract_parts/AbstractFuse.py
@@ -15,6 +15,9 @@ class Fuse(InternalSubcircuit, Block):
     """Model-wise, equivalent to a VoltageSource|Sink passthrough, with a trip rating."""
     super().__init__()
 
+    self.a = self.Port(Passive())
+    self.b = self.Port(Passive())
+
     self.trip_current = self.ArgParameter(trip_current)  # current at which this will trip
     self.actual_trip_current = self.Parameter(RangeExpr())
     self.hold_current = self.ArgParameter(hold_current)  # current within at which this will NOT trip
@@ -22,15 +25,8 @@ class Fuse(InternalSubcircuit, Block):
     self.voltage = self.ArgParameter(voltage)  # operating voltage
     self.actual_voltage_rating = self.Parameter(RangeExpr())
 
-    self.a = self.Port(Passive())
-    self.b = self.Port(Passive())
-
-    self.require(self.actual_trip_current.within(self.trip_current),
-                 "trip current not within specified rating")
-    self.require(self.actual_hold_current.within(self.hold_current),
-                 "hold current not within specified rating")
-    self.require(self.voltage.within(self.actual_voltage_rating),
-                 "operating voltage not within rating")
+  def contents(self):
+    super().contents()
 
     self.description = DescriptionString(
       "<b>trip current:</b> ", DescriptionString.FormatUnits(self.actual_trip_current, "A"),
@@ -40,6 +36,13 @@ class Fuse(InternalSubcircuit, Block):
       "<b>voltage rating:</b> ", DescriptionString.FormatUnits(self.actual_voltage_rating, "V"),
       " <b>of operating:</b> ", DescriptionString.FormatUnits(self.voltage, "V")
     )
+
+    self.require(self.actual_trip_current.within(self.trip_current),
+                 "trip current not within specified rating")
+    self.require(self.actual_hold_current.within(self.hold_current),
+                 "hold current not within specified rating")
+    self.require(self.voltage.within(self.actual_voltage_rating),
+                 "operating voltage not within rating")
 
 
 @abstract_block

--- a/electronics_abstract_parts/AbstractInductor.py
+++ b/electronics_abstract_parts/AbstractInductor.py
@@ -26,6 +26,9 @@ class Inductor(PassiveComponent):
     self.actual_current_rating = self.Parameter(RangeExpr())
     self.actual_frequency_rating = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>inductance:</b> ", DescriptionString.FormatUnits(self.actual_inductance, "H"),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.inductance, "H"), "\n",

--- a/electronics_abstract_parts/AbstractOscillator.py
+++ b/electronics_abstract_parts/AbstractOscillator.py
@@ -19,6 +19,9 @@ class Oscillator(DiscreteApplication):
     self.pwr = self.Port(VoltageSink.empty(), [Power])
     self.out = self.Port(DigitalSource.empty(), [Output])
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>frequency:</b> ", DescriptionString.FormatUnits(self.actual_frequency, "Hz"),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.frequency, "Hz"),

--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -18,14 +18,17 @@ class DcDcConverter(PowerConditioner):
     self.pwr_out = self.Port(VoltageSource.empty(), [Output])
     self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.require(self.pwr_out.voltage_out.within(self.output_voltage),
-                 "Output voltage must be within spec")
+  def contents(self):
+    super().contents()
 
     self.description = DescriptionString(
       "<b>output voltage:</b> ", DescriptionString.FormatUnits(self.pwr_out.voltage_out, "V"),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.output_voltage, "V"), "\n",
       "<b>input voltage:</b> ", DescriptionString.FormatUnits(self.pwr_in.link().voltage, "V")
     )
+
+    self.require(self.pwr_out.voltage_out.within(self.output_voltage),
+                 "Output voltage must be within spec")
 
 
 @abstract_block
@@ -163,6 +166,9 @@ class BuckConverterPowerPath(InternalSubcircuit, GeneratorBlock):
                    input_voltage_ripple, output_voltage_ripple, dutycycle_limit,
                    inductor_scale)
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>duty cycle:</b> ", DescriptionString.FormatUnits(self.actual_dutycycle, ""),
       " <b>of limits:</b> ", DescriptionString.FormatUnits(self.dutycycle_limit, ""), "\n",
@@ -286,6 +292,9 @@ class BoostConverterPowerPath(InternalSubcircuit, GeneratorBlock):
                    inductor_current_ripple, efficiency,
                    input_voltage_ripple, output_voltage_ripple, dutycycle_limit)
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>duty cycle:</b> ", DescriptionString.FormatUnits(self.actual_dutycycle, ""),
       " <b>of limits:</b> ", DescriptionString.FormatUnits(self.dutycycle_limit, ""), "\n",
@@ -397,6 +406,9 @@ class BuckBoostConverterPowerPath(InternalSubcircuit, GeneratorBlock):
     self.generator(self.generate_passives, input_voltage, output_voltage, frequency, output_current,
                    inductor_current_ripple, efficiency,
                    input_voltage_ripple, output_voltage_ripple)
+
+  def contents(self):
+    super().contents()
 
     self.description = DescriptionString(
       "<b>duty cycle:</b> ", DescriptionString.FormatUnits(self.buck_dutycycle, ""), " (buck)",

--- a/electronics_abstract_parts/AbstractResistor.py
+++ b/electronics_abstract_parts/AbstractResistor.py
@@ -45,6 +45,9 @@ class Resistor(PassiveComponent, KiCadInstantiableBlock):
     self.actual_resistance = self.Parameter(RangeExpr())
     self.actual_power_rating = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>resistance:</b> ", DescriptionString.FormatUnits(self.actual_resistance, "Ω"),
       " <b>of spec</b> ", DescriptionString.FormatUnits(self.resistance, "Ω"), "\n",

--- a/electronics_abstract_parts/AbstractResistorArray.py
+++ b/electronics_abstract_parts/AbstractResistorArray.py
@@ -31,8 +31,9 @@ class ResistorArray(PassiveComponent, MultipackBlock):
     self.actual_count = self.Parameter(IntExpr())
     self.actual_resistance = self.Parameter(RangeExpr())
     self.actual_power_rating = self.Parameter(RangeExpr())  # per element
-    self.unpacked_assign(self.elements.params(lambda x: x.actual_resistance), self.actual_resistance)
-    self.unpacked_assign(self.elements.params(lambda x: x.actual_power_rating), self.actual_power_rating)
+
+  def contents(self):
+    super().contents()
 
     self.description = DescriptionString(  # TODO better support for array typed
       "<b>count:</b> ", DescriptionString.FormatUnits(self.actual_count, ""),  # TODO unitless
@@ -42,6 +43,9 @@ class ResistorArray(PassiveComponent, MultipackBlock):
       "<b>element power:</b> ", DescriptionString.FormatUnits(self.actual_power_rating, "W"),
       " <b>of operating:</b> ", DescriptionString.FormatUnits(self.powers, "W")
     )
+
+    self.unpacked_assign(self.elements.params(lambda x: x.actual_resistance), self.actual_resistance)
+    self.unpacked_assign(self.elements.params(lambda x: x.actual_power_rating), self.actual_power_rating)
 
 
 @non_library

--- a/electronics_abstract_parts/AbstractResistorArray.py
+++ b/electronics_abstract_parts/AbstractResistorArray.py
@@ -32,6 +32,9 @@ class ResistorArray(PassiveComponent, MultipackBlock):
     self.actual_resistance = self.Parameter(RangeExpr())
     self.actual_power_rating = self.Parameter(RangeExpr())  # per element
 
+    self.unpacked_assign(self.elements.params(lambda x: x.actual_resistance), self.actual_resistance)
+    self.unpacked_assign(self.elements.params(lambda x: x.actual_power_rating), self.actual_power_rating)
+
   def contents(self):
     super().contents()
 
@@ -43,9 +46,6 @@ class ResistorArray(PassiveComponent, MultipackBlock):
       "<b>element power:</b> ", DescriptionString.FormatUnits(self.actual_power_rating, "W"),
       " <b>of operating:</b> ", DescriptionString.FormatUnits(self.powers, "W")
     )
-
-    self.unpacked_assign(self.elements.params(lambda x: x.actual_resistance), self.actual_resistance)
-    self.unpacked_assign(self.elements.params(lambda x: x.actual_power_rating), self.actual_power_rating)
 
 
 @non_library

--- a/electronics_abstract_parts/OpampCircuits.py
+++ b/electronics_abstract_parts/OpampCircuits.py
@@ -90,6 +90,9 @@ class Amplifier(OpampApplication, KiCadSchematicBlock, KiCadImportableBlock, Gen
 
     self.actual_amplification = self.Parameter(RangeExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>amplification:</b> ", DescriptionString.FormatUnits(self.actual_amplification, ""),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.amplification, "")
@@ -210,6 +213,10 @@ class DifferentialAmplifier(OpampApplication, KiCadSchematicBlock, KiCadImportab
 
     self.ratio = self.ArgParameter(ratio)
     self.actual_ratio = self.Parameter(RangeExpr())
+
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>ratio:</b> ", DescriptionString.FormatUnits(self.actual_ratio, ""),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.ratio, "")
@@ -327,6 +334,10 @@ class IntegratorInverting(OpampApplication, KiCadSchematicBlock, KiCadImportable
 
     self.factor = self.ArgParameter(factor)
     self.actual_factor = self.Parameter(RangeExpr())
+
+  def contents(self) -> None:
+    super().contents()
+
     self.description = DescriptionString(
       "<b>factor:</b> ", DescriptionString.FormatUnits(self.actual_factor, ""),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.factor, "")

--- a/electronics_abstract_parts/ResistiveDivider.py
+++ b/electronics_abstract_parts/ResistiveDivider.py
@@ -76,6 +76,9 @@ class ResistiveDivider(InternalSubcircuit, GeneratorBlock):
 
     self.generator(self.generate_divider, self.ratio, self.impedance, series, tolerance)
 
+  def contents(self) -> None:
+    super().contents()
+
     self.description = DescriptionString(
       "<b>ratio:</b> ", DescriptionString.FormatUnits(self.actual_ratio, ""),
       " <b>of spec</b> ", DescriptionString.FormatUnits(self.ratio, ""),
@@ -196,17 +199,20 @@ class FeedbackVoltageDivider(Analog, BaseVoltageDivider):
        self.output_voltage.upper() / self.actual_ratio.lower())
     ))
 
-    ratio_lower = self.output_voltage.upper() / self.assumed_input_voltage.upper()
-    ratio_upper = self.output_voltage.lower() / self.assumed_input_voltage.lower()
-    self.require(ratio_lower <= ratio_upper,
-                   "can't generate feedback divider with input voltage of tighter tolerance than output voltage")
-    self.assign(self.ratio, (ratio_lower, ratio_upper))
+  def contents(self) -> None:
+    super().contents()
 
     self.description = DescriptionString(  # TODO forward from internal?
       "<b>ratio:</b> ", DescriptionString.FormatUnits(self.actual_ratio, ""),
       " <b>of spec</b> ", DescriptionString.FormatUnits(self.ratio, ""),
       "\n<b>impedance:</b> ", DescriptionString.FormatUnits(self.actual_impedance, "Ω"),
       " <b>of spec:</b> ", DescriptionString.FormatUnits(self.impedance, "Ω"))
+
+    ratio_lower = self.output_voltage.upper() / self.assumed_input_voltage.upper()
+    ratio_upper = self.output_voltage.lower() / self.assumed_input_voltage.lower()
+    self.require(ratio_lower <= ratio_upper,
+                 "can't generate feedback divider with input voltage of tighter tolerance than output voltage")
+    self.assign(self.ratio, (ratio_lower, ratio_upper))
 
 
 class SignalDivider(Analog, Block):

--- a/electronics_model/AnalogPort.py
+++ b/electronics_model/AnalogPort.py
@@ -44,10 +44,7 @@ class AnalogLink(CircuitLink):
 
 
 class AnalogBase(CircuitPort[AnalogLink]):
-  def __init__(self) -> None:
-    super().__init__()
-
-    self.link_type = AnalogLink
+  link_type = AnalogLink
 
 
 class AnalogSinkBridge(CircuitPortBridge):

--- a/electronics_model/AnalogPort.py
+++ b/electronics_model/AnalogPort.py
@@ -100,6 +100,8 @@ class AnalogSourceBridge(CircuitPortBridge):  # basic passthrough port, sources 
 
 
 class AnalogSink(AnalogBase):
+  bridge_type = AnalogSinkBridge
+
   @staticmethod
   def from_supply(neg: Port[VoltageLink], pos: Port[VoltageLink], *,
                   voltage_limit_tolerance: RangeLike = Default((-0.3, 0.3)),
@@ -116,8 +118,6 @@ class AnalogSink(AnalogBase):
                current_draw: RangeLike = Default(RangeExpr.ZERO),
                impedance: RangeLike = Default(RangeExpr.INF)) -> None:
     super().__init__()
-    self.bridge_type = AnalogSinkBridge
-
     # TODO maybe separate absolute maximum limits from sensing limits?
     self.voltage_limits = self.Parameter(RangeExpr(voltage_limits))
     self.current_draw = self.Parameter(RangeExpr(current_draw))
@@ -125,6 +125,8 @@ class AnalogSink(AnalogBase):
 
 
 class AnalogSource(AnalogBase):
+  bridge_type = AnalogSourceBridge
+
   @staticmethod
   def from_supply(neg: Port[VoltageLink], pos: Port[VoltageLink], *,
                   current_limits: RangeLike = Default(RangeExpr.ALL),
@@ -139,8 +141,6 @@ class AnalogSource(AnalogBase):
                current_limits: RangeLike = Default(RangeExpr.ALL),
                impedance: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
-    self.bridge_type = AnalogSourceBridge
-
     self.voltage_out = self.Parameter(RangeExpr(voltage_out))
     self.current_limits = self.Parameter(RangeExpr(current_limits))
     self.impedance = self.Parameter(RangeExpr(impedance))

--- a/electronics_model/AnalogPort.py
+++ b/electronics_model/AnalogPort.py
@@ -23,6 +23,9 @@ class AnalogLink(CircuitLink):
     self.voltage_limits = self.Parameter(RangeExpr())
     self.current_limits = self.Parameter(RangeExpr())
 
+  def contents(self) -> None:
+    super().contents()
+
     self.description = DescriptionString(
       "<b>voltage</b>: ", DescriptionString.FormatUnits(self.voltage, "V"),
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.voltage_limits, "V"),
@@ -30,9 +33,6 @@ class AnalogLink(CircuitLink):
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.current_limits, "A"),
       "\n<b>sink impedance</b>: ", DescriptionString.FormatUnits(self.sink_impedance, "Ω"),
       ", <b>source impedance</b>: ", DescriptionString.FormatUnits(self.source_impedance, "Ω"))
-
-  def contents(self) -> None:
-    super().contents()
 
     self.assign(self.sink_impedance, 1 / (1 / self.sinks.map_extract(lambda x: x.impedance)).sum())
     self.require(self.source.impedance.upper() <= self.sink_impedance.lower() * 0.1)  # about 10x for signal integrity

--- a/electronics_model/CanPort.py
+++ b/electronics_model/CanPort.py
@@ -26,10 +26,10 @@ class CanLogicLink(Link):
 
 
 class CanControllerPort(Bundle[CanLogicLink]):
+  link_type = CanLogicLink
+
   def __init__(self, model: Optional[DigitalBidir] = None) -> None:
     super().__init__()
-    self.link_type = CanLogicLink
-
     if model is None:  # ideal by default
       model = DigitalBidir()
     self.txd = self.Port(DigitalSource.from_bidir(model))
@@ -37,10 +37,10 @@ class CanControllerPort(Bundle[CanLogicLink]):
 
 
 class CanTransceiverPort(Bundle[CanLogicLink]):
+  link_type = CanLogicLink
+
   def __init__(self, model: Optional[DigitalBidir] = None) -> None:
     super().__init__()
-    self.link_type = CanLogicLink
-
     if model is None:  # ideal by default
       model = DigitalBidir()
     self.txd = self.Port(DigitalSink.from_bidir(model))
@@ -48,10 +48,10 @@ class CanTransceiverPort(Bundle[CanLogicLink]):
 
 
 class CanPassivePort(Bundle[CanLogicLink]):
+  link_type = CanLogicLink
+
   def __init__(self, model: Optional[DigitalBidir] = None) -> None:
     super().__init__()
-    self.link_type = CanLogicLink
-
     if model is None:  # ideal by default
       model = DigitalBidir()
     self.txd = self.Port(DigitalSink.from_bidir(model))
@@ -76,18 +76,6 @@ class CanDiffLink(Link):
                              flatten=True)
 
 
-class CanDiffPort(Bundle[CanDiffLink]):
-  def __init__(self, model: Optional[DigitalBidir] = None) -> None:
-    super().__init__()
-    self.link_type = CanDiffLink
-    self.bridge_type = CanDiffBridge
-
-    if model is None:  # ideal by default
-      model = DigitalBidir()
-    self.canh = self.Port(model)
-    self.canl = self.Port(model)
-
-
 class CanDiffBridge(PortBridge):
   def __init__(self) -> None:
     super().__init__()
@@ -105,3 +93,15 @@ class CanDiffBridge(PortBridge):
     self.canl_bridge = self.Block(DigitalBidirBridge())
     self.connect(self.outer_port.canl, self.canl_bridge.outer_port)
     self.connect(self.canl_bridge.inner_link, self.inner_link.canl)
+
+
+class CanDiffPort(Bundle[CanDiffLink]):
+  link_type = CanDiffLink
+  bridge_type = CanDiffBridge
+
+  def __init__(self, model: Optional[DigitalBidir] = None) -> None:
+    super().__init__()
+    if model is None:  # ideal by default
+      model = DigitalBidir()
+    self.canh = self.Port(model)
+    self.canl = self.Port(model)

--- a/electronics_model/CrystalPort.py
+++ b/electronics_model/CrystalPort.py
@@ -20,10 +20,10 @@ class CrystalLink(Link):
 
 
 class CrystalPort(Bundle[CrystalLink]):
+  link_type = CrystalLink
+
   def __init__(self, frequency: RangeLike = Default(RangeExpr.EMPTY_ZERO)) -> None:
     super().__init__()
-    self.link_type = CrystalLink
-
     self.a = self.Port(Passive())  # TODO can this have voltages?
     self.b = self.Port(Passive())
 
@@ -31,11 +31,11 @@ class CrystalPort(Bundle[CrystalLink]):
 
 
 class CrystalDriver(Bundle[CrystalLink]):
+  link_type = CrystalLink
+
   def __init__(self, frequency_limits: RangeLike = Default(RangeExpr.ALL),
                voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO)) -> None:
     super().__init__()
-    self.link_type = CrystalLink
-
     self.voltage_out = self.Parameter(RangeExpr(voltage_out))
     self.xtal_in = self.Port(Passive())
     self.xtal_out = self.Port(Passive())

--- a/electronics_model/DebugPorts.py
+++ b/electronics_model/DebugPorts.py
@@ -24,10 +24,10 @@ class SwdLink(Link):
 
 
 class SwdHostPort(Bundle[SwdLink]):
+  link_type = SwdLink
+
   def __init__(self, model: Optional[DigitalBidir] = None) -> None:
     super().__init__()
-    self.link_type = SwdLink
-
     if model is None:
       model = DigitalBidir()  # ideal by default
     self.swdio = self.Port(model)
@@ -36,10 +36,10 @@ class SwdHostPort(Bundle[SwdLink]):
 
 
 class SwdTargetPort(Bundle[SwdLink]):
+  link_type = SwdLink
+
   def __init__(self, model: Optional[DigitalBidir] = None) -> None:
     super().__init__()
-    self.link_type = SwdLink
-
     if model is None:
       model = DigitalBidir()  # ideal by default
     self.swdio = self.Port(model)
@@ -48,10 +48,10 @@ class SwdTargetPort(Bundle[SwdLink]):
 
 
 class SwdPullPort(Bundle[SwdLink]):
+  link_type = SwdLink
+
   def __init__(self, model: Optional[DigitalSingleSource] = None) -> None:
     super().__init__()
-    self.link_type = SwdLink
-
     if model is None:
       model = DigitalSingleSource()  # ideal by default
     self.swdio = self.Port(model)

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -143,7 +143,33 @@ class DigitalBase(CircuitPort[DigitalLink]):
   link_type = DigitalLink
 
 
+class DigitalSinkBridge(CircuitPortBridge):
+  def __init__(self) -> None:
+    super().__init__()
+
+    self.outer_port = self.Port(DigitalSink(voltage_limits=RangeExpr(),
+                                            current_draw=RangeExpr(),
+                                            input_thresholds=RangeExpr()))
+
+    # TODO can we actually define something here? as a pseudoport, this doesn't have limits
+    self.inner_link = self.Port(DigitalSource(current_limits=RangeExpr.ALL,
+                                              voltage_out=RangeExpr(),
+                                              output_thresholds=RangeExpr()))
+
+  def contents(self) -> None:
+    super().contents()
+
+    self.assign(self.outer_port.voltage_limits, self.inner_link.link().voltage_limits)
+    self.assign(self.outer_port.current_draw, self.inner_link.link().current_drawn)
+    self.assign(self.inner_link.voltage_out, self.outer_port.link().voltage)
+
+    self.assign(self.inner_link.output_thresholds, self.outer_port.link().output_thresholds)
+    self.assign(self.outer_port.input_thresholds, self.inner_link.link().input_thresholds)
+
+
 class DigitalSink(DigitalBase):
+  bridge_type = DigitalSinkBridge
+
   @staticmethod
   def from_supply(neg: Port[VoltageLink], pos: Port[VoltageLink], *,
                   voltage_limit_tolerance: RangeLike = Default((-0.3, 0.3)),
@@ -177,8 +203,6 @@ class DigitalSink(DigitalBase):
                current_draw: RangeLike = Default(RangeExpr.ZERO), *,
                input_thresholds: RangeLike = Default(RangeExpr.EMPTY_DIT)) -> None:
     super().__init__()
-    self.bridge_type = DigitalSinkBridge
-
     self.voltage_limits: RangeExpr = self.Parameter(RangeExpr(voltage_limits))
     self.current_draw: RangeExpr = self.Parameter(RangeExpr(current_draw))
     self.input_thresholds: RangeExpr = self.Parameter(RangeExpr(input_thresholds))
@@ -210,30 +234,6 @@ class DigitalSourceBridge(CircuitPortBridge):
     self.assign(self.outer_port.output_thresholds, self.inner_link.link().output_thresholds)
 
 
-class DigitalSinkBridge(CircuitPortBridge):
-  def __init__(self) -> None:
-    super().__init__()
-
-    self.outer_port = self.Port(DigitalSink(voltage_limits=RangeExpr(),
-                                            current_draw=RangeExpr(),
-                                            input_thresholds=RangeExpr()))
-
-    # TODO can we actually define something here? as a pseudoport, this doesn't have limits
-    self.inner_link = self.Port(DigitalSource(current_limits=RangeExpr.ALL,
-                                              voltage_out=RangeExpr(),
-                                              output_thresholds=RangeExpr()))
-
-  def contents(self) -> None:
-    super().contents()
-
-    self.assign(self.outer_port.voltage_limits, self.inner_link.link().voltage_limits)
-    self.assign(self.outer_port.current_draw, self.inner_link.link().current_drawn)
-    self.assign(self.inner_link.voltage_out, self.outer_port.link().voltage)
-
-    self.assign(self.inner_link.output_thresholds, self.outer_port.link().output_thresholds)
-    self.assign(self.outer_port.input_thresholds, self.inner_link.link().input_thresholds)
-
-
 class DigitalSourceAdapterVoltageSource(CircuitPortAdapter[VoltageSource]):
   @init_in_parent
   def __init__(self):
@@ -248,6 +248,8 @@ class DigitalSourceAdapterVoltageSource(CircuitPortAdapter[VoltageSource]):
 
 
 class DigitalSource(DigitalBase):
+  bridge_type = DigitalSourceBridge
+
   @staticmethod
   def from_supply(neg: Port[VoltageLink], pos: Port[VoltageLink],
                   current_limits: RangeLike = Default(RangeExpr.ALL), *,
@@ -277,8 +279,6 @@ class DigitalSource(DigitalBase):
                pullup_capable: BoolLike = Default(False),
                pulldown_capable: BoolLike = Default(False)) -> None:
     super().__init__()
-    self.bridge_type = DigitalSourceBridge
-
     self.voltage_out: RangeExpr = self.Parameter(RangeExpr(voltage_out))
     self.current_limits: RangeExpr = self.Parameter(RangeExpr(current_limits))
     self.output_thresholds: RangeExpr = self.Parameter(RangeExpr(output_thresholds))
@@ -290,6 +290,43 @@ class DigitalSource(DigitalBase):
     return self._convert(DigitalSourceAdapterVoltageSource())
 
 
+class DigitalBidirBridge(CircuitPortBridge):
+  def __init__(self) -> None:
+    super().__init__()
+
+    self.outer_port = self.Port(DigitalBidir(voltage_out=RangeExpr(), current_draw=RangeExpr(),
+                                             voltage_limits=RangeExpr(), current_limits=RangeExpr(),
+                                             output_thresholds=RangeExpr(), input_thresholds=RangeExpr(),
+                                             # TODO see issue 58, how do we propagate this in both directions?
+                                             # pulldown_capable=BoolExpr(), pullup_capable=BoolExpr(),
+                                             ))
+    # TODO can we actually define something here? as a pseudoport, this doesn't have limits
+    self.inner_link = self.Port(DigitalBidir(voltage_limits=RangeExpr.ALL, current_limits=RangeExpr.ALL,
+                                             pulldown_capable=BoolExpr(), pullup_capable=BoolExpr(),
+                                             ))
+
+  def contents(self) -> None:
+    super().contents()
+
+    self.assign(self.outer_port.voltage_out, self.inner_link.link().voltage)
+    self.assign(self.outer_port.current_draw, self.inner_link.link().current_drawn)
+    self.assign(self.outer_port.voltage_limits, self.inner_link.link().voltage_limits)
+    self.assign(self.outer_port.current_limits, self.inner_link.link().current_limits)  # TODO compensate for internal current draw
+
+    self.assign(self.outer_port.output_thresholds, self.inner_link.link().output_thresholds)
+    self.assign(self.outer_port.input_thresholds, self.inner_link.link().input_thresholds)
+
+    # TODO this is a hacktastic in that it's not bidirectional, but it serves the use case for the USB PD CC case
+    # TODO this is a bit hacky, but allows a externally disconnected port
+    self.assign(self.inner_link.pullup_capable, self.outer_port.is_connected().then_else(
+      self.outer_port.link().pullup_capable, BoolExpr._to_expr_type(False)))
+    self.assign(self.inner_link.pulldown_capable, self.outer_port.is_connected().then_else(
+      self.outer_port.link().pulldown_capable, BoolExpr._to_expr_type(False)))
+    # TODO see issue 58, how do we propagate this in both directions?
+    # self.assign(self.outer_port.pullup_capable, self.inner_link.link().pullup_capable)
+    # self.assign(self.outer_port.pulldown_capable, self.inner_link.link().pulldown_capable)
+
+
 class DigitalBidirNotConnected(NotConnectableBlock['DigitalBidir']):
   """Not-connected dummy block for Digital bidir ports"""
   def __init__(self) -> None:
@@ -298,6 +335,9 @@ class DigitalBidirNotConnected(NotConnectableBlock['DigitalBidir']):
 
 
 class DigitalBidir(DigitalBase, NotConnectablePort):
+  bridge_type = DigitalBidirBridge
+  not_connected_type = DigitalBidirNotConnected
+
   @staticmethod
   def from_supply(neg: Port[VoltageLink], pos: Port[VoltageLink],
                   voltage_limit_abs: Optional[RangeLike] = None,
@@ -357,9 +397,6 @@ class DigitalBidir(DigitalBase, NotConnectablePort):
                pullup_capable: BoolLike = Default(False),
                pulldown_capable: BoolLike = Default(False)) -> None:
     super().__init__()
-    self.bridge_type = DigitalBidirBridge
-    self.not_connected_type = DigitalBidirNotConnected
-
     self.voltage_limits: RangeExpr = self.Parameter(RangeExpr(voltage_limits))
     self.current_draw: RangeExpr = self.Parameter(RangeExpr(current_draw))
     self.voltage_out: RangeExpr = self.Parameter(RangeExpr(voltage_out))
@@ -374,43 +411,6 @@ class DigitalBidir(DigitalBase, NotConnectablePort):
     """Adapts this DigitalBidir to a DigitalSingleSource open-drain (low-side-only) driver.
     Not that not all digital ports can be driven in open-drain mode, check your particular IO's capabilities."""
     return self._convert(DigitalBidirAdapterOpenDrain())
-
-
-class DigitalBidirBridge(CircuitPortBridge):
-  def __init__(self) -> None:
-    super().__init__()
-
-    self.outer_port = self.Port(DigitalBidir(voltage_out=RangeExpr(), current_draw=RangeExpr(),
-                                             voltage_limits=RangeExpr(), current_limits=RangeExpr(),
-                                             output_thresholds=RangeExpr(), input_thresholds=RangeExpr(),
-                                             # TODO see issue 58, how do we propagate this in both directions?
-                                             # pulldown_capable=BoolExpr(), pullup_capable=BoolExpr(),
-                                             ))
-    # TODO can we actually define something here? as a pseudoport, this doesn't have limits
-    self.inner_link = self.Port(DigitalBidir(voltage_limits=RangeExpr.ALL, current_limits=RangeExpr.ALL,
-                                             pulldown_capable=BoolExpr(), pullup_capable=BoolExpr(),
-                                             ))
-
-  def contents(self) -> None:
-    super().contents()
-
-    self.assign(self.outer_port.voltage_out, self.inner_link.link().voltage)
-    self.assign(self.outer_port.current_draw, self.inner_link.link().current_drawn)
-    self.assign(self.outer_port.voltage_limits, self.inner_link.link().voltage_limits)
-    self.assign(self.outer_port.current_limits, self.inner_link.link().current_limits)  # TODO compensate for internal current draw
-
-    self.assign(self.outer_port.output_thresholds, self.inner_link.link().output_thresholds)
-    self.assign(self.outer_port.input_thresholds, self.inner_link.link().input_thresholds)
-
-    # TODO this is a hacktastic in that it's not bidirectional, but it serves the use case for the USB PD CC case
-    # TODO this is a bit hacky, but allows a externally disconnected port
-    self.assign(self.inner_link.pullup_capable, self.outer_port.is_connected().then_else(
-      self.outer_port.link().pullup_capable, BoolExpr._to_expr_type(False)))
-    self.assign(self.inner_link.pulldown_capable, self.outer_port.is_connected().then_else(
-      self.outer_port.link().pulldown_capable, BoolExpr._to_expr_type(False)))
-    # TODO see issue 58, how do we propagate this in both directions?
-    # self.assign(self.outer_port.pullup_capable, self.inner_link.link().pullup_capable)
-    # self.assign(self.outer_port.pulldown_capable, self.inner_link.link().pulldown_capable)
 
 
 class DigitalSingleSource(DigitalBase):

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -140,10 +140,7 @@ class DigitalLink(CircuitLink):
 
 
 class DigitalBase(CircuitPort[DigitalLink]):
-  def __init__(self) -> None:
-    super().__init__()
-
-    self.link_type = DigitalLink
+  link_type = DigitalLink
 
 
 class DigitalSink(DigitalBase):

--- a/electronics_model/DigitalPorts.py
+++ b/electronics_model/DigitalPorts.py
@@ -52,6 +52,9 @@ class DigitalLink(CircuitLink):
     self.has_low_signal_driver = self.Parameter(BoolExpr())
     self.has_high_signal_driver = self.Parameter(BoolExpr())
 
+  def contents(self):
+    super().contents()
+
     self.description = DescriptionString(
       "<b>voltage</b>: ", DescriptionString.FormatUnits(self.voltage, "V"),
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.voltage_limits, "V"),
@@ -59,9 +62,6 @@ class DigitalLink(CircuitLink):
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.current_limits, "A"),
       "\n<b>output thresholds</b>: ", DescriptionString.FormatUnits(self.output_thresholds, "V"),
       ", <b>input thresholds</b>: ", DescriptionString.FormatUnits(self.input_thresholds, "V"))
-
-  def contents(self):
-    super().contents()
 
     self.require(self.source.is_connected() | (self.single_sources.length() > 0) | (self.bidirs.length() > 0),
                  "DigitalLink must have some kind of source")

--- a/electronics_model/PassivePort.py
+++ b/electronics_model/PassivePort.py
@@ -131,6 +131,7 @@ class PassiveBridge(CircuitPortBridge):
 
 
 class Passive(CircuitPort[PassiveLink]):
+  """Basic copper-only port, which can be adapted to a more strongly typed Voltage/Digital/Analog* port"""
   adapter_type_map: Dict[Type[Port], Type[CircuitPortAdapter]] = {
     VoltageSource: PassiveAdapterVoltageSource,
     VoltageSink: PassiveAdapterVoltageSink,
@@ -141,13 +142,8 @@ class Passive(CircuitPort[PassiveLink]):
     AnalogSink: PassiveAdapterAnalogSink,
     AnalogSource: PassiveAdapterAnalogSource
   }
-
-  """Basic copper-only port, which can be adapted to a more strongly typed Voltage/Digital/Analog* port"""
-  def __init__(self) -> None:
-    super().__init__()
-
-    self.link_type = PassiveLink
-    self.bridge_type = PassiveBridge
+  link_type = PassiveLink
+  bridge_type = PassiveBridge
 
   AdaptTargetType = TypeVar('AdaptTargetType', bound=CircuitPort)
   def adapt_to(self, that: AdaptTargetType) -> AdaptTargetType:

--- a/electronics_model/SpeakerPort.py
+++ b/electronics_model/SpeakerPort.py
@@ -18,9 +18,10 @@ class SpeakerLink(Link):
 
 
 class SpeakerDriverPort(Bundle[SpeakerLink]):
+  link_type = SpeakerLink
+
   def __init__(self, model: Optional[AnalogSource] = None) -> None:
     super().__init__()
-    self.link_type = SpeakerLink
 
     if model is None:
       model = AnalogSource()  # ideal by default
@@ -29,10 +30,10 @@ class SpeakerDriverPort(Bundle[SpeakerLink]):
 
 
 class SpeakerPort(Bundle[SpeakerLink]):
+  link_type = SpeakerLink
+
   def __init__(self, model: Optional[AnalogSink] = None) -> None:
     super().__init__()
-    self.link_type = SpeakerLink
-
     if model is None:
       model = AnalogSink()  # ideal by default
     self.a = self.Port(model)  # TODO how to model max power?

--- a/electronics_model/SpiPort.py
+++ b/electronics_model/SpiPort.py
@@ -21,11 +21,11 @@ class SpiLink(Link):
 
 
 class SpiMaster(Bundle[SpiLink]):
+  link_type = SpiLink
+
   def __init__(self, model: Optional[DigitalBidir] = None,
                frequency: RangeLike = Default(RangeExpr.EMPTY_ZERO)) -> None:
     super().__init__()
-    self.link_type = SpiLink
-
     if model is None:
       model = DigitalBidir()  # ideal by default
     self.sck = self.Port(DigitalSource.from_bidir(model))
@@ -37,12 +37,12 @@ class SpiMaster(Bundle[SpiLink]):
 
 
 class SpiSlave(Bundle[SpiLink]):
+  link_type = SpiLink
+
   # TODO: for now, CS is defined separately
   def __init__(self, model: Optional[DigitalBidir] = None,
                frequency_limit: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()
-    self.link_type = SpiLink
-
     if model is None:
       model = DigitalBidir()  # ideal by default
     self.sck = self.Port(DigitalSink.from_bidir(model))

--- a/electronics_model/SpiPort.py
+++ b/electronics_model/SpiPort.py
@@ -39,7 +39,6 @@ class SpiMaster(Bundle[SpiLink]):
 class SpiSlave(Bundle[SpiLink]):
   link_type = SpiLink
 
-  # TODO: for now, CS is defined separately
   def __init__(self, model: Optional[DigitalBidir] = None,
                frequency_limit: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()
@@ -48,6 +47,7 @@ class SpiSlave(Bundle[SpiLink]):
     self.sck = self.Port(DigitalSink.from_bidir(model))
     self.mosi = self.Port(DigitalSink.from_bidir(model))
     self.miso = self.Port(model)
+    # TODO: (?) CS is defined separately
 
     self.frequency_limit = self.Parameter(RangeExpr(frequency_limit))  # range of acceptable frequencies
     self.mode_limit = self.Parameter(RangeExpr())  # range of acceptable modes, in [0, 3]

--- a/electronics_model/UartPort.py
+++ b/electronics_model/UartPort.py
@@ -18,10 +18,10 @@ class UartLink(Link):
 
 
 class UartPort(Bundle[UartLink]):
+  link_type = UartLink
+
   def __init__(self, model: Optional[DigitalBidir] = None) -> None:
     super().__init__()
-    self.link_type = UartLink
-
     if model is None:
       model = DigitalBidir()  # ideal by default
     self.tx = self.Port(DigitalSource.from_bidir(model))

--- a/electronics_model/UsbPort.py
+++ b/electronics_model/UsbPort.py
@@ -22,30 +22,17 @@ class UsbLink(Link):
 
 
 class UsbHostPort(Bundle[UsbLink]):
+  link_type = UsbLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = UsbLink
-
     self.dp = self.Port(DigitalBidir())
     self.dm = self.Port(DigitalBidir())
-
-
-class UsbDevicePort(Bundle[UsbLink]):
-  def __init__(self, model: Optional[DigitalBidir] = None) -> None:
-    super().__init__()
-    self.link_type = UsbLink
-    self.bridge_type = UsbDeviceBridge
-
-    if model is None:
-      model = DigitalBidir()  # ideal by default
-    self.dp = self.Port(model)
-    self.dm = self.Port(model)
 
 
 class UsbDeviceBridge(PortBridge):
   def __init__(self) -> None:
     super().__init__()
-
     self.outer_port = self.Port(UsbDevicePort.empty())
     self.inner_link = self.Port(UsbHostPort.empty())
 
@@ -62,11 +49,23 @@ class UsbDeviceBridge(PortBridge):
     self.connect(self.dp_bridge.inner_link, self.inner_link.dp)
 
 
+class UsbDevicePort(Bundle[UsbLink]):
+  link_type = UsbLink
+  bridge_type = UsbDeviceBridge
+
+  def __init__(self, model: Optional[DigitalBidir] = None) -> None:
+    super().__init__()
+    if model is None:
+      model = DigitalBidir()  # ideal by default
+    self.dp = self.Port(model)
+    self.dm = self.Port(model)
+
+
 class UsbPassivePort(Bundle[UsbLink]):
+  link_type = UsbLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = UsbLink
-
     self.dp = self.Port(DigitalBidir())
     self.dm = self.Port(DigitalBidir())
 
@@ -89,9 +88,9 @@ class UsbCcLink(Link):
 
 
 class UsbCcPort(Bundle[UsbCcLink]):
+  link_type = UsbCcLink
+
   def __init__(self, pullup_capable: BoolLike = Default(False)) -> None:
     super().__init__()
-    self.link_type = UsbCcLink
-
     self.cc1 = self.Port(DigitalBidir(pullup_capable=pullup_capable))
     self.cc2 = self.Port(DigitalBidir(pullup_capable=pullup_capable))

--- a/electronics_model/VoltagePorts.py
+++ b/electronics_model/VoltagePorts.py
@@ -94,10 +94,10 @@ class CircuitPort(Port[CircuitLinkType], Generic[CircuitLinkType]):
 
 
 class VoltageBase(CircuitPort[VoltageLink]):
+  link_type = VoltageLink
+
   def __init__(self) -> None:
     super().__init__()
-    self.link_type = VoltageLink
-
 #     self.isolation_domain = self.Parameter(RefParameter())  # semantics TBD
 #     self.reference = self.Parameter(RefParameter())  # semantics TBD, ideally some concept of implicit domains
 

--- a/electronics_model/VoltagePorts.py
+++ b/electronics_model/VoltagePorts.py
@@ -23,14 +23,14 @@ class VoltageLink(CircuitLink):
     self.current_drawn = self.Parameter(RangeExpr())
     self.current_limits = self.Parameter(RangeExpr())
 
+  def contents(self) -> None:
+    super().contents()
+
     self.description = DescriptionString(
       "<b>voltage</b>: ", DescriptionString.FormatUnits(self.voltage, "V"),
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.voltage_limits, "V"),
       "\n<b>current</b>: ", DescriptionString.FormatUnits(self.current_drawn, "A"),
       " <b>of limits</b>: ", DescriptionString.FormatUnits(self.current_limits, "A"))
-
-  def contents(self) -> None:
-    super().contents()
 
     self.assign(self.voltage, self.source.voltage_out)
     self.assign(self.voltage_limits, self.sinks.intersection(lambda x: x.voltage_limits))
@@ -96,10 +96,7 @@ class CircuitPort(Port[CircuitLinkType], Generic[CircuitLinkType]):
 class VoltageBase(CircuitPort[VoltageLink]):
   link_type = VoltageLink
 
-  def __init__(self) -> None:
-    super().__init__()
-#     self.isolation_domain = self.Parameter(RefParameter())  # semantics TBD
-#     self.reference = self.Parameter(RefParameter())  # semantics TBD, ideally some concept of implicit domains
+  # TODO: support isolation domains and offset grounds
 
   # these are here (instead of in VoltageSource) since the port may be on the other side of a bridge
   def as_digital_source(self) -> DigitalSource:
@@ -108,7 +105,10 @@ class VoltageBase(CircuitPort[VoltageLink]):
   def as_analog_source(self) -> AnalogSource:
     return self._convert(VoltageSinkAdapterAnalogSource())
 
+
 class VoltageSink(VoltageBase):
+  bridge_type = VoltageSinkBridge
+
   @staticmethod
   def from_gnd(gnd: VoltageSink, voltage_limits: RangeLike = Default(RangeExpr.ALL),
                current_draw: RangeLike = Default(RangeExpr.ZERO)) -> 'VoltageSink':
@@ -120,8 +120,6 @@ class VoltageSink(VoltageBase):
   def __init__(self, voltage_limits: RangeLike = Default(RangeExpr.ALL),
                current_draw: RangeLike = Default(RangeExpr.ZERO)) -> None:
     super().__init__()
-    self.bridge_type = VoltageSinkBridge
-
     self.voltage_limits: RangeExpr = self.Parameter(RangeExpr(voltage_limits))
     self.current_draw: RangeExpr = self.Parameter(RangeExpr(current_draw))
 
@@ -165,11 +163,11 @@ class VoltageSinkAdapterAnalogSource(CircuitPortAdapter['AnalogSource']):
 
 
 class VoltageSource(VoltageBase):
+  bridge_type = VoltageSourceBridge
+
   def __init__(self, voltage_out: RangeLike = Default(RangeExpr.EMPTY_ZERO),
                current_limits: RangeLike = Default(RangeExpr.ALL)) -> None:
     super().__init__()
-    self.bridge_type = VoltageSourceBridge
-
     self.voltage_out: RangeExpr = self.Parameter(RangeExpr(voltage_out))
     self.current_limits: RangeExpr = self.Parameter(RangeExpr(current_limits))
 


### PR DESCRIPTION
Small cleanup and optimizations, to reduce the compute needed for each block / port instantiation. No functional changes.

- Move `link_type`, `bridge_type`, and `not_connected_type` into class variables
- Move `self.description` into `contents`

