### PR TITLE
Don't include non_library parts in superclasses

### DIFF
--- a/edg_hdl_server/__main__.py
+++ b/edg_hdl_server/__main__.py
@@ -53,6 +53,9 @@ class LibraryElementIndexer:
 LibraryElementType = TypeVar('LibraryElementType', bound=LibraryElement)
 def elaborate_class(elt_cls: Type[LibraryElementType]) -> Tuple[LibraryElementType, edgir.Library.NS.Val]:
   obj = elt_cls()
+  assert (elt_cls, NonLibraryProperty) not in elt_cls._elt_properties.keys(), \
+    f"tried to elaborate non-library {elt_cls.__name__}"
+
   if isinstance(obj, Block):
     block_proto = builder.elaborate_toplevel(obj)
     return obj, edgir.Library.NS.Val(hierarchy_block=block_proto)  # type: ignore


### PR DESCRIPTION
Also adds an assertion guard in case a non_library element tries to elaborate, the overall idea is that non_library parts behave as if they don't exist from a compilation standpoint