### PR TITLE
Connect refactor: incremental connect, support connect joins

### DIFF
--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -247,7 +247,7 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
     self._required_ports = IdentitySet[BasePort]()
     self._connects = self.manager.new_dict(Connection, anon_prefix='anon_link')
     self._connects_by_port = IdentityDict[BasePort, Connection]()  # port -> connection
-    self._connects_delegated = IdentityDict[Connection, Connection]()  # for net joins, prior connect -> joined connect
+    self._connects_delegated = IdentityDict[Connection, List[Connection]]()  # for net joins, joined connect -> prior connects
     self._constraints: SubElementDict[ConstraintExpr] = self.manager.new_dict(ConstraintExpr, anon_prefix='anon_constr')  # type: ignore
 
     self._name = StringExpr()._bind(NameBinding(self))
@@ -519,7 +519,7 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
         connect.add_ports(merge_connect.ports)
         for port in merge_connect.ports:
           self._connects_by_port.update(port, connect)
-        self._connects_delegated[merge_connect] = connect
+        self._connects_delegated.setdefault(connect, []).append(merge_connect)
 
     for port in connects_ports_new:
       if port._block_parent() is not self:

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -124,7 +124,7 @@ class Connection():
           raise UnconnectableError(f"Can't connect array and non-array ports without flattening")
 
       # allocate the connection
-      if port.link_type is not type(link):
+      if self._baseport_leaf_type(port).link_type is not type(link):
         raise UnconnectableError(f"Can't connect {port._name_from(self.parent)} to link of type {type(link)}")
       port_type = type(self._baseport_leaf_type(port))
       allocatable_link_ports = self.available_link_ports_by_type.get(port_type, None)

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -72,6 +72,7 @@ class Connection():
 
   def add_ports(self, ports: Iterable[BasePort]):
     from .HierarchyBlock import Block
+    from .Link import Link
 
     self.ports.extend(ports)
     if len(self.ports) < 2:
@@ -106,11 +107,13 @@ class Connection():
         if port._block_parent() is self.parent:
           if port._get_initializers([]):
             raise UnconnectableError(f"Connected boundary port {port._name_from(self.parent)} may not have initializers")
+          if not isinstance(port, Port):
+            raise UnconnectableError(f"Can't generate bridge for non-Port {port._name_from(self.parent)}")
 
           bridge = port._bridge()
           if bridge is None:
             raise UnconnectableError(f"No bridge for {port._name_from(self.parent)}")
-          self.bridged_ports[port] = bridge
+          self.bridged_ports[port] = bridge.outer_port
         else:
           pass  # no bridge needed
       elif isinstance(self.parent, Link):  # links don't bridge, all ports are treated as internal

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -75,8 +75,13 @@ class Connection():
     from .Link import Link
 
     self.ports.extend(ports)
-    if len(self.ports) < 2:
-      return  # only one port, not a connection yet
+    if len(self.ports) < 1:
+      return  # empty connection, doesn't exist
+
+    port0 = self.ports[0]  # first port is special, eg to determine link type
+    if len(self.ports) == 1:
+      if not (self.flatten and isinstance(port0, BaseVector)):  # flatten can result in multiple connections
+        return  # single element connection, can be a naming operation
     elif len(self.ports) == 2:
       is_export = self._is_export()
       if is_export:
@@ -87,7 +92,6 @@ class Connection():
 
     # otherwise, is a link-mediated connection
     if self.link_instance is None:  # if link not yet defined, create using the first port as authoritative
-      port0 = self.ports[0]  # first port is special, eg to determine link type
       ports_to_connect: Iterable[BasePort] = self.ports  # new link, need to allocate all ports
       # initialize mutable state
       link_type = self._baseport_leaf_type(port0).link_type
@@ -147,8 +151,13 @@ class Connection():
       self.link_connected_ports.setdefault(allocated_link_port, []).append(port)
 
   def make_connection(self) -> Optional[Union[ConnectedLink, Export]]:
-    if len(self.ports) < 2:
-      return None  # only one port, not a connection yet
+    if len(self.ports) < 1:
+      return None  # empty connection, doesn't exist
+
+    port0 = self.ports[0]
+    if len(self.ports) == 1:
+      if not (self.flatten and isinstance(port0, BaseVector)):
+        return None
 
     is_export = self._is_export()
     if is_export:

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -49,6 +49,7 @@ class ConnectionBuilder():
 
     self.ports: List[BasePort] = []  # all connected ports
     self.link_instance: Optional[Link] = None  # link instance, if connects have built up to be a link
+    self.link_ports: Optional[List[Tuple[BasePort, List[BasePort]]]] = None  # link port -> [connected ports]
 
   def add_ports(self, ports: Iterable[BasePort]):
     for port in ports:
@@ -69,10 +70,12 @@ class ConnectionBuilder():
     if self.link_instance is None:  # if link not yet defined, create using the first port as authoritative
       link_type = self._baseport_leaf_type(port0).link_type
       link = self.link_instance = link_type()
+      ports_to_connect = self.ports  # new link, need to allocate all ports
     else:
       link = self.link_instance
+      ports_to_connect = [port]  # other ports previously allocated, only allocate new port
 
-    # add all ports to the link, including prior ports if this if this is a new link instance
+
 
 
 class Connection():

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import itertools
 from abc import abstractmethod
 from enum import Enum
 from typing import *
@@ -247,10 +248,27 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
     self._required_ports = IdentitySet[BasePort]()
     self._connects = self.manager.new_dict(Connection, anon_prefix='anon_link')
     self._connects_by_port = IdentityDict[BasePort, Connection]()  # port -> connection
-    self._connects_delegated = IdentityDict[Connection, List[Connection]]()  # for net joins, joined connect -> prior connects
+    self._connect_delegateds = IdentityDict[Connection, List[Connection]]()  # for net joins, joined connect -> prior connects
     self._constraints: SubElementDict[ConstraintExpr] = self.manager.new_dict(ConstraintExpr, anon_prefix='anon_constr')  # type: ignore
 
     self._name = StringExpr()._bind(NameBinding(self))
+
+  def _all_delegated_connects(self) -> IdentitySet[Connection]:
+    """Returns all the prior connects that have been superseded by a joined connect"""
+    return IdentitySet(*itertools.chain(*self._connect_delegateds.values()))
+
+  def _all_connects_of(self, base: Connection) -> IdentitySet[Connection]:
+    """Returns all connects (including prior / superseded connects) for a joined connect"""
+    frontier = [base]
+    delegated_connects = IdentitySet[Connection]()
+    while frontier:
+      cur = frontier.pop()
+      if cur in delegated_connects:
+        continue
+      delegated_connects.add(cur)
+      frontier.extend(self._connect_delegateds.get(cur, []))
+
+    return delegated_connects
 
   def _post_init(self):
     assert self._elaboration_state == BlockElaborationState.init
@@ -519,7 +537,7 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
         connect.add_ports(merge_connect.ports)
         for port in merge_connect.ports:
           self._connects_by_port.update(port, connect)
-        self._connects_delegated.setdefault(connect, []).append(merge_connect)
+        self._connect_delegateds.setdefault(connect, []).append(merge_connect)
 
     for port in connects_ports_new:
       if port._block_parent() is not self:

--- a/edg_core/Blocks.py
+++ b/edg_core/Blocks.py
@@ -119,6 +119,10 @@ class Connection():
       else:
         raise ValueError(f"unknown parent {self.parent}")
 
+      if isinstance(port, BaseVector):
+        if not self.is_link_array and not self.flatten:
+          raise UnconnectableError(f"Can't connect array and non-array ports without flattening")
+
       # allocate the connection
       if port.link_type is not type(link):
         raise UnconnectableError(f"Can't connect {port._name_from(self.parent)} to link of type {type(link)}")
@@ -131,8 +135,7 @@ class Connection():
 
       allocated_link_port = allocatable_link_ports[0]
       if isinstance(allocated_link_port, BaseVector):  # array on link side, can connected multiple ports
-        if not self.is_link_array and not self.flatten:
-          raise UnconnectableError(f"Can't connect array and non-array ports without flattening")
+        pass
       else:  # single port on link side, consumed
         assert allocated_link_port not in self.link_connected_ports
         allocatable_link_ports.pop(0)

--- a/edg_core/Builder.py
+++ b/edg_core/Builder.py
@@ -46,6 +46,8 @@ class Builder:
         elaborated = block._elaborated_def_to_proto()
 
       return elaborated
+    except Exception as e:
+      raise Exception(f"While elaborating {block.__class__}") from e
     finally:
       self.pop_to(None)
 

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -338,13 +338,6 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
 
     return pb
 
-  def _connected_ports(self) -> IdentitySet[BasePort]:
-    """Returns an IdentitySet of all ports (boundary and interior) involved in a connect or export."""
-    rtn = IdentitySet[BasePort]()
-    for name, connect in self._connects.items_ordered():
-      rtn.update(connect.ports())
-    return rtn
-
   # TODO make this non-overriding?
   def _def_to_proto(self) -> edgir.HierarchyBlock:
     assert not self._mixins  # blocks with mixins can only be instantiated anonymously
@@ -352,11 +345,6 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     pb = edgir.HierarchyBlock()
     pb.prerefine_class.target.name = self._get_def_name()  # TODO integrate with a non-link populate_def_proto_block...
     pb = self._populate_def_proto_block_base(pb)
-
-    for (port) in self._connected_ports():
-      if port._block_parent() is self:
-        initializers = port._get_initializers([])
-        assert not initializers, f"connected boundary port {port._name_from(self)} has unexpected initializers {initializers}"
     pb = self._populate_def_proto_port_init(pb)
 
     for (name, (param, param_value)) in self._get_init_params_values().items():

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 from functools import reduce
 from typing import *
 
@@ -263,8 +264,9 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
       for i, connect in enumerate(chain.links):
         link_chain_names.setdefault(connect, []).append(f"{name}_{i}")
 
+    delegated_connects = IdentitySet(*itertools.chain(*self._connects_delegated.values()))
     for name, connect in self._connects.items_ordered():
-      if connect in self._connects_delegated:
+      if connect in delegated_connects:
         continue
 
       connect_elts = connect.make_connection()

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -268,8 +268,8 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
     for name, connect in self._connects.items_ordered():
       if connect in delegated_connects:
         continue
-      connect_names = [self._connects.name_of(c) for c in self._all_connects_of(connect)]
-      connect_names = [c for c in connect_names if c is not None and not c.startswith('anon_')]
+      connect_names_opt = [self._connects.name_of(c) for c in self._all_connects_of(connect)]
+      connect_names = [c for c in connect_names_opt if c is not None and not c.startswith('anon_')]
       if len(connect_names) > 1:
         raise UnconnectableError(f"Multiple names {connect_names} for connect")
       elif len(connect_names) == 1:

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -264,7 +264,7 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
         link_chain_names.setdefault(connect, []).append(f"{name}_{i}")
 
     for name, connect in self._connects.items_ordered():
-      connect_elts = connect.make_connection(self)
+      connect_elts = connect.make_connection()
 
       if name.startswith('anon_'):  # infer a non-anon name if possible
         if connect in link_chain_names and not link_chain_names[connect][0].startswith('anon_'):

--- a/edg_core/HierarchyBlock.py
+++ b/edg_core/HierarchyBlock.py
@@ -264,6 +264,9 @@ class Block(BaseBlock[edgir.HierarchyBlock]):
         link_chain_names.setdefault(connect, []).append(f"{name}_{i}")
 
     for name, connect in self._connects.items_ordered():
+      if connect in self._connects_delegated:
+        continue
+
       connect_elts = connect.make_connection()
 
       if name.startswith('anon_'):  # infer a non-anon name if possible

--- a/edg_core/IdentityDict.py
+++ b/edg_core/IdentityDict.py
@@ -32,6 +32,7 @@ class IdentityDict(Generic[KeyType, ValueType]):  # TODO this should implement M
     key_id = id(key)
     if key_id not in self.dict:
       self.dict[key_id] = default
+      self.keys_dict[key_id] = key
     return self.dict[key_id]
 
   def __repr__(self) -> str:

--- a/edg_core/IdentityDict.py
+++ b/edg_core/IdentityDict.py
@@ -47,6 +47,12 @@ class IdentityDict(Generic[KeyType, ValueType]):  # TODO this should implement M
     self.dict[key_id] = item
     self.keys_dict[key_id] = key
 
+  def update(self, key: KeyType, item: ValueType):
+    key_id = id(key)
+    assert key_id in self.dict, f"attempted to update {key}={self.dict[key_id]} with no prior"
+    self.dict[key_id] = item
+    self.keys_dict[key_id] = key
+
   def extend(self, items: Iterable[Tuple[KeyType, ValueType]]) -> IdentityDict[KeyType, ValueType]:
     for (key, value) in items:
       self[key] = value

--- a/edg_core/IdentityDict.py
+++ b/edg_core/IdentityDict.py
@@ -62,3 +62,6 @@ class IdentityDict(Generic[KeyType, ValueType]):  # TODO this should implement M
 
   def __contains__(self, item: KeyType) -> bool:
     return id(item) in self.dict
+
+  def __bool__(self):
+    return bool(self.dict)

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 from typing import *
+import itertools
 
 import edgir
 from .Array import BaseVector, DerivedVector
-from .Blocks import BaseBlock, Connection, DescriptionString
+from .Blocks import BaseBlock, Connection
 from .Core import Refable, non_library
-from .HdlUserExceptions import *
 from .IdentityDict import IdentityDict
-from .Ports import BasePort, Port
+from .IdentitySet import IdentitySet
+from .Ports import Port
 
 
 @non_library
@@ -41,8 +42,9 @@ class Link(BaseBlock[edgir.Link]):
     # actually generate the links and connects
     ref_map = self._get_ref_map(edgir.LocalPath())
     self._connects.finalize()
+    delegated_connects = IdentitySet(*itertools.chain(*self._connects_delegated.values()))
     for name, connect in self._connects.items_ordered():
-      if connect in self._connects_delegated:
+      if connect in delegated_connects:
         continue
 
       connect_elts = connect.make_connection()

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -42,7 +42,7 @@ class Link(BaseBlock[edgir.Link]):
     ref_map = self._get_ref_map(edgir.LocalPath())
     self._connects.finalize()
     for name, connect in self._connects.items_ordered():
-      connect_elts = connect.make_connection(self)
+      connect_elts = connect.make_connection()
       assert isinstance(connect_elts, Connection.ConnectedLink)
 
       link_path = edgir.localpath_concat(edgir.LocalPath(), name)

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -45,8 +45,8 @@ class Link(BaseBlock[edgir.Link]):
     for name, connect in self._connects.items_ordered():
       if connect in delegated_connects:
         continue
-      connect_names = [self._connects.name_of(c) for c in self._all_connects_of(connect)]
-      connect_names = [c for c in connect_names if c is not None and not c.startswith('anon_')]
+      connect_names_opt = [self._connects.name_of(c) for c in self._all_connects_of(connect)]
+      connect_names = [c for c in connect_names_opt if c is not None and not c.startswith('anon_')]
       if len(connect_names) > 1:
         raise UnconnectableError(f"Multiple names {connect_names} for connect")
       elif len(connect_names) == 1:

--- a/edg_core/Link.py
+++ b/edg_core/Link.py
@@ -42,6 +42,9 @@ class Link(BaseBlock[edgir.Link]):
     ref_map = self._get_ref_map(edgir.LocalPath())
     self._connects.finalize()
     for name, connect in self._connects.items_ordered():
+      if connect in self._connects_delegated:
+        continue
+
       connect_elts = connect.make_connection()
       assert isinstance(connect_elts, Connection.ConnectedLink)
 

--- a/edg_core/test_block_errors.py
+++ b/edg_core/test_block_errors.py
@@ -2,7 +2,7 @@ import unittest
 
 from . import *
 from .HdlUserExceptions import *
-from .test_common import TestPortSource, TestBlockSource, TestBlockSink, TestBlockImplicitSink
+from .test_common import TestPortSource, TestBlockSource, TestBlockSink
 
 
 class BadLinkTestCase(unittest.TestCase):
@@ -15,7 +15,9 @@ class BadLinkTestCase(unittest.TestCase):
       self.source1 = self.Block(TestBlockSource())
       self.source2 = self.Block(TestBlockSource())
       self.sink = self.Block(TestBlockSink())
-      self.test_net = self.connect(self.source1.source, self.source2.source, self.sink.sink)
+      self.test_net = self.connect(self.source1.source, self.sink.sink)
+      self.connect(self.source1.source, self.source2.source)
+      assert False  # the above connect should error (providing a useful traceback), should not reach this statement
 
   def test_overconnected_link(self) -> None:
     with self.assertRaises(UnconnectableError):
@@ -32,6 +34,7 @@ class BadLinkTestCase(unittest.TestCase):
       self.source = self.Block(TestBlockSource())
       self.sink = self.Block(TestBlockSink())
       self.test_net = self.connect(self.source_port, self.source.source, self.sink.sink)
+      assert False  # the above connect should error
 
   def test_no_bridge_link(self) -> None:
     with self.assertRaises(UnconnectableError):
@@ -43,6 +46,7 @@ class BadLinkTestCase(unittest.TestCase):
       super().__init__()
       unbound_port = TestPortSource()
       self.test_net = self.connect(unbound_port)
+      assert False  # the above connect should error
 
   def test_unbound_link(self) -> None:
     with self.assertRaises(UnconnectableError):
@@ -54,6 +58,7 @@ class BadLinkTestCase(unittest.TestCase):
       def __init__(self, above_port: TestPortSource) -> None:
         super().__init__()
         self.connect(above_port)
+        assert False  # the above connect should error
 
     def __init__(self) -> None:
       super().__init__()

--- a/edg_core/test_block_errors.py
+++ b/edg_core/test_block_errors.py
@@ -72,6 +72,21 @@ class BadLinkTestCase(unittest.TestCase):
     with self.assertRaises(UnconnectableError):
       self.AboveConnectBlock()._elaborated_def_to_proto()
 
+  class AmbiguousJoinBlock(Block):
+    """A block with a connect join that merges two names"""
+    def contents(self) -> None:
+      super().contents()
+      self.source = self.Block(TestBlockSource())
+      self.sink1 = self.Block(TestBlockSink())
+      self.sink2 = self.Block(TestBlockSink())
+      self.test_net1 = self.connect(self.source.source, self.sink1.sink)
+      self.test_net2 = self.connect(self.sink2.sink)
+      self.connect(self.test_net1, self.test_net2)
+
+  def test_ambiguous_join(self) -> None:
+    with self.assertRaises(UnconnectableError):
+      self.AmbiguousJoinBlock()._elaborated_def_to_proto()
+
 
 class InaccessibleParamTestCase(unittest.TestCase):
   class BadParamReferenceBlock(Block):

--- a/edg_core/test_hierarchy_block.py
+++ b/edg_core/test_hierarchy_block.py
@@ -117,6 +117,70 @@ class MultiConnectBlockProtoTestCase(unittest.TestCase):
     self.assertIn(expected_conn, constraints)
 
 
+class ConnectJoinBlock(Block):
+  def contents(self):
+    super().contents()
+
+    self.source = self.Block(TestBlockSource())
+    self.sink1 = self.Block(TestBlockSink())
+    self.sink2 = self.Block(TestBlockSink())
+    self.sink3 = self.Block(TestBlockSink())
+    self.sink4 = self.Block(TestBlockSink())
+
+    self.test_net = self.connect(self.source.source, self.sink1.sink)  # authoritative name
+    self.connect(self.sink2.sink, self.sink3.sink)  # not named, to not conflict with the first
+    self.connect(self.source.source, self.sink3.sink)
+    self.connect(self.sink3.sink, self.sink4.sink)  # connect to the overridden net
+
+
+class ConnectJoinBlockProtoTestCase(unittest.TestCase):
+  def setUp(self) -> None:
+    self.pb = ConnectJoinBlock()._elaborated_def_to_proto()
+
+  def test_connectivity(self) -> None:
+    self.assertEqual(len(self.pb.constraints), 5)
+    constraints = list(map(lambda pair: pair.value, self.pb.constraints))
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connected.link_port.ref.steps.add().name = 'source'
+    expected_conn.connected.block_port.ref.steps.add().name = 'source'
+    expected_conn.connected.block_port.ref.steps.add().name = 'source'
+    self.assertIn(expected_conn, constraints)
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink1'
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, constraints)
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink2'
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, constraints)
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink3'
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, constraints)
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
+    expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink4'
+    expected_conn.connected.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, constraints)
+
+
 class ExportPortHierarchyBlock(Block):
   def __init__(self) -> None:
     super().__init__()

--- a/edg_core/test_port_adapter.py
+++ b/edg_core/test_port_adapter.py
@@ -43,7 +43,6 @@ class AdapterTestTop(Block):
 
 
 class ImplicitConnectTestCase(unittest.TestCase):
-  @unittest.skip("adapter link naming is broken")
   def test_connectivity(self) -> None:
     pb = AdapterTestTop()._elaborated_def_to_proto()
     adapter_pb = edgir.pair_get(pb.blocks, '(adapter)adapter_src.port')
@@ -55,20 +54,6 @@ class ImplicitConnectTestCase(unittest.TestCase):
     constraints = list(map(lambda pair: pair.value, pb.constraints))
 
     expected_conn = edgir.ValueExpr()
-    expected_conn.connected.block_port.ref.steps.add().name = 'adapter_src'
-    expected_conn.connected.block_port.ref.steps.add().name = 'port'
-    expected_conn.connected.link_port.ref.steps.add().name = '(adapter_net)adapter_src.port'
-    expected_conn.connected.link_port.ref.steps.add().name = 'ports'
-    self.assertIn(expected_conn, constraints)
-
-    expected_conn = edgir.ValueExpr()
-    expected_conn.connected.link_port.ref.steps.add().name = '(adapter_net)adapter_src.port'
-    expected_conn.connected.link_port.ref.steps.add().name = 'ports'
-    expected_conn.connected.block_port.ref.steps.add().name = '(adapter)adapter_src.port'
-    expected_conn.connected.block_port.ref.steps.add().name = 'src'
-    self.assertIn(expected_conn, constraints)
-
-    expected_conn = edgir.ValueExpr()
     expected_conn.connected.block_port.ref.steps.add().name = '(adapter)adapter_src.port'
     expected_conn.connected.block_port.ref.steps.add().name = 'dst'
     expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
@@ -78,6 +63,23 @@ class ImplicitConnectTestCase(unittest.TestCase):
     expected_conn = edgir.ValueExpr()
     expected_conn.connected.link_port.ref.steps.add().name = 'test_net'
     expected_conn.connected.link_port.ref.steps.add().name = 'sinks'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
     expected_conn.connected.block_port.ref.steps.add().name = 'sink'
     expected_conn.connected.block_port.ref.steps.add().name = 'sink'
+    self.assertIn(expected_conn, constraints)
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.block_port.ref.steps.add().name = 'adapter_src'
+    expected_conn.connected.block_port.ref.steps.add().name = 'port'
+    expected_conn.connected.link_port.ref.steps.add().name = '_adapter_src_port_link'  # anonymous
+    expected_conn.connected.link_port.ref.steps.add().name = 'ports'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
+    self.assertIn(expected_conn, constraints)
+
+    expected_conn = edgir.ValueExpr()
+    expected_conn.connected.link_port.ref.steps.add().name = '_adapter_src_port_link'  # anonymous
+    expected_conn.connected.link_port.ref.steps.add().name = 'ports'
+    expected_conn.connected.block_port.ref.steps.add().name = '(adapter)adapter_src.port'
+    expected_conn.connected.block_port.ref.steps.add().name = 'src'
+    expected_conn.connected.link_port.ref.steps.add().allocate = ''
     self.assertIn(expected_conn, constraints)


### PR DESCRIPTION
- Make connects operations incremental again, that is validation happens on every `connect(...)` and errors should show the failing line
  - Connects treat the first port as authoritative in determining the link type
- Implement net joins, by merging ports of other connects into the first connect and maintaining a delegation graph;
  - Surprisingly this wasn't too difficult
- Remove adapter naming component of skipped test
- Add debugging into to exceptions (by rethrowing) in Builder elaboration
- Fix infrastructural bug in IdentityDict, where `setdefault` failed to set `keys_dict`
- Add `__bool__` for IdentityDict