### PR TITLE
Parts cleanup

### DIFF
--- a/edg/BoardTop.py
+++ b/edg/BoardTop.py
@@ -38,6 +38,8 @@ class BaseBoardTop(DesignTop):
         (SwdCortexTargetWithSwoTdiConnector, SwdCortexTargetHeader),
 
         (SpiMemory, W25q),
+
+        (Speaker, ConnectorSpeaker),
       ], class_values=[
         (SmdStandardPackage, ['smd_min_package'], '0603'),
       ]

--- a/electronics_lib/Fpga_Ice40up.py
+++ b/electronics_lib/Fpga_Ice40up.py
@@ -180,9 +180,10 @@ class Ice40up_Device(PinMappable, BaseIoController, InternalSubcircuit, Generato
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
       (UartPort, uart_requests), (CanControllerPort, can_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -204,9 +204,10 @@ class Esp32_Wroom_32_Device(Esp32_Device, FootprintBlock, JlcPart):
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (SpiMaster, spi_requests), (I2cMaster, i2c_requests), (UartPort, uart_requests),
       (CanControllerPort, can_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 
@@ -317,9 +318,10 @@ class Esp32_Wrover_Dev_Device(Esp32_Device, FootprintBlock):
     system_pins: Dict[str, CircuitPort] = self.system_pinmaps.remap(self.SYSTEM_PIN_REMAP)
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (SpiMaster, spi_requests), (I2cMaster, i2c_requests), (UartPort, uart_requests),
       (CanControllerPort, can_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -180,9 +180,10 @@ class Lpc1549Base_Device(PinMappable, BaseIoController, InternalSubcircuit, Gene
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
       (UartPort, uart_requests), (CanControllerPort, can_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -192,9 +192,10 @@ class Rp2040_Device(PinMappable, BaseIoController, InternalSubcircuit, Generator
                usb_requests: List[str], can_requests: List[str], swd_connected: bool) -> None:
     allocated = self.pinmaps.allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
       (UartPort, uart_requests), (CanControllerPort, can_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -179,9 +179,10 @@ class Stm32f103Base_Device(PinMappable, BaseIoController, InternalSubcircuit, Ge
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
       (UartPort, uart_requests), (CanControllerPort, can_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -209,9 +209,10 @@ class Nucleo_F303k8(PinMappable, Microcontroller, BaseIoController, GeneratorBlo
 
     allocated = Stm32f303Base_Device.mappable_ios(self.gnd, self.pwr_3v3, self.pwr_3v3)\
       .remap_pins(self.RESOURCE_PIN_REMAP).allocate([
+        (AnalogSource, dac_requests), (AnalogSink, adc_requests),
         (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
         (UartPort, uart_requests), (CanControllerPort, can_requests),
-        (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+        (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -230,9 +230,10 @@ class Holyiot_18010_Device(Nrf52840Base_Device, FootprintBlock):
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
       (UartPort, uart_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 
@@ -340,9 +341,10 @@ class Mdbt50q_1mv2_Device(Nrf52840Base_Device, JlcPart, FootprintBlock):
 
     allocated = self.abstract_pinmaps.remap_pins(self.RESOURCE_PIN_REMAP).allocate([
       (SwdTargetPort, ['swd'] if swd_connected else []),
+      (AnalogSource, dac_requests), (AnalogSink, adc_requests),
       (UsbDevicePort, usb_requests), (SpiMaster, spi_requests), (I2cMaster, i2c_requests),
       (UartPort, uart_requests),
-      (AnalogSink, adc_requests), (AnalogSource, dac_requests), (DigitalBidir, gpio_requests),
+      (DigitalBidir, gpio_requests),
     ], assignments)
     self.generator_set_allocation(allocated)
 

--- a/electronics_lib/Neopixel.py
+++ b/electronics_lib/Neopixel.py
@@ -2,6 +2,7 @@ from electronics_abstract_parts import *
 from .JlcPart import JlcPart
 
 
+@abstract_block_default(lambda: Ws2812b)
 class Neopixel(Light, Block):
     """Abstract base class for Neopixel-type LEDs including the Vdd/Gnd/Din/Dout interface."""
     def __init__(self) -> None:

--- a/electronics_model/BomBackend.py
+++ b/electronics_model/BomBackend.py
@@ -20,7 +20,7 @@ class GenerateBom(BaseBackend):      # creates and populates .csv file
         bom_list = BomTransform(design).run()
 
         bom_string = io.StringIO()
-        csv_data = ['Id', 'Designator', 'Package', 'Quantity',
+        csv_data = ['Id', 'Designator', 'Footprint', 'Quantity',
                     'Designation', 'Supplier and Ref', 'JLCPCB Part #']  # populates headers
         writer = csv.writer(bom_string, lineterminator='\n', quoting=csv.QUOTE_MINIMAL)
         writer.writerow(csv_data)

--- a/examples/jlcpcb_pcba_postprocess.py
+++ b/examples/jlcpcb_pcba_postprocess.py
@@ -34,7 +34,10 @@ PART_ROTATIONS = {
   'C6568': -90,  # CP2102 USB UART
   'C190271': 180,  # SOT-23-6 93LC56 EEPROM
   'C73478': 180,  # SOT-23-5 LP5907 1.2v reg
+  'C80670': 180,  # SOT-23-5 LP5907 3.3v reg
   'C976032': -90,  # LGA-16 QMC5883L
+
+  'C650309': -90,  # AD5941
 }
 
 _FOOTPRINT_ROTATIONS = {
@@ -44,6 +47,8 @@ _FOOTPRINT_ROTATIONS = {
   'Package_TO_SOT_SMD:SOT-223-3_TabPin2': 180,
   'Package_SO:SOIC-8_3.9x4.9mm_P1.27mm': -90,
   'Package_SO:SOIC-8_5.23x5.23mm_P1.27mm': -90,
+
+  'Connector_Coaxial:BNC_Amphenol_B6252HB-NPP3G-50_Horizontal': 180,
 }
 
 # footprint position export doesn't include the footprint library name
@@ -54,6 +59,8 @@ PACKAGE_ROTATIONS = {footprint.split(':')[-1]: rot for footprint, rot in _FOOTPR
 _FOOTPRINT_OFFSETS = {
   'Connector_USB:USB_C_Receptacle_XKB_U262-16XN-4BVC11': (0, -1.25),
   'RF_Module:ESP32-WROOM-32': (0, 0.8),
+
+  'Connector_Coaxial:BNC_Amphenol_B6252HB-NPP3G-50_Horizontal': (0, -2.5),
 }
 PACKAGE_OFFSETS = {footprint.split(':')[-1]: offset for footprint, offset in _FOOTPRINT_OFFSETS.items()}
 


### PR DESCRIPTION
- When doing pin allocation, allocate the DAC first, then the ADC, since those are probably the most restrictive
- Add default implementation for abstract Neopixel, to the classic WS2812b
- BoM generation: use Package as column header, JLC seems to no longer accept Footprint
- Add default speaker implementation (to the connector-speaker)
- Add more corrections to the position postprocess script