### PR TITLE
Recursively resolve refinements

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -544,7 +544,10 @@ class Compiler private (
     // apply the user-specified refinement, then recurse with class-based and block-side default refinements
     var refinementLibraryPath = refinements.instanceRefinements.get(path) // None if no refinement
     var blockLibraryPath = refinementLibraryPath.getOrElse(block.target) // always contains a value
-    var libraryBlockPb = library.getBlock(block.target, block.mixins) match { // mixins only apply pre-refinement
+    var libraryBlockPb = (refinementLibraryPath match {
+      case None => library.getBlock(block.target, block.mixins) // mixins only apply pre-refinement
+      case Some(refinementLibraryPath) => library.getBlock(refinementLibraryPath)
+    }) match {
       case Errorable.Success(blockPb) => blockPb
       case Errorable.Error(err) =>
         errors += CompilerError.LibraryError(path, blockLibraryPath, err)
@@ -570,7 +573,7 @@ class Compiler private (
         } else {
           refinementLibraryPath = Some(nextPath)
           blockLibraryPath = nextPath
-          libraryBlockPb = library.getBlock(blockLibraryPath, block.mixins) match {
+          libraryBlockPb = library.getBlock(blockLibraryPath) match {
             case Errorable.Success(blockPb) => blockPb
             case Errorable.Error(err) =>
               errors += CompilerError.LibraryError(path, blockLibraryPath, err)

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -531,9 +531,8 @@ class Compiler private (
     }
   }
 
-  // Recursively resolves the refined library, accounting for class refinements and default refinements.
+  // Recursively resolves the refined library, accounting for instance, class, and default refinements.
   // Returns none of no further refinement is specified.
-  // Instance refinements must be handled beforehand
   protected def resolveRefinementLibrary(
       path: DesignPath,
       blockLibrary: ref.LibraryPath,

--- a/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
@@ -340,6 +340,12 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
   }
 
   "Compiler on design with chained (default + class) refinement" should "work" in {
+    val blockDefaultInputDesign = Design(Block.Block(
+      "topDesign",
+      blocks = SeqMap(
+        "block" -> Block.Library("superclassDefaultBlock"),
+      )
+    ))
     val expected = Design(Block.Block(
       "topDesign",
       blocks = SeqMap(
@@ -359,7 +365,7 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
       )
     ))
     testCompile(
-      inputDesign,
+      blockDefaultInputDesign,
       library,
       refinements = Refinements(
         classRefinements = Map(LibraryPath("subclassBlock") -> LibraryPath("subsubclassBlock"))

--- a/examples/test_robotowl.py
+++ b/examples/test_robotowl.py
@@ -143,7 +143,7 @@ class RobotOwl(JlcBoardTop):
         (['reg_12v', 'power_path', 'inductor', 'manual_frequency_rating'], Range(0, 7e6)),
       ],
       class_refinements=[
-        (PassiveConnector, PinHeader254Horizontal),  # default connector series unless otherwise specified
+        (PassiveConnector, PinHeader254),  # default connector series unless otherwise specified
         (PinHeader254, PinHeader254Horizontal),
         (TestPoint, CompactKeystone5015),
         (Speaker, ConnectorSpeaker),

--- a/examples/test_switch_controller.py
+++ b/examples/test_switch_controller.py
@@ -90,7 +90,7 @@ class SwitchController(JlcBoardTop):
         (['mcu'], Esp32_Wroom_32),
         (['reg_3v3'], Ld1117),
 
-        (['conn', 'conn'], PinHeader254Vertical),
+        (['conn', 'conn'], PinHeader254),
       ],
       instance_values=[
         (['mcu', 'pin_assigns'], [

--- a/examples/test_usb_uart.py
+++ b/examples/test_usb_uart.py
@@ -64,7 +64,7 @@ class UsbUart(JlcBoardTop):
   def refinements(self) -> Refinements:
     return super().refinements() + Refinements(
       instance_refinements=[
-        (['out', 'conn'], PinHeader254Vertical),
+        (['out', 'conn'], PinHeader254),
         (['reg_3v3'], Ap2204k),
       ],
       instance_values=[


### PR DESCRIPTION
Class refinements and block-based default can now chain, eg PassiveHeader -> PinConnector254 and PinConnector254 -> PinConnector254Vertical will result in PassiveHeader -> PinConnector254Vertical.