### PR TITLE
Continue refactoring to use mixins

### DIFF
--- a/electronics_abstract_parts/AbstractLedDriver.py
+++ b/electronics_abstract_parts/AbstractLedDriver.py
@@ -1,0 +1,33 @@
+from electronics_abstract_parts import *
+
+
+@abstract_block
+class LedDriver(PowerConditioner, Interface):
+    """Abstract current-regulated high-power LED driver.
+    LED ports are passive and should be directly connected to the LED (or LED string)."""
+    @init_in_parent
+    def __init__(self, max_current: RangeLike):
+        super().__init__()
+
+        self.pwr = self.Port(VoltageSink.empty(), [Power])
+        self.gnd = self.Port(Ground.empty(), [Common])
+
+        self.leda = self.Port(Passive())
+        self.ledk = self.Port(Passive())
+
+        self.max_current = self.ArgParameter(max_current)
+
+
+class LedDriverSwitchingConverter(BlockInterfaceMixin[LedDriver]):
+    """LED driver mixin indicating that the LED driver is a switching converter and with a peak-peak ripple limit."""
+    @init_in_parent
+    def __init__(self, *args, ripple_limit: FloatLike = float('inf'), **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ripple_limit = self.ArgParameter(ripple_limit)
+
+
+class LedDriverPwm(BlockInterfaceMixin[LedDriver]):
+    """LED driver mixin with PWM input for dimming control."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pwm = self.Port(DigitalSink.empty(), optional=True)

--- a/electronics_abstract_parts/IdealIoController.py
+++ b/electronics_abstract_parts/IdealIoController.py
@@ -1,0 +1,68 @@
+from electronics_model import *
+from .Categories import IdealModel
+from .IoController import IoController
+from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s
+
+
+class IdealIoController(IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, IoController, IdealModel,
+                        GeneratorBlock):
+    """An ideal IO controller, with as many IOs as requested.
+    Output have voltages at pwr/gnd, all other parameters are ideal."""
+    def __init__(self) -> None:
+        super().__init__()
+        self.generator_param(self.adc.requested(), self.dac.requested(), self.gpio.requested(), self.spi.requested(),
+                             self.i2c.requested(), self.uart.requested(), self.usb.requested(), self.can.requested(),
+                             self.i2s.requested())
+
+    def generate(self) -> None:
+        self.pwr.init_from(VoltageSink(
+            current_draw=RangeExpr()
+        ))
+        self.gnd.init_from(Ground())
+
+        io_current_draw_builder = RangeExpr._to_expr_type(RangeExpr.ZERO)
+
+        self.adc.defined()
+        for elt in self.get(self.adc.requested()):
+            self.adc.append_elt(AnalogSink(), elt)
+        self.dac.defined()
+        for elt in self.get(self.dac.requested()):
+            aout = self.dac.append_elt(AnalogSource(
+                voltage_out=self.gnd.link().voltage.hull(self.pwr.link().voltage)
+            ), elt)
+            io_current_draw_builder = io_current_draw_builder + (
+                aout.link().current_drawn.lower().min(0), aout.link().current_drawn.upper().max(0)
+            )
+
+        dio_model = DigitalBidir(
+            voltage_out=self.gnd.link().voltage.hull(self.pwr.link().voltage),
+            pullup_capable=True, pulldown_capable=True
+        )
+
+        self.gpio.defined()
+        for elt in self.get(self.gpio.requested()):
+            dio = self.gpio.append_elt(dio_model, elt)
+            io_current_draw_builder = io_current_draw_builder + (
+                dio.link().current_drawn.lower().min(0), dio.link().current_drawn.upper().max(0)
+            )
+
+        self.spi.defined()
+        for elt in self.get(self.spi.requested()):
+            self.spi.append_elt(SpiMaster(dio_model), elt)
+        self.i2c.defined()
+        for elt in self.get(self.i2c.requested()):
+            self.i2c.append_elt(I2cMaster(dio_model), elt)
+        self.uart.defined()
+        for elt in self.get(self.uart.requested()):
+            self.uart.append_elt(UartPort(dio_model), elt)
+        self.usb.defined()
+        for elt in self.get(self.usb.requested()):
+            self.usb.append_elt(UsbDevicePort(), elt)
+        self.can.defined()
+        for elt in self.get(self.can.requested()):
+            self.can.append_elt(CanControllerPort(dio_model), elt)
+        self.i2s.defined()
+        for elt in self.get(self.i2s.requested()):
+            self.i2s.append_elt(I2sController(dio_model), elt)
+
+        self.assign(self.pwr.current_draw, io_current_draw_builder)

--- a/electronics_abstract_parts/IoControllerInterfaceMixins.py
+++ b/electronics_abstract_parts/IoControllerInterfaceMixins.py
@@ -2,12 +2,36 @@ from electronics_model import *
 from .IoController import BaseIoController, IoController
 
 
+class IoControllerDac(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.dac = self.Port(Vector(AnalogSource.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.insert(0, self.dac))  # allocate first
+
+
+class IoControllerCan(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.can = self.Port(Vector(CanControllerPort.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.append(self.can))
+
+
+class IoControllerUsb(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.usb = self.Port(Vector(UsbDevicePort.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.append(self.usb))
+
+
 class IoControllerI2s(BlockInterfaceMixin[BaseIoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         self.i2s = self.Port(Vector(I2sController.empty()), optional=True)
-        self.implementation(lambda base: base._io_ports.insert(0, self.i2s))
+        self.implementation(lambda base: base._io_ports.append(self.i2s))
 
 
 class IoControllerDvp8(BlockInterfaceMixin[BaseIoController]):
@@ -15,7 +39,7 @@ class IoControllerDvp8(BlockInterfaceMixin[BaseIoController]):
         super().__init__(*args, **kwargs)
 
         self.dvp8 = self.Port(Vector(Dvp8Host.empty()), optional=True)
-        self.implementation(lambda base: base._io_ports.insert(0, self.dvp8))
+        self.implementation(lambda base: base._io_ports.append(self.dvp8))
 
 
 class IoControllerWifi(BlockInterfaceMixin[BaseIoController]):

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -76,7 +76,9 @@ from .UsbBitBang import UsbBitBang
 
 from .IoController import BaseIoController, IoController, IoControllerPowerRequired
 from .IoController import BaseIoControllerPinmapGenerator, BaseIoControllerExportable
-from .IoControllerInterfaceMixins import IoControllerI2s, IoControllerDvp8, IoControllerPowerOut, IoControllerUsbOut
+from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, \
+    IoControllerDvp8
+from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut
 from .IoControllerInterfaceMixins import IoControllerWifi, IoControllerBluetooth, IoControllerBle
 from .IoControllerProgramming import IoControllerWithSwdTargetConnector
 from .IoControllerMixins import WithCrystalGenerator

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -58,6 +58,7 @@ from .AbstractPowerConverters import VoltageRegulator, VoltageRegulatorEnable, V
 from .AbstractPowerConverters import LinearRegulator, VoltageReference, LinearRegulatorDevice, SwitchingVoltageRegulator
 from .AbstractPowerConverters import BuckConverter, DiscreteBuckConverter, BoostConverter, DiscreteBoostConverter
 from .AbstractPowerConverters import BuckConverterPowerPath, BoostConverterPowerPath, BuckBoostConverterPowerPath
+from .AbstractLedDriver import LedDriver, LedDriverPwm, LedDriverSwitchingConverter
 from .AbstractFuse import Fuse, PptcFuse, FuseStandardFootprint, TableFuse, SeriesPowerPptcFuse
 from .AbstractCrystal import Crystal, TableCrystal, OscillatorReference, CeramicResonator
 from .AbstractOscillator import Oscillator, TableOscillator

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -7,8 +7,8 @@ from .Microcontroller_Esp import HasEspProgramming
 
 
 @non_library
-class Esp32_Interfaces(IoControllerDvp8, IoControllerI2s, IoControllerWifi, IoControllerBle, IoControllerBluetooth,
-                       BaseIoController):
+class Esp32_Interfaces(IoControllerDac, IoControllerCan, IoControllerDvp8, IoControllerI2s, IoControllerWifi,
+                       IoControllerBle, IoControllerBluetooth, BaseIoController):
   """Defines base interfaces for ESP32 microcontrollers"""
 
 

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -7,7 +7,8 @@ from .Microcontroller_Esp import HasEspProgramming
 
 
 @non_library
-class Esp32s3_Interfaces(IoControllerDvp8, IoControllerI2s, IoControllerWifi, IoControllerBle, BaseIoController):
+class Esp32s3_Interfaces(IoControllerCan, IoControllerUsb, IoControllerI2s, IoControllerDvp8, IoControllerWifi,
+                         IoControllerBle, BaseIoController):
   """Defines base interfaces for ESP32S3 microcontrollers"""
 
 

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -5,7 +5,8 @@ from .JlcPart import JlcPart
 
 
 @abstract_block
-class Lpc1549Base_Device(BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock):
+class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, BaseIoControllerPinmapGenerator,
+                         InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock):
   PACKAGE: str  # package name for footprint(...)
   PART: str  # part name for footprint(...)
   LCSC_PART: str
@@ -325,7 +326,8 @@ class Lpc1549SwdPull(InternalSubcircuit, Block):
 
 
 @abstract_block
-class Lpc1549Base(Microcontroller, IoControllerWithSwdTargetConnector, WithCrystalGenerator, IoControllerPowerRequired,
+class Lpc1549Base(IoControllerDac, IoControllerCan, IoControllerUsb, Microcontroller,
+                  IoControllerWithSwdTargetConnector, WithCrystalGenerator, IoControllerPowerRequired,
                   BaseIoControllerExportable):
   DEVICE: Type[Lpc1549Base_Device] = Lpc1549Base_Device  # type: ignore
   DEFAULT_CRYSTAL_FREQUENCY = 12*MHertz(tol=0.005)

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -4,7 +4,8 @@ from electronics_abstract_parts import *
 from .JlcPart import JlcPart
 
 
-class Rp2040_Device(BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock):
+class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, JlcPart,
+                    FootprintBlock):
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
@@ -218,8 +219,8 @@ class Rp2040Usb(InternalSubcircuit, Block):
       UsbBitBang.digital_external_from_link(self.usb_rp.dp)))
 
 
-class Rp2040(Microcontroller, IoControllerWithSwdTargetConnector, WithCrystalGenerator, IoControllerPowerRequired,
-             BaseIoControllerExportable):
+class Rp2040(IoControllerUsb, Microcontroller, IoControllerWithSwdTargetConnector, WithCrystalGenerator,
+             IoControllerPowerRequired, BaseIoControllerExportable):
   DEFAULT_CRYSTAL_FREQUENCY = 12*MHertz(tol=0.005)
 
   def __init__(self, **kwargs):

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -5,7 +5,8 @@ from .JlcPart import JlcPart
 
 
 @abstract_block
-class Stm32f103Base_Device(InternalSubcircuit, BaseIoControllerPinmapGenerator, GeneratorBlock, JlcPart, FootprintBlock):
+class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit, BaseIoControllerPinmapGenerator,
+                           GeneratorBlock, JlcPart, FootprintBlock):
   PACKAGE: str  # package name for footprint(...)
   PART: str  # part name for footprint(...)
   LCSC_PART: str
@@ -252,8 +253,8 @@ class UsbDpPullUp(InternalSubcircuit, Block):
 
 
 @abstract_block
-class Stm32f103Base(Microcontroller, IoControllerWithSwdTargetConnector, WithCrystalGenerator,
-                    IoControllerPowerRequired, BaseIoControllerExportable):
+class Stm32f103Base(IoControllerCan, IoControllerUsb, Microcontroller, IoControllerWithSwdTargetConnector,
+                    WithCrystalGenerator, IoControllerPowerRequired, BaseIoControllerExportable):
   DEVICE: Type[Stm32f103Base_Device] = Stm32f103Base_Device  # type: ignore
   DEFAULT_CRYSTAL_FREQUENCY = 12*MHertz(tol=0.005)
 

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -5,7 +5,7 @@ from electronics_abstract_parts import *
 
 
 @abstract_block
-class Stm32f303_Ios(BaseIoControllerPinmapGenerator):
+class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGenerator):
   """Base class for STM32F303 devices.
   Unlike other microcontrollers, this one also supports dev boards (Nucleo-32) which can be
   a power source, so there's a bit more complexity here."""

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -6,7 +6,7 @@ from .JlcPart import JlcPart
 
 
 @non_library
-class Nrf52840_Interfaces(IoControllerI2s, IoControllerBle, BaseIoController):
+class Nrf52840_Interfaces(IoControllerUsb, IoControllerI2s, IoControllerBle, BaseIoController):
   """Defines base interfaces for nRF52840 microcontrollers"""
 
 

--- a/electronics_lib/__init__.py
+++ b/electronics_lib/__init__.py
@@ -63,7 +63,8 @@ from .Microcontroller_Lpc1549 import Lpc1549_48, Lpc1549_64
 from .Microcontroller_Stm32f103 import Stm32f103_48
 from .Microcontroller_Stm32f303 import Nucleo_F303k8
 from .Microcontroller_nRF52840 import Holyiot_18010, Mdbt50q_1mv2, Feather_Nrf52840
-from .Microcontroller_Esp import EspAutoProgrammingHeader, EspProgrammingPins, EspProgrammingTc2030, HasEspProgramming
+from .Microcontroller_Esp import EspProgrammingHeader, EspProgrammingAutoReset, EspProgrammingPinHeader254, EspProgrammingTc2030
+from .Microcontroller_Esp import HasEspProgramming
 from .Microcontroller_Esp import EspAutoProgram
 from .Microcontroller_Esp32 import Esp32_Wroom_32, Freenove_Esp32_Wrover
 from .Microcontroller_Esp32s3 import Esp32s3_Wroom_1, Freenove_Esp32s3_Wroom

--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -30,8 +30,10 @@ class CanAdapter(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
-      (self.xcvr, ), self.can_chain = self.chain(self.mcu.can.request('can'), imp.Block(Iso1050dub()))
+      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()),
+                                       self.mcu.with_mixin(IoControllerUsb()).usb.request())
+      (self.xcvr, ), self.can_chain = self.chain(self.mcu.with_mixin(IoControllerCan()).can.request('can'),
+                                                 imp.Block(Iso1050dub()))
 
       (self.sw_usb, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw_usb'))
       (self.sw_can, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw_can'))

--- a/examples/test_datalogger.py
+++ b/examples/test_datalogger.py
@@ -51,9 +51,10 @@ class Datalogger(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      self.connect(self.mcu.usb.request(), self.usb_conn.usb)
+      self.connect(self.mcu.with_mixin(IoControllerUsb()).usb.request(), self.usb_conn.usb)
 
-      (self.can, ), _ = self.chain(self.mcu.can.request('can'), imp.Block(CalSolCanBlock()))
+      (self.can, ), _ = self.chain(self.mcu.with_mixin(IoControllerCan()).can.request('can'),
+                                   imp.Block(CalSolCanBlock()))
 
       # TODO need proper support for exported unconnected ports
       self.can_gnd_load = self.Block(DummyVoltageSink())

--- a/examples/test_fcml.py
+++ b/examples/test_fcml.py
@@ -345,7 +345,7 @@ class Fcml(JlcBoardTop):
       (self.mcu_leds, ), _ = self.chain(self.mcu.gpio.request_vector('led'), imp.Block(IndicatorLedArray(4)))
 
       (self.usb_mcu_esd, ), self.usb_mcu_chain = self.chain(
-        self.mcu.usb.request('usb'), imp.Block(UsbEsdDiode()), self.usb_mcu.usb)
+        self.mcu.with_mixin(IoControllerUsb()).usb.request('usb'), imp.Block(UsbEsdDiode()), self.usb_mcu.usb)
 
       self.tp_fpga = ElementDict[DigitalTestPoint]()
       for i in range(4):

--- a/examples/test_high_switch.py
+++ b/examples/test_high_switch.py
@@ -265,7 +265,8 @@ class HighSwitch(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.can, ), self.can_chain = self.chain(self.mcu.can.request('can'), imp.Block(CalSolCanBlock()))
+      (self.can, ), self.can_chain = self.chain(self.mcu.with_mixin(IoControllerCan()).can.request('can'),
+                                                imp.Block(CalSolCanBlock()))
 
       # TODO need proper support for exported unconnected ports
       self.can_gnd_load = self.Block(DummyVoltageSink())

--- a/examples/test_iot_display.py
+++ b/examples/test_iot_display.py
@@ -62,7 +62,8 @@ class IotDisplay(JlcBoardTop):
       self.mcu.with_mixin(IoControllerWifi())
 
       # need to name the USB chain so the USB net has the _N and _P postfix for differential traces
-      (self.usb_esd, ), self.usb_chain = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+      (self.usb_esd, ), self.usb_chain = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()),
+                                                    self.mcu.with_mixin(IoControllerUsb()).usb.request())
 
       (self.ledr, ), _ = self.chain(imp.Block(IndicatorLed(Led.Red)), self.mcu.gpio.request('ledr'))
       (self.ledg, ), _ = self.chain(imp.Block(IndicatorLed(Led.Green)), self.mcu.gpio.request('ledg'))

--- a/examples/test_iot_display.py
+++ b/examples/test_iot_display.py
@@ -115,7 +115,7 @@ class IotDisplay(JlcBoardTop):
         (['pwr_or', 'diode', 'part'], 'B5819W SL'),  # autopicked one is OOS
       ],
       class_refinements=[
-        (EspAutoProgrammingHeader, EspProgrammingTc2030),
+        (EspProgrammingHeader, EspProgrammingTc2030),
         (TestPoint, CompactKeystone5015),
         (Fpc050Bottom, Fpc050BottomFlip),
       ],

--- a/examples/test_iot_fan.py
+++ b/examples/test_iot_fan.py
@@ -124,7 +124,7 @@ class IotFan(JlcBoardTop):
         (['fan_drv[1]', 'drv', 'part'], ParamValue(['fan_drv[0]', 'drv', 'part'])),
       ],
       class_refinements=[
-        (EspAutoProgrammingHeader, EspProgrammingTc2030),
+        (EspProgrammingHeader, EspProgrammingTc2030),
         (PowerBarrelJack, Pj_036ah),
         (Neopixel, Sk6805_Ec15),
         (TestPoint, CompactKeystone5015),

--- a/examples/test_iot_knob.py
+++ b/examples/test_iot_knob.py
@@ -47,7 +47,8 @@ class IotKnob(JlcBoardTop):
         imp.Block(I2cPullup()), imp.Block(I2cTestPoint()))
 
       # need to name the USB chain so the USB net has the _N and _P postfix for differential traces
-      (self.usb_esd, ), self.usb_chain = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+      (self.usb_esd, ), self.usb_chain = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()),
+                                                    self.mcu.with_mixin(IoControllerUsb()).usb.request())
 
       # debugging LEDs
       (self.ledr, ), _ = self.chain(imp.Block(IndicatorLed(Led.Red)), self.mcu.gpio.request('ledr'))

--- a/examples/test_iot_knob.py
+++ b/examples/test_iot_knob.py
@@ -145,7 +145,7 @@ class IotKnob(JlcBoardTop):
         (['mcu', 'programming'], 'uart-auto'),
       ],
       class_refinements=[
-        (EspAutoProgrammingHeader, EspProgrammingTc2030),
+        (EspProgrammingHeader, EspProgrammingTc2030),
         (Neopixel, Sk6805_Ec15),
         (Speaker, ConnectorSpeaker),
         (PassiveConnector, JstPhKVertical),  # default connector series unless otherwise specified

--- a/examples/test_robotcrawler.py
+++ b/examples/test_robotcrawler.py
@@ -186,7 +186,7 @@ class RobotCrawler(RobotCrawlerSpec, JlcBoardTop):
         (['mcu', 'programming'], 'uart-auto')
       ],
       class_refinements=[
-        (EspAutoProgrammingHeader, EspProgrammingTc2030),
+        (EspProgrammingHeader, EspProgrammingTc2030),
         (Neopixel, Sk6805_Ec15),
         (TestPoint, CompactKeystone5015),
       ],

--- a/examples/test_robotdriver.py
+++ b/examples/test_robotdriver.py
@@ -124,7 +124,7 @@ class RobotDriver(JlcBoardTop):
             ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       (self.spk_tp, self.spk_drv, self.spk), self.spk_chain = self.chain(
-        self.mcu.dac.request('spk'),
+        self.mcu.with_mixin(IoControllerDac()).dac.request('spk'),
         self.Block(AnalogTestPoint()),
         imp.Block(Tpa2005d1(gain=Range.from_tolerance(10, 0.2))),
         self.Block(Speaker()))

--- a/examples/test_seven_segment.py
+++ b/examples/test_seven_segment.py
@@ -121,7 +121,7 @@ class SevenSegment(JlcBoardTop):
         (['mcu', 'programming'], 'uart-auto')
       ],
       class_refinements=[
-        (EspAutoProgrammingHeader, EspProgrammingTc2030),
+        (EspProgrammingHeader, EspProgrammingTc2030),
         (Neopixel, Sk6805_Ec15),
         (Switch, Skrtlae010),
         (Speaker, ConnectorSpeaker),

--- a/examples/test_simon.py
+++ b/examples/test_simon.py
@@ -48,7 +48,7 @@ class Simon(BoardTop):
         ImplicitConnect(self.gnd, [Common]),
     ) as imp:
       (self.spk_drv, self.spk), _ = self.chain(
-        self.mcu.dac.request('spk'),
+        self.mcu.with_mixin(IoControllerDac()).dac.request('spk'),
         imp.Block(Lm4871()),
         self.Block(Speaker()))
 

--- a/examples/test_swd_debugger.py
+++ b/examples/test_swd_debugger.py
@@ -112,7 +112,8 @@ class SwdDebugger(JlcBoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.usb_esd, ), self.usb_chain = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+      (self.usb_esd, ), self.usb_chain = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()),
+                                                    self.mcu.with_mixin(IoControllerUsb()).usb.request())
 
       (self.led_tgt, ), _ = self.chain(self.mcu.gpio.request(f'led_target'),
                                        imp.Block(IndicatorLed(Led.Yellow)))

--- a/examples/test_tofarray.py
+++ b/examples/test_tofarray.py
@@ -77,10 +77,11 @@ class TofArray(JlcBoardTop):
       self.connect(self.mcu.gpio.request_vector('tof_xshut'), self.tof.xshut)
 
       (self.usb_esd, ), self.usb_chain = self.chain(
-        self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+        self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.with_mixin(IoControllerUsb()).usb.request())
 
       (self.tp_can, self.xcvr, self.can_esd), self.can_chain = self.chain(
-        self.mcu.can.request('can'), imp.Block(CanControllerTestPoint()),
+        self.mcu.with_mixin(IoControllerCan()).can.request('can'),
+        imp.Block(CanControllerTestPoint()),
         imp.Block(Sn65hvd230()), imp.Block(CanEsdDiode()), self.can.differential
       )
 

--- a/examples/test_usb_source_measure.py
+++ b/examples/test_usb_source_measure.py
@@ -322,7 +322,8 @@ class UsbSourceMeasure(JlcBoardTop):
 
       self.mcu = imp.Block(IoController())
 
-      (self.usb_esd, ), _ = self.chain(self.data_usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+      (self.usb_esd, ), _ = self.chain(self.data_usb.usb, imp.Block(UsbEsdDiode()),
+                                       self.mcu.with_mixin(IoControllerUsb()).usb.request())
 
       (self.i2c_pull, ), _ = self.chain(self.mcu.i2c.request(), imp.Block(I2cPullup()), self.pd.i2c)
       self.connect(self.mcu.gpio.request('pd_int'), self.pd.int)


### PR DESCRIPTION
- Create abstract LedDriver class, refactor Al8861 to inherit this and its mixins
- Break out USB, CAN, DAC from abstract IoController
- IdealIoController now implements I2S (in addition to the other mixins)
- Refactor ESP auto-programming header to be a mixin