### PR TITLE
Add packaging tests, support blocks defined in __main__

### DIFF
--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -43,8 +43,7 @@ jobs:
         pip install mypy mypy-protobuf types-protobuf types-Deprecated
         mypy --version
     - name: mypy
-      run: |
-        mypy --install-types .
+      run: mypy --install-types .
 
   unittest_latest_3_11:
     needs: pre_job
@@ -57,10 +56,26 @@ jobs:
         python-version: '3.11'
 
     - name: install dependencies
-      run: |
-        pip install -r requirements.txt
+      run: pip install -r requirements.txt
     - name: unittest
       run: python -m unittest discover
+
+  packagetest_latest_3_11:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.11'
+
+      - name: install dependencies
+        run: pip install -r requirements.txt
+      - name: package
+        run: python -m pip install .
+      - name: unittest
+        run: cd examples && python -m unittest test_blinky
 
   mypy_latest_3_9:
     needs: pre_job
@@ -77,8 +92,7 @@ jobs:
           pip install mypy mypy-protobuf types-protobuf types-Deprecated
           mypy --version
       - name: mypy
-        run: |
-          mypy --install-types .
+        run: mypy --install-types .
 
   unittest_latest_3_9:
     needs: pre_job
@@ -91,7 +105,6 @@ jobs:
           python-version: '3.9'
 
       - name: install dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
       - name: unittest
         run: python -m unittest discover

--- a/.github/workflows/pr-python.yml
+++ b/.github/workflows/pr-python.yml
@@ -76,6 +76,8 @@ jobs:
         run: python -m pip install .
       - name: unittest
         run: cd examples && python -m unittest test_blinky
+      - name: toptest
+        run: cd examples && python test_blinky.py
 
   mypy_latest_3_9:
     needs: pre_job

--- a/developing.md
+++ b/developing.md
@@ -59,6 +59,7 @@ Local:
 - Install in editable mode (package refers to this source directory, instead of making a copy): `python -m pip install -e .`
 
 Upload:
+- These dependencies are necessary: `python -m pip install build twine`
 - Build the package (creates a `dist` folder with a `.whl` (zipped) file): `python -m build`
 - Optionally, upload to TestPyPI: `twine upload -r testpypi dist/*`
 - Upload to PyPI: `twine upload dist/*`

--- a/developing.md
+++ b/developing.md
@@ -61,8 +61,8 @@ Local:
 Upload:
 - These dependencies are necessary: `python -m pip install build twine`
 - Build the package (creates a `dist` folder with a `.whl` (zipped) file): `python -m build`
-- Optionally, upload to TestPyPI: `twine upload -r testpypi dist/*`
-- Upload to PyPI: `twine upload dist/*`
+- Optionally, upload to TestPyPI: `python -m twine upload -r testpypi dist/*`
+- Upload to PyPI: `python -m twine upload dist/*`
 
 
 ## Frontend Architecture

--- a/developing.md
+++ b/developing.md
@@ -55,13 +55,14 @@ If you have not modified any of the .scala files, you do not need to recompile t
 ### Packaging
 Largely based on [this tutorial](https://realpython.com/pypi-publish-python-package/).
 
-Local
+Local:
 - Install in editable mode (package refers to this source directory, instead of making a copy): `python -m pip install -e .`
 
 Upload:
 - Build the package (creates a `dist` folder with a `.whl` (zipped) file): `python -m build`
 - Optionally, upload to TestPyPI: `twine upload -r testpypi dist/*`
 - Upload to PiPI: `twine upload dist/*`
+
 
 ## Frontend Architecture
 _Some documentation may be out of date._

--- a/developing.md
+++ b/developing.md
@@ -50,8 +50,18 @@ If you have not modified any of the .scala files, you do not need to recompile t
 1. [Download and install sbt](https://www.scala-sbt.org/download.html), a build tool or Scala.
 2. In the `compiler/` folder, run `sbt assembly` to compile the compiler JAR file.
    The system will automatically prefer the locally built JAR file over the pre-compiled JAR and indicate its use through the console.
-3. Optionally, to commit a new pre-compiled JAR, move the newly compiled JAR from `compiler/target/scala-*/edg-compiler-assembly-*-SNAPSHOT.jar` to `compiler/edg-compiler-precompiled.jar`.
+3. Optionally, to commit a new pre-compiled JAR, move the newly compiled JAR from `compiler/target/scala-*/edg-compiler-assembly-*-SNAPSHOT.jar` to `edg_core/resources/edg-compiler-precompiled.jar`.
 
+### Packaging
+Largely based on [this tutorial](https://realpython.com/pypi-publish-python-package/).
+
+Local
+- Install in editable mode (package refers to this source directory, instead of making a copy): `python -m pip install -e .`
+
+Upload:
+- Build the package (creates a `dist` folder with a `.whl` (zipped) file): `python -m build`
+- Optionally, upload to TestPyPI: `twine upload -r testpypi dist/*`
+- Upload to PiPI: `twine upload dist/*`
 
 ## Frontend Architecture
 _Some documentation may be out of date._

--- a/developing.md
+++ b/developing.md
@@ -61,7 +61,7 @@ Local:
 Upload:
 - Build the package (creates a `dist` folder with a `.whl` (zipped) file): `python -m build`
 - Optionally, upload to TestPyPI: `twine upload -r testpypi dist/*`
-- Upload to PiPI: `twine upload dist/*`
+- Upload to PyPI: `twine upload dist/*`
 
 
 ## Frontend Architecture

--- a/edg_core/Core.py
+++ b/edg_core/Core.py
@@ -227,7 +227,16 @@ class LibraryElement(Refable, metaclass=ElementMeta):
   def _static_def_name(cls) -> str:
     """If this library element is defined by class (all instances have an equivalent library definition),
     returns the definition name. Otherwise, should crash."""
-    return cls.__module__ + "." + cls.__name__
+    if cls.__module__ == "__main__":
+      # when the top-level design is run as main, the module name is __main__ which is meaningless
+      # and breaks when the HDL server tries to resolve the __main__ reference (to itself),
+      # so this needs to resolve the correct name
+      import inspect
+      import os
+      module = os.path.splitext(os.path.basename(inspect.getfile(cls)))[0]
+    else:
+      module = cls.__module__
+    return module + "." + cls.__name__
 
   def _get_def_name(self) -> str:
     """Returns the definition name"""

--- a/edg_core/Util.py
+++ b/edg_core/Util.py
@@ -28,4 +28,3 @@ def edg_to_dict(obj: Union[BasePort, BaseBlock]) -> Dict[str, Any]:
       }
   else:
     raise ValueError
-

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -445,3 +445,13 @@ class BlinkyTestCase(unittest.TestCase):
 
   def test_design_packed(self) -> None:
     compile_board_inplace(TestBlinkyPacked, False)
+
+
+if __name__ == "__main__":
+  # this unit test can also be run as __main__ to test a non-unit-test environment
+  compile_board_inplace(TestBlinkyEmpty, False)
+  compile_board_inplace(TestBlinkyComplete, False)
+  compile_board_inplace(TestBlinkyWithLibrary, False)
+  compile_board_inplace(TestBlinkyWithLibraryExport, False)
+  compile_board_inplace(TestBlinkyArray, False)
+  compile_board_inplace(TestBlinkyPacked, False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "edg"
-version = "0.0.0"
+version = "0.0.1"
 description = "Hardware description language for circuit boards"
 readme = "README.md"
 authors = [{ name = "Ducky", email = "richard.lin@berkeley.edu" }]


### PR DESCRIPTION
Add local packaging run to workflow tests, with an abbreviated (blinky-only) unittest and top-level test.

Resolves #251, where blocks defined in `__main__` cause an error when the HDL server tries to resolve those blocks, because the HDL server is a separate Python instance and thinks itself is `__main__` (instead of the original file). The fix is to detect when a library's module is `__main__` and effectively guess the correct original module name by using the filename. Might be a better way to do it, but this works, and is largely what a websearch turned out for finding the original module name for `__main__`.

Bumps the package version since this is a significant bugfix.
