### PR TITLE
Add I2C target and SPI peripheral ports to IoController base, update SPI and I2C naming

### DIFF
--- a/electronics_abstract_parts/AbstractSpiMemory.py
+++ b/electronics_abstract_parts/AbstractSpiMemory.py
@@ -12,7 +12,7 @@ class SpiMemory(Memory, Block):
     self.pwr = self.Port(VoltageSink.empty(), [Power])
     self.gnd = self.Port(Ground.empty(), [Common])
 
-    self.spi = self.Port(SpiSlave.empty())
+    self.spi = self.Port(SpiPeripheral.empty())
     self.cs = self.Port(DigitalSink.empty())
 
     self.size = self.ArgParameter(size)

--- a/electronics_abstract_parts/AbstractTestPoint.py
+++ b/electronics_abstract_parts/AbstractTestPoint.py
@@ -75,7 +75,7 @@ class I2cTestPoint(TypedTestPoint, Block):
   """Two test points for I2C SDA and SCL"""
   def __init__(self):
     super().__init__()
-    self.io = self.Port(I2cSlave(DigitalBidir.empty()), [InOut])
+    self.io = self.Port(I2cTarget(DigitalBidir.empty()), [InOut])
     self.tp_scl = self.Block(DigitalTestPoint())
     self.connect(self.tp_scl.io, self.io.scl)
     self.tp_sda = self.Block(DigitalTestPoint())

--- a/electronics_abstract_parts/IdealIoController.py
+++ b/electronics_abstract_parts/IdealIoController.py
@@ -11,8 +11,8 @@ class IdealIoController(IoControllerDac, IoControllerCan, IoControllerUsb, IoCon
     def __init__(self) -> None:
         super().__init__()
         self.generator_param(self.adc.requested(), self.dac.requested(), self.gpio.requested(), self.spi.requested(),
-                             self.i2c.requested(), self.uart.requested(), self.usb.requested(), self.can.requested(),
-                             self.i2s.requested())
+                             self.spi_peripheral.requested(), self.i2c.requested(), self.i2c_target.requested(),
+                             self.uart.requested(), self.usb.requested(), self.can.requested(), self.i2s.requested())
 
     def generate(self) -> None:
         self.pwr.init_from(VoltageSink(

--- a/electronics_abstract_parts/IdealIoController.py
+++ b/electronics_abstract_parts/IdealIoController.py
@@ -48,7 +48,7 @@ class IdealIoController(IoControllerDac, IoControllerCan, IoControllerUsb, IoCon
 
         self.spi.defined()
         for elt in self.get(self.spi.requested()):
-            self.spi.append_elt(SpiMaster(dio_model), elt)
+            self.spi.append_elt(SpiController(dio_model), elt)
         self.i2c.defined()
         for elt in self.get(self.i2c.requested()):
             self.i2c.append_elt(I2cController(dio_model), elt)

--- a/electronics_abstract_parts/IdealIoController.py
+++ b/electronics_abstract_parts/IdealIoController.py
@@ -49,9 +49,15 @@ class IdealIoController(IoControllerDac, IoControllerCan, IoControllerUsb, IoCon
         self.spi.defined()
         for elt in self.get(self.spi.requested()):
             self.spi.append_elt(SpiController(dio_model), elt)
+        self.spi_peripheral.defined()
+        for elt in self.get(self.spi_peripheral.requested()):
+            self.spi_peripheral.append_elt(SpiPeripheral(dio_model), elt)
         self.i2c.defined()
         for elt in self.get(self.i2c.requested()):
             self.i2c.append_elt(I2cController(dio_model), elt)
+        self.i2c_target.defined()
+        for elt in self.get(self.i2c_target.requested()):
+            self.i2c_target.append_elt(I2cTarget(dio_model), elt)
         self.uart.defined()
         for elt in self.get(self.uart.requested()):
             self.uart.append_elt(UartPort(dio_model), elt)

--- a/electronics_abstract_parts/IdealIoController.py
+++ b/electronics_abstract_parts/IdealIoController.py
@@ -51,7 +51,7 @@ class IdealIoController(IoControllerDac, IoControllerCan, IoControllerUsb, IoCon
             self.spi.append_elt(SpiMaster(dio_model), elt)
         self.i2c.defined()
         for elt in self.get(self.i2c.requested()):
-            self.i2c.append_elt(I2cMaster(dio_model), elt)
+            self.i2c.append_elt(I2cController(dio_model), elt)
         self.uart.defined()
         for elt in self.get(self.uart.requested()):
             self.uart.append_elt(UartPort(dio_model), elt)

--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -22,7 +22,7 @@ class BaseIoController(PinMappable, Block):
     self.adc = self.Port(Vector(AnalogSink.empty()), optional=True)
 
     self.spi = self.Port(Vector(SpiMaster.empty()), optional=True)
-    self.i2c = self.Port(Vector(I2cMaster.empty()), optional=True)
+    self.i2c = self.Port(Vector(I2cController.empty()), optional=True)
     self.uart = self.Port(Vector(UartPort.empty()), optional=True)
 
     self.io_current_draw = self.Parameter(RangeExpr())  # total current draw for all leaf-level IO sinks

--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -21,7 +21,7 @@ class BaseIoController(PinMappable, Block):
     self.gpio = self.Port(Vector(DigitalBidir.empty()), optional=True)
     self.adc = self.Port(Vector(AnalogSink.empty()), optional=True)
 
-    self.spi = self.Port(Vector(SpiMaster.empty()), optional=True)
+    self.spi = self.Port(Vector(SpiController.empty()), optional=True)
     self.i2c = self.Port(Vector(I2cController.empty()), optional=True)
     self.uart = self.Port(Vector(UartPort.empty()), optional=True)
 

--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -25,10 +25,13 @@ class BaseIoController(PinMappable, Block):
     self.i2c = self.Port(Vector(I2cController.empty()), optional=True)
     self.uart = self.Port(Vector(UartPort.empty()), optional=True)
 
+    self.spi_peripheral = self.Port(Vector(SpiPeripheral.empty()), optional=True)
+    self.i2c_target = self.Port(Vector(I2cTarget.empty()), optional=True)
+
     self.io_current_draw = self.Parameter(RangeExpr())  # total current draw for all leaf-level IO sinks
 
     self._io_ports: List[BasePort] = [  # ordered by assignment order, most restrictive should be first
-      self.adc, self.spi, self.i2c, self.uart, self.gpio]
+      self.adc, self.spi, self.i2c, self.uart, self.spi_peripheral, self.i2c_target, self.gpio]
 
   def _type_of_io(self, io_port: BasePort) -> Type[Port]:
     if isinstance(io_port, Vector):

--- a/electronics_abstract_parts/IoControllerInterfaceMixins.py
+++ b/electronics_abstract_parts/IoControllerInterfaceMixins.py
@@ -18,6 +18,14 @@ class IoControllerCan(BlockInterfaceMixin[BaseIoController]):
         self.implementation(lambda base: base._io_ports.append(self.can))
 
 
+class IoControllerSpiPeripheral(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.spi_peripheral = self.Port(Vector(SpiPeripheral.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.append(self.spi_peripheral))
+
+
 class IoControllerI2cTarget(BlockInterfaceMixin[BaseIoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/electronics_abstract_parts/IoControllerInterfaceMixins.py
+++ b/electronics_abstract_parts/IoControllerInterfaceMixins.py
@@ -18,6 +18,14 @@ class IoControllerCan(BlockInterfaceMixin[BaseIoController]):
         self.implementation(lambda base: base._io_ports.append(self.can))
 
 
+class IoControllerI2cTarget(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.i2c_target = self.Port(Vector(I2cTarget.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.append(self.i2c_target))
+
+
 class IoControllerUsb(BlockInterfaceMixin[BaseIoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/electronics_abstract_parts/IoControllerInterfaceMixins.py
+++ b/electronics_abstract_parts/IoControllerInterfaceMixins.py
@@ -18,22 +18,6 @@ class IoControllerCan(BlockInterfaceMixin[BaseIoController]):
         self.implementation(lambda base: base._io_ports.append(self.can))
 
 
-class IoControllerSpiPeripheral(BlockInterfaceMixin[BaseIoController]):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.spi_peripheral = self.Port(Vector(SpiPeripheral.empty()), optional=True)
-        self.implementation(lambda base: base._io_ports.append(self.spi_peripheral))
-
-
-class IoControllerI2cTarget(BlockInterfaceMixin[BaseIoController]):
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-
-        self.i2c_target = self.Port(Vector(I2cTarget.empty()), optional=True)
-        self.implementation(lambda base: base._io_ports.append(self.i2c_target))
-
-
 class IoControllerUsb(BlockInterfaceMixin[BaseIoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/electronics_abstract_parts/MergedBlocks.py
+++ b/electronics_abstract_parts/MergedBlocks.py
@@ -108,7 +108,7 @@ class MergedAnalogSource(KiCadImportableBlock, DummyDevice, NetBlock, GeneratorB
     return self
 
 
-class MergedSpiMaster(DummyDevice, GeneratorBlock):
+class MergedSpiController(DummyDevice, GeneratorBlock):
   def __init__(self) -> None:
     super().__init__()
     self.ins = self.Port(Vector(SpiPeripheral.empty()))
@@ -130,7 +130,7 @@ class MergedSpiMaster(DummyDevice, GeneratorBlock):
       self.connect(self.sck_merge.ins.request(in_request), in_port.sck)
       self.connect(self.mosi_merge.ins.request(in_request), in_port.mosi)
 
-  def connected_from(self, *ins: Port[SpiLink]) -> 'MergedSpiMaster':
+  def connected_from(self, *ins: Port[SpiLink]) -> 'MergedSpiController':
     for in_port in ins:
       cast(Block, builder.get_enclosing_block()).connect(in_port, self.ins.request())
     return self

--- a/electronics_abstract_parts/MergedBlocks.py
+++ b/electronics_abstract_parts/MergedBlocks.py
@@ -111,8 +111,8 @@ class MergedAnalogSource(KiCadImportableBlock, DummyDevice, NetBlock, GeneratorB
 class MergedSpiMaster(DummyDevice, GeneratorBlock):
   def __init__(self) -> None:
     super().__init__()
-    self.ins = self.Port(Vector(SpiSlave.empty()))
-    self.out = self.Port(SpiMaster.empty())
+    self.ins = self.Port(Vector(SpiPeripheral.empty()))
+    self.out = self.Port(SpiController.empty())
     self.generator_param(self.ins.requested())
 
   def generate(self):
@@ -125,7 +125,7 @@ class MergedSpiMaster(DummyDevice, GeneratorBlock):
 
     self.ins.defined()
     for in_request in self.get(self.ins.requested()):
-      in_port = self.ins.append_elt(SpiSlave.empty(), in_request)
+      in_port = self.ins.append_elt(SpiPeripheral.empty(), in_request)
       self.connect(miso_net, in_port.miso)
       self.connect(self.sck_merge.ins.request(in_request), in_port.sck)
       self.connect(self.mosi_merge.ins.request(in_request), in_port.mosi)

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -77,8 +77,8 @@ from .UsbBitBang import UsbBitBang
 
 from .IoController import BaseIoController, IoController, IoControllerPowerRequired
 from .IoController import BaseIoControllerPinmapGenerator, BaseIoControllerExportable
-from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, \
-    IoControllerDvp8, IoControllerI2cTarget
+from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerI2cTarget, \
+    IoControllerSpiPeripheral, IoControllerUsb, IoControllerI2s, IoControllerDvp8
 from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut
 from .IoControllerInterfaceMixins import IoControllerWifi, IoControllerBluetooth, IoControllerBle
 from .IoControllerProgramming import IoControllerWithSwdTargetConnector

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -78,7 +78,7 @@ from .UsbBitBang import UsbBitBang
 from .IoController import BaseIoController, IoController, IoControllerPowerRequired
 from .IoController import BaseIoControllerPinmapGenerator, BaseIoControllerExportable
 from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, \
-    IoControllerDvp8
+    IoControllerDvp8, IoControllerI2cTarget
 from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut
 from .IoControllerInterfaceMixins import IoControllerWifi, IoControllerBluetooth, IoControllerBle
 from .IoControllerProgramming import IoControllerWithSwdTargetConnector

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -77,8 +77,8 @@ from .UsbBitBang import UsbBitBang
 
 from .IoController import BaseIoController, IoController, IoControllerPowerRequired
 from .IoController import BaseIoControllerPinmapGenerator, BaseIoControllerExportable
-from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerI2cTarget, \
-    IoControllerSpiPeripheral, IoControllerUsb, IoControllerI2s, IoControllerDvp8
+from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, \
+    IoControllerDvp8
 from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut
 from .IoControllerInterfaceMixins import IoControllerWifi, IoControllerBluetooth, IoControllerBle
 from .IoControllerProgramming import IoControllerWithSwdTargetConnector

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -89,4 +89,4 @@ from .VariantPinRemapper import VariantPinRemapper
 
 from .DummyDevices import DummyPassive, DummyVoltageSource, DummyVoltageSink, DummyDigitalSink, DummyAnalogSink
 from .DummyDevices import ForcedVoltageCurrentDraw, ForcedVoltage, ForcedDigitalSinkCurrentDraw
-from .MergedBlocks import MergedVoltageSource, MergedDigitalSource, MergedAnalogSource, MergedSpiMaster
+from .MergedBlocks import MergedVoltageSource, MergedDigitalSource, MergedAnalogSource, MergedSpiController

--- a/electronics_lib/AdcSpi_Mcp3201.py
+++ b/electronics_lib/AdcSpi_Mcp3201.py
@@ -28,7 +28,7 @@ class Mcp3201_Device(InternalSubcircuit, FootprintBlock):
       input_threshold_factor=(0.3, 0.7)
     )
     # Datasheet section 6.2, minimum clock speed
-    self.spi = self.Port(SpiSlave(dio_model, frequency_limit=(10, 1600)*kHertz))
+    self.spi = self.Port(SpiPeripheral(dio_model, frequency_limit=(10, 1600) * kHertz))
     self.cs = self.Port(dio_model)
 
   def contents(self) -> None:

--- a/electronics_lib/AdcSpi_Mcp3561.py
+++ b/electronics_lib/AdcSpi_Mcp3561.py
@@ -33,7 +33,7 @@ class Mcp3561_Device(InternalSubcircuit, FootprintBlock):
       input_threshold_factor=(0.3, 0.7)
     )
     # Datasheet table 1.1
-    self.spi = self.Port(SpiSlave(dio_model, frequency_limit=(0, 10)*MHertz))  # note 20MHz for >2.7V DVdd
+    self.spi = self.Port(SpiPeripheral(dio_model, frequency_limit=(0, 10) * MHertz))  # note 20MHz for >2.7V DVdd
     self.cs = self.Port(dio_model)
 
   def contents(self) -> None:

--- a/electronics_lib/Camera_Ov2640_Fpc24.py
+++ b/electronics_lib/Camera_Ov2640_Fpc24.py
@@ -52,7 +52,7 @@ class Ov2640_Fpc24_Device(InternalSubcircuit, Block):
         # formally this is SCCB (serial camera control bus), but is I2C compatible
         # https://e2e.ti.com/support/processors-group/processors/f/processors-forum/6092/sccb-vs-i2c
         # 0x60 for write, 0x61 for read, translated to the 7-bit address
-        self.sio = self.Port(I2cSlave(DigitalBidir.empty(), [0x30]))
+        self.sio = self.Port(I2cTarget(DigitalBidir.empty(), [0x30]))
         self.connect(self.sio.scl, self.conn.pins.request('20').adapt_to(dio_model))
         self.connect(self.sio.sda, self.conn.pins.request('22').adapt_to(dio_model))
 

--- a/electronics_lib/DacSpi_Mcp4901.py
+++ b/electronics_lib/DacSpi_Mcp4901.py
@@ -29,7 +29,7 @@ class Mcp4921_Device(InternalSubcircuit, FootprintBlock):
       input_threshold_factor=(0.2, 0.7)
     )
     self.ldac = self.Port(dio_model)
-    self.spi = self.Port(SpiSlave(dio_model, frequency_limit=(0, 20)*MHertz))
+    self.spi = self.Port(SpiPeripheral(dio_model, frequency_limit=(0, 20) * MHertz))
     self.cs = self.Port(dio_model)
 
   def contents(self) -> None:

--- a/electronics_lib/Distance_Vl53l0x.py
+++ b/electronics_lib/Distance_Vl53l0x.py
@@ -42,7 +42,7 @@ class Vl53l0x_Device(Vl53l0x_DeviceBase, InternalSubcircuit, JlcPart, FootprintB
     self.gpio1 = self.Port(gpio_model, optional=True)
 
     # TODO: support addresses, the default is 0x29 though it's software remappable
-    self.i2c = self.Port(I2cSlave(self._i2c_io_model(self.vss, self.vdd)), [Output])
+    self.i2c = self.Port(I2cTarget(self._i2c_io_model(self.vss, self.vdd)), [Output])
 
   def contents(self):
     super().contents()
@@ -78,7 +78,7 @@ class Vl53l0x(DistanceSensor, Block):
     self.pwr = self.Port(VoltageSink().empty(), [Power])
     self.gnd = self.Port(Ground().empty(), [Common])
 
-    self.i2c = self.Port(I2cSlave.empty())
+    self.i2c = self.Port(I2cTarget.empty())
     self.xshut = self.Port(DigitalSink.empty(), optional=True)
     self.gpio1 = self.Port(DigitalBidir.empty(), optional=True)
 
@@ -103,7 +103,7 @@ class Vl53l0xConnector(Vl53l0x_DeviceBase, Vl53l0x, GeneratorBlock):
     i2c_io_model = self._i2c_io_model(self.gnd, self.pwr)
     self.connect(self.i2c.scl, self.conn.pins.request('3').adapt_to(i2c_io_model))
     self.connect(self.i2c.sda, self.conn.pins.request('4').adapt_to(i2c_io_model))
-    self.i2c.init_from(I2cSlave(DigitalBidir.empty(), []))
+    self.i2c.init_from(I2cTarget(DigitalBidir.empty(), []))
 
     gpio_model = self._gpio_model(self.gnd, self.pwr)
     if self.get(self.xshut.is_connected()):
@@ -144,7 +144,7 @@ class Vl53l0xArray(DistanceSensor, GeneratorBlock):
     super().__init__()
     self.pwr = self.Port(VoltageSink.empty(), [Power])
     self.gnd = self.Port(Ground.empty(), [Common])
-    self.i2c = self.Port(I2cSlave.empty())
+    self.i2c = self.Port(I2cTarget.empty())
     self.xshut = self.Port(Vector(DigitalSink.empty()))
     self.gpio1 = self.Port(Vector(DigitalBidir.empty()), optional=True)
 

--- a/electronics_lib/EInk_E2154fs091.py
+++ b/electronics_lib/EInk_E2154fs091.py
@@ -25,7 +25,7 @@ class E2154fs091_Device(InternalSubcircuit, FootprintBlock):
     self.reset = self.Port(DigitalSink.from_bidir(dio_model))
     self.dc = self.Port(DigitalSink.from_bidir(dio_model))
     self.cs = self.Port(DigitalSink.from_bidir(dio_model))
-    self.spi = self.Port(SpiSlave(model=dio_model))
+    self.spi = self.Port(SpiPeripheral(model=dio_model))
 
     # TODO model all these parts, then fix all the Passive connections
     self.gdr = self.Port(Passive())

--- a/electronics_lib/EInk_Er_Epd027_2.py
+++ b/electronics_lib/EInk_Er_Epd027_2.py
@@ -71,7 +71,7 @@ class Er_Epd027_2_Device(InternalSubcircuit, Block):
         self.dc = self.Export(self.conn.pins.request('11').adapt_to(din_model), optional=True)
         self.csb = self.Export(self.conn.pins.request('12').adapt_to(din_model))
 
-        self.spi = self.Port(SpiSlave.empty())
+        self.spi = self.Port(SpiPeripheral.empty())
         self.connect(self.spi.sck, self.conn.pins.request('13').adapt_to(din_model))  # SCL
         self.connect(self.spi.mosi, self.conn.pins.request('14').adapt_to(din_model))  # SDA
         self.miso_nc = self.Block(DigitalBidirNotConnected())

--- a/electronics_lib/EnvironmentalSensor_Bme680.py
+++ b/electronics_lib/EnvironmentalSensor_Bme680.py
@@ -19,7 +19,7 @@ class Bme680_Device(InternalSubcircuit, FootprintBlock, JlcPart):
             voltage_limit_abs=(-0.3*Volt, self.vddio.voltage_limits.upper()+0.3),
             input_threshold_factor=(0.2, 0.8)
         )
-        self.i2c = self.Port(I2cSlave(dio_model, [0x76]))
+        self.i2c = self.Port(I2cTarget(dio_model, [0x76]))
 
     def contents(self) -> None:
         self.footprint(

--- a/electronics_lib/EnvironmentalSensor_Sensirion.py
+++ b/electronics_lib/EnvironmentalSensor_Sensirion.py
@@ -15,7 +15,7 @@ class Shtc3_Device(InternalSubcircuit, FootprintBlock, JlcPart):
             self.vss, self.vdd,
             input_threshold_factor=(0.42, 0.7)
         )
-        self.i2c = self.Port(I2cSlave(dio_model, [0x70]))
+        self.i2c = self.Port(I2cTarget(dio_model, [0x70]))
 
     def contents(self) -> None:
         self.footprint(

--- a/electronics_lib/Fpga_Ice40up.py
+++ b/electronics_lib/Fpga_Ice40up.py
@@ -119,7 +119,7 @@ class Ice40up_Device(BaseIoControllerPinmapGenerator, InternalSubcircuit, Genera
 
 
   # hard macros, not tied to any particular pin
-    i2c_model = I2cMaster(DigitalBidir.empty())  # user I2C, table 4.7
+    i2c_model = I2cController(DigitalBidir.empty())  # user I2C, table 4.7
     spi_model = SpiMaster(DigitalBidir.empty(), (0, 45)*MHertz)  # user SPI, table 4.10
 
     return PinMapUtil([  # names consistent with pinout spreadsheet

--- a/electronics_lib/Fpga_Ice40up.py
+++ b/electronics_lib/Fpga_Ice40up.py
@@ -285,7 +285,7 @@ class Ice40up(Fpga, IoController):
 
       # this defaults to flash programming, but to use CRAM programming you can swap the
       # SDI/SDO pins on the debug probe and disconnect the CS line
-      self.spi_merge = self.Block(MergedSpiMaster()).connected_from(self.ic.spi_config, self.prog.spi)
+      self.spi_merge = self.Block(MergedSpiController()).connected_from(self.ic.spi_config, self.prog.spi)
       self.connect(self.spi_merge.out, self.mem.spi)
       self.connect(self.ic.spi_config_cs, self.prog.cs)
       (self.cs_jmp, ), _ = self.chain(self.ic.spi_config_cs, self.Block(DigitalJumper()), self.mem.cs)

--- a/electronics_lib/Fpga_Ice40up.py
+++ b/electronics_lib/Fpga_Ice40up.py
@@ -11,7 +11,7 @@ class Ice40TargetHeader(ProgrammingConnector, FootprintBlock):
     super().__init__()
     self.pwr = self.Port(VoltageSink.empty(), [Power])  # in practice this can power the target
     self.gnd = self.Port(Ground.empty(), [Common])  # TODO pin at 0v
-    self.spi = self.Port(SpiMaster.empty())
+    self.spi = self.Port(SpiController.empty())
     self.cs = self.Port(DigitalSource.empty())
     self.reset = self.Port(DigitalSource.empty())
 
@@ -87,7 +87,7 @@ class Ice40up_Device(BaseIoControllerPinmapGenerator, InternalSubcircuit, Genera
 
     # TODO requirements on SPI device frequency
     # TODO this is really bidirectional, so this could be either separate ports or split ports
-    self.spi_config = self.Port(SpiMaster(self._dpio1_model))
+    self.spi_config = self.Port(SpiController(self._dpio1_model))
     self.spi_config_cs = self.Port(self._dpio1_model)
 
   def _system_pinmap(self) -> Dict[str, CircuitPort]:    # names consistent with pinout spreadsheet
@@ -120,7 +120,7 @@ class Ice40up_Device(BaseIoControllerPinmapGenerator, InternalSubcircuit, Genera
 
   # hard macros, not tied to any particular pin
     i2c_model = I2cController(DigitalBidir.empty())  # user I2C, table 4.7
-    spi_model = SpiMaster(DigitalBidir.empty(), (0, 45)*MHertz)  # user SPI, table 4.10
+    spi_model = SpiController(DigitalBidir.empty(), (0, 45) * MHertz)  # user SPI, table 4.10
 
     return PinMapUtil([  # names consistent with pinout spreadsheet
       PinResource('IOB_0a', {'IOB_0a': pio2_model}),

--- a/electronics_lib/Fusb302b.py
+++ b/electronics_lib/Fusb302b.py
@@ -21,7 +21,7 @@ class Fusb302b_Device(InternalSubcircuit, FootprintBlock, JlcPart):
       input_thresholds=(0.51, 1.32)*Volt,
       output_thresholds=(0.35, float('inf')) * Volt,
     )
-    self.i2c = self.Port(I2cSlave(i2c_model, [0x22]))
+    self.i2c = self.Port(I2cTarget(i2c_model, [0x22]))
     self.int_n = self.Port(DigitalSingleSource.low_from_supply(self.gnd), optional=True)
 
   def contents(self) -> None:

--- a/electronics_lib/Imu_Lsm6ds3trc.py
+++ b/electronics_lib/Imu_Lsm6ds3trc.py
@@ -21,7 +21,7 @@ class Imu_Lsm6ds3trc_Device(InternalSubcircuit, FootprintBlock, JlcPart):
             current_limits=(-4, 4)*mAmp,
             input_threshold_factor=(0.3, 0.7)
         )
-        self.i2c = self.Port(I2cSlave(dio_model))
+        self.i2c = self.Port(I2cTarget(dio_model))
 
         dout_model = DigitalSingleSource.low_from_supply(self.gnd)
         self.int1 = self.Port(dout_model, optional=True)

--- a/electronics_lib/IoExpander_Pcf8574.py
+++ b/electronics_lib/IoExpander_Pcf8574.py
@@ -21,7 +21,7 @@ class Pcf8574_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
       voltage_limit_tolerance=(-0.5, 0.5)*Volt,
       input_threshold_factor=(0.3, 0.7)
     )
-    self.i2c = self.Port(I2cSlave(i2c_model))
+    self.i2c = self.Port(I2cTarget(i2c_model))
 
     self.io = self.Port(Vector(DigitalBidir().empty()), optional=True)
 

--- a/electronics_lib/Lcd_Qt096t_if09.py
+++ b/electronics_lib/Lcd_Qt096t_if09.py
@@ -26,7 +26,7 @@ class Qt096t_if09_Device(InternalSubcircuit, Block):
     self.rs = self.Export(self.conn.pins.request('4').adapt_to(io_model))
     self.cs = self.Export(self.conn.pins.request('8').adapt_to(io_model))
 
-    self.spi = self.Port(SpiSlave.empty())
+    self.spi = self.Port(SpiPeripheral.empty())
     self.connect(self.spi.sck, self.conn.pins.request('6').adapt_to(io_model))  # scl
     self.connect(self.spi.mosi, self.conn.pins.request('5').adapt_to(io_model))  # sda
 

--- a/electronics_lib/LightSensor_Bh1750.py
+++ b/electronics_lib/LightSensor_Bh1750.py
@@ -16,7 +16,7 @@ class Bh1750_Device(InternalSubcircuit, FootprintBlock, JlcPart):
             self.gnd, self.vcc,
             input_threshold_factor=(0.3, 0.7)
         )
-        self.i2c = self.Port(I2cSlave(dio_model, [0x23]))
+        self.i2c = self.Port(I2cTarget(dio_model, [0x23]))
 
     def contents(self) -> None:
         self.footprint(

--- a/electronics_lib/Mag_Qmc5883l.py
+++ b/electronics_lib/Mag_Qmc5883l.py
@@ -19,7 +19,7 @@ class Mag_Qmc5883l_Device(InternalSubcircuit, FootprintBlock, JlcPart):
             voltage_limit_abs=(-0.3*Volt, self.vddio.voltage_limits.upper()+0.3),
             input_threshold_factor=(0.3, 0.7)
         )
-        self.i2c = self.Port(I2cSlave(dio_model))
+        self.i2c = self.Port(I2cTarget(dio_model))
         self.drdy = self.Port(DigitalSource.from_bidir(dio_model), optional=True)
 
         self.setp = self.Port(Passive())

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -54,7 +54,7 @@ class Esp32_Ios(Esp32_Interfaces, BaseIoControllerPinmapGenerator):
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiMaster(DigitalBidir.empty(), (0, 80)*MHertz)  # section 4.1.17
-    i2c_model = I2cMaster(DigitalBidir.empty())  # section 4.1.11, 100/400kHz and up to 5MHz
+    i2c_model = I2cController(DigitalBidir.empty())  # section 4.1.11, 100/400kHz and up to 5MHz
     can_model = CanControllerPort(DigitalBidir.empty())  # aka TWAI
     i2s_model = I2sController(DigitalBidir.empty())
     dvp8_model = Dvp8Host(DigitalBidir.empty())

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -53,7 +53,7 @@ class Esp32_Ios(Esp32_Interfaces, BaseIoControllerPinmapGenerator):
     dac_model = AnalogSource.from_supply(gnd, pwr)  # TODO: no specs in datasheet?!
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty(), (0, 80)*MHertz)  # section 4.1.17
+    spi_model = SpiController(DigitalBidir.empty(), (0, 80) * MHertz)  # section 4.1.17
     i2c_model = I2cController(DigitalBidir.empty())  # section 4.1.11, 100/400kHz and up to 5MHz
     can_model = CanControllerPort(DigitalBidir.empty())  # aka TWAI
     i2s_model = I2sController(DigitalBidir.empty())

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -54,7 +54,9 @@ class Esp32_Ios(Esp32_Interfaces, BaseIoControllerPinmapGenerator):
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty(), (0, 80) * MHertz)  # section 4.1.17
+    spi_peripheral_model = SpiPeripheral(DigitalBidir.empty(), (0, 80) * MHertz)
     i2c_model = I2cController(DigitalBidir.empty())  # section 4.1.11, 100/400kHz and up to 5MHz
+    i2c_target_model = I2cTarget(DigitalBidir.empty())
     can_model = CanControllerPort(DigitalBidir.empty())  # aka TWAI
     i2s_model = I2sController(DigitalBidir.empty())
     dvp8_model = Dvp8Host(DigitalBidir.empty())
@@ -112,10 +114,14 @@ class Esp32_Ios(Esp32_Interfaces, BaseIoControllerPinmapGenerator):
 
       PeripheralAnyResource('I2CEXT0', i2c_model),
       PeripheralAnyResource('I2CEXT1', i2c_model),
+      PeripheralAnyResource('I2CEXT0_T', i2c_target_model),  # TODO shared resource w/ I2C controller
+      PeripheralAnyResource('I2CEXT1_T', i2c_target_model),  # TODO shared resource w/ I2C controller
 
       # PeripheralAnyResource('SPI', spi_model),  # for flash, non-allocatable
       PeripheralAnyResource('HSPI', spi_model),
       PeripheralAnyResource('VSPI', spi_model),
+      PeripheralAnyResource('HSPI_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
+      PeripheralAnyResource('VSPI_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
 
       PeripheralAnyResource('TWAI', can_model),
 

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -64,7 +64,7 @@ class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequ
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty(), (0, 60)*MHertz)  # section 3.4.2, max block in GP master mode
+    spi_model = SpiController(DigitalBidir.empty(), (0, 60) * MHertz)  # section 3.4.2, max block in GP master mode
     i2c_model = I2cController(DigitalBidir.empty())  # section 3.4.4, supporting 100/400 and up to 800 kbit/s
 
     return PinMapUtil([  # section 2.2

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -65,7 +65,7 @@ class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequ
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiMaster(DigitalBidir.empty(), (0, 60)*MHertz)  # section 3.4.2, max block in GP master mode
-    i2c_model = I2cMaster(DigitalBidir.empty())  # section 3.4.4, supporting 100/400 and up to 800 kbit/s
+    i2c_model = I2cController(DigitalBidir.empty())  # section 3.4.4, supporting 100/400 and up to 800 kbit/s
 
     return PinMapUtil([  # section 2.2
       PinResource('GPIO0', {'GPIO0': self._dio_model, 'ADC1_CH0': adc_model}),  # also XTAL_32K_P

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -64,7 +64,7 @@ class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequ
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiController(DigitalBidir.empty(), (0, 60) * MHertz)  # section 3.4.2, max block in GP master mode
+    spi_model = SpiController(DigitalBidir.empty(), (0, 60) * MHertz)  # section 3.4.2, max block in GP controller mode
     spi_peripheral_model = SpiPeripheral(DigitalBidir.empty(), (0, 60) * MHertz)
     i2c_model = I2cController(DigitalBidir.empty())  # section 3.4.4, supporting 100/400 and up to 800 kbit/s
     i2c_target_model = I2cTarget(DigitalBidir.empty())

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -65,7 +65,9 @@ class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequ
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty(), (0, 60) * MHertz)  # section 3.4.2, max block in GP master mode
+    spi_peripheral_model = SpiPeripheral(DigitalBidir.empty(), (0, 60) * MHertz)
     i2c_model = I2cController(DigitalBidir.empty())  # section 3.4.4, supporting 100/400 and up to 800 kbit/s
+    i2c_target_model = I2cTarget(DigitalBidir.empty())
 
     return PinMapUtil([  # section 2.2
       PinResource('GPIO0', {'GPIO0': self._dio_model, 'ADC1_CH0': adc_model}),  # also XTAL_32K_P
@@ -92,7 +94,9 @@ class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequ
       # }),
       PeripheralAnyResource('U1', uart_model),
       PeripheralAnyResource('I2C', i2c_model),
+      PeripheralAnyResource('I2C_T', i2c_target_model),  # TODO shared resource w/ I2C controller
       PeripheralAnyResource('SPI2', spi_model),
+      PeripheralAnyResource('SPI2_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
       PeripheralAnyResource('I2S', I2sController.empty()),
     ])
 

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -45,7 +45,7 @@ class Esp32s3_Ios(Esp32s3_Interfaces, BaseIoControllerPinmapGenerator):
 
     uart_model = UartPort(DigitalBidir.empty())  # section 3.5.5, up to 5Mbps
     spi_model = SpiMaster(DigitalBidir.empty(), (0, 80)*MHertz)  # section 3.5.2, 80MHz in master, 60MHz in slave
-    i2c_model = I2cMaster(DigitalBidir.empty())  # section 3.5.6, 100/400kHz and up to 800kbit/s
+    i2c_model = I2cController(DigitalBidir.empty())  # section 3.5.6, 100/400kHz and up to 800kbit/s
     can_model = CanControllerPort(DigitalBidir.empty())  # aka TWAI, up to 1Mbit/s
     i2s_model = I2sController(DigitalBidir.empty())
     dvp8_model = Dvp8Host(DigitalBidir.empty())
@@ -329,7 +329,7 @@ class Freenove_Esp32s3_Wroom(IoControllerUsbOut, IoControllerPowerOut, Esp32s3_I
   def _io_pinmap(self) -> PinMapUtil:  # allow the camera I2C pins to be used externally
     gnd, pwr = self._gnd_vddio()
     return super()._io_pinmap().add([
-      PeripheralFixedPin('CAM_SCCB', I2cMaster(self._dio_model(gnd, pwr), has_pullup=True), {
+      PeripheralFixedPin('CAM_SCCB', I2cController(self._dio_model(gnd, pwr), has_pullup=True), {
         'scl': '4', 'sda': '3'
       })
     ])

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -44,7 +44,7 @@ class Esp32s3_Ios(Esp32s3_Interfaces, BaseIoControllerPinmapGenerator):
     adc_model = AnalogSink.from_supply(gnd, pwr)  # table 4-5, no other specs given
 
     uart_model = UartPort(DigitalBidir.empty())  # section 3.5.5, up to 5Mbps
-    spi_model = SpiMaster(DigitalBidir.empty(), (0, 80)*MHertz)  # section 3.5.2, 80MHz in master, 60MHz in slave
+    spi_model = SpiController(DigitalBidir.empty(), (0, 80) * MHertz)  # section 3.5.2, 80MHz in master, 60MHz in slave
     i2c_model = I2cController(DigitalBidir.empty())  # section 3.5.6, 100/400kHz and up to 800kbit/s
     can_model = CanControllerPort(DigitalBidir.empty())  # aka TWAI, up to 1Mbit/s
     i2s_model = I2sController(DigitalBidir.empty())

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -44,7 +44,7 @@ class Esp32s3_Ios(Esp32s3_Interfaces, BaseIoControllerPinmapGenerator):
     adc_model = AnalogSink.from_supply(gnd, pwr)  # table 4-5, no other specs given
 
     uart_model = UartPort(DigitalBidir.empty())  # section 3.5.5, up to 5Mbps
-    spi_model = SpiController(DigitalBidir.empty(), (0, 80) * MHertz)  # section 3.5.2, 80MHz in master, 60MHz in slave
+    spi_model = SpiController(DigitalBidir.empty(), (0, 80) * MHertz)  # section 3.5.2, 80MHz in controller, 60MHz in peripheral
     spi_peripheral_model = SpiPeripheral(DigitalBidir.empty(), (0, 80) * MHertz)
     i2c_model = I2cController(DigitalBidir.empty())  # section 3.5.6, 100/400kHz and up to 800kbit/s
     i2c_target_model = I2cController(DigitalBidir.empty())

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -45,7 +45,9 @@ class Esp32s3_Ios(Esp32s3_Interfaces, BaseIoControllerPinmapGenerator):
 
     uart_model = UartPort(DigitalBidir.empty())  # section 3.5.5, up to 5Mbps
     spi_model = SpiController(DigitalBidir.empty(), (0, 80) * MHertz)  # section 3.5.2, 80MHz in master, 60MHz in slave
+    spi_peripheral_model = SpiPeripheral(DigitalBidir.empty(), (0, 80) * MHertz)
     i2c_model = I2cController(DigitalBidir.empty())  # section 3.5.6, 100/400kHz and up to 800kbit/s
+    i2c_target_model = I2cController(DigitalBidir.empty())
     can_model = CanControllerPort(DigitalBidir.empty())  # aka TWAI, up to 1Mbit/s
     i2s_model = I2sController(DigitalBidir.empty())
     dvp8_model = Dvp8Host(DigitalBidir.empty())
@@ -119,9 +121,13 @@ class Esp32s3_Ios(Esp32s3_Interfaces, BaseIoControllerPinmapGenerator):
       PeripheralAnyResource('U2', uart_model),
       PeripheralAnyResource('I2CEXT0', i2c_model),
       PeripheralAnyResource('I2CEXT1', i2c_model),
+      PeripheralAnyResource('I2CEXT0_T', i2c_target_model),  # TODO shared resource w/ I2C controller
+      PeripheralAnyResource('I2CEXT1_T', i2c_target_model),  # TODO shared resource w/ I2C controller
       # SPI0/1 may be used for (possibly on-chip) flash / PSRAM
       PeripheralAnyResource('SPI2', spi_model),
       PeripheralAnyResource('SPI3', spi_model),
+      PeripheralAnyResource('SPI2_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
+      PeripheralAnyResource('SPI3_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
       PeripheralAnyResource('TWAI', can_model),
       PeripheralAnyResource('I2S0', i2s_model),
       PeripheralAnyResource('I2S1', i2s_model),

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -92,7 +92,7 @@ class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, Base
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty())
+    spi_model = SpiController(DigitalBidir.empty())
 
     return PinMapUtil([  # partial table for 48- and 64-pin only
       PinResource('PIO0_0', {'PIO0_0': dio_5v_model, 'ADC0_10': adc_model}),

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -93,6 +93,7 @@ class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, Base
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty())
+    spi_peripheral_model = SpiPeripheral(DigitalBidir.empty())  # MISO driven when CS asserted
 
     return PinMapUtil([  # partial table for 48- and 64-pin only
       PinResource('PIO0_0', {'PIO0_0': dio_5v_model, 'ADC0_10': adc_model}),
@@ -150,9 +151,14 @@ class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, Base
       PeripheralAnyResource('UART2', uart_model),
       PeripheralAnyResource('SPI0', spi_model),
       PeripheralAnyResource('SPI1', spi_model),
+      PeripheralAnyResource('SPI0_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
+      PeripheralAnyResource('SPI1_P', spi_peripheral_model),  # TODO shared resource w/ SPI controller
       PeripheralAnyResource('CAN0', CanControllerPort(DigitalBidir.empty())),
 
       PeripheralFixedResource('I2C0', I2cController(DigitalBidir.empty()), {
+        'scl': ['PIO0_22'], 'sda': ['PIO0_23']
+      }),
+      PeripheralFixedResource('I2C0_T', I2cTarget(DigitalBidir.empty()), {  # TODO shared resource w/ I2C controller
         'scl': ['PIO0_22'], 'sda': ['PIO0_23']
       }),
       PeripheralFixedPin('USB', UsbDevicePort(), {

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -152,7 +152,7 @@ class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, Base
       PeripheralAnyResource('SPI1', spi_model),
       PeripheralAnyResource('CAN0', CanControllerPort(DigitalBidir.empty())),
 
-      PeripheralFixedResource('I2C0', I2cMaster(DigitalBidir.empty()), {
+      PeripheralFixedResource('I2C0', I2cController(DigitalBidir.empty()), {
         'scl': ['PIO0_22'], 'sda': ['PIO0_23']
       }),
       PeripheralFixedPin('USB', UsbDevicePort(), {

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -109,7 +109,7 @@ class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSu
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiMaster(DigitalBidir.empty())
-    i2c_model = I2cMaster(DigitalBidir.empty())
+    i2c_model = I2cController(DigitalBidir.empty())
 
     return PinMapUtil([
       PinResource('2', {'GPIO0': self._dio_ft_model}),

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -110,6 +110,7 @@ class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSu
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty())
     i2c_model = I2cController(DigitalBidir.empty())
+    i2c_target_model = I2cTarget(DigitalBidir.empty())
 
     return PinMapUtil([
       PinResource('2', {'GPIO0': self._dio_ft_model}),
@@ -160,21 +161,30 @@ class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSu
         'rx': ['GPIO5', 'GPIO9', 'GPIO21', 'GPIO25']
       }),
 
-      PeripheralFixedResource('SPI0', spi_model, {  # assumes master mode
+      PeripheralFixedResource('SPI0', spi_model, {
         'miso': ['GPIO0', 'GPIO4', 'GPIO16', 'GPIO20'],  # RX
         'sck': ['GPIO2', 'GPIO6', 'GPIO18', 'GPIO22'],
         'mosi': ['GPIO3', 'GPIO7', 'GPIO19', 'GPIO23']  # TX
       }),
-      PeripheralFixedResource('SPI1', spi_model, {  # assumes master mode
+      PeripheralFixedResource('SPI1', spi_model, {
         'miso': ['GPIO8', 'GPIO12', 'GPIO24', 'GPIO28'],  # RX
         'sck': ['GPIO10', 'GPIO14', 'GPIO26'],
         'mosi': ['GPIO11', 'GPIO15', 'GPIO27']  # TX
       }),
+      # SPI peripheral omitted, since TX tri-state is not tied to CS and must be controlled in software
       PeripheralFixedResource('I2C0', i2c_model, {
         'sda': ['GPIO0', 'GPIO4', 'GPIO8', 'GPIO12', 'GPIO16', 'GPIO20', 'GPIO24', 'GPIO28'],
         'scl': ['GPIO1', 'GPIO5', 'GPIO9', 'GPIO13', 'GPIO17', 'GPIO21', 'GPIO25', 'GPIO20']
       }),
       PeripheralFixedResource('I2C1', i2c_model, {
+        'sda': ['GPIO2', 'GPIO6', 'GPIO10', 'GPIO14', 'GPIO18', 'GPIO22', 'GPIO24', 'GPIO26'],
+        'scl': ['GPIO3', 'GPIO7', 'GPIO11', 'GPIO15', 'GPIO19', 'GPIO23', 'GPIO25', 'GPIO27']
+      }),
+      PeripheralFixedResource('I2C0_T', i2c_target_model, {  # TODO shared resource w/ I2C controller
+        'sda': ['GPIO0', 'GPIO4', 'GPIO8', 'GPIO12', 'GPIO16', 'GPIO20', 'GPIO24', 'GPIO28'],
+        'scl': ['GPIO1', 'GPIO5', 'GPIO9', 'GPIO13', 'GPIO17', 'GPIO21', 'GPIO25', 'GPIO20']
+      }),
+      PeripheralFixedResource('I2C1_T', i2c_target_model, {  # TODO shared resource w/ I2C controller
         'sda': ['GPIO2', 'GPIO6', 'GPIO10', 'GPIO14', 'GPIO18', 'GPIO22', 'GPIO24', 'GPIO26'],
         'scl': ['GPIO3', 'GPIO7', 'GPIO11', 'GPIO15', 'GPIO19', 'GPIO23', 'GPIO25', 'GPIO27']
       }),

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -38,7 +38,7 @@ class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSu
     ))
 
     # Additional ports (on top of IoController)
-    self.qspi = self.Port(SpiMaster.empty())  # TODO actually QSPI
+    self.qspi = self.Port(SpiController.empty())  # TODO actually QSPI
     self.qspi_cs = self.Port(DigitalBidir.empty())
 
     self.xosc = self.Port(CrystalDriver(frequency_limits=(1, 15)*MHertz,  # datasheet 2.15.2.2
@@ -61,7 +61,7 @@ class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSu
     )
     self._dio_std_model = self._dio_ft_model  # exactly the same characteristics
 
-    self.qspi.init_from(SpiMaster(self._dio_std_model))
+    self.qspi.init_from(SpiController(self._dio_std_model))
     self.qspi_cs.init_from(self._dio_std_model)
 
   # Pin/peripheral resource definitions (table 3)
@@ -108,7 +108,7 @@ class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSu
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty())
+    spi_model = SpiController(DigitalBidir.empty())
     i2c_model = I2cController(DigitalBidir.empty())
 
     return PinMapUtil([

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -87,7 +87,7 @@ class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit,
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiMaster(DigitalBidir.empty())
-    i2c_model = I2cMaster(DigitalBidir.empty())
+    i2c_model = I2cController(DigitalBidir.empty())
 
     return PinMapUtil([  # Table 5, partial table for 48-pin only
       PinResource('PA0', {'PA0': dio_std_model, 'ADC12_IN0': adc_model}),

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -87,7 +87,9 @@ class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit,
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty())
+    # TODO SPI peripherals, which have fixed-pin CS lines
     i2c_model = I2cController(DigitalBidir.empty())
+    i2c_target_model = I2cTarget(DigitalBidir.empty())
 
     return PinMapUtil([  # Table 5, partial table for 48-pin only
       PinResource('PA0', {'PA0': dio_std_model, 'ADC12_IN0': adc_model}),
@@ -145,6 +147,9 @@ class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit,
       PeripheralFixedResource('I2C2', i2c_model, {
         'scl': ['PB10'], 'sda': ['PB11']
       }),
+      PeripheralFixedResource('I2C2_T', i2c_target_model, {  # TODO shared resource w/ I2C controller
+        'scl': ['PB10'], 'sda': ['PB11']
+      }),
       PeripheralFixedResource('SPI2', spi_model, {
         'sck': ['PB13'], 'miso': ['PB14'], 'mosi': ['PB15']
       }),
@@ -161,6 +166,9 @@ class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit,
         'swdio': 'PA13', 'swclk': 'PA14', 'reset': 'NRST'  # note: SWO is PB3
       }),
       PeripheralFixedResource('I2C1', i2c_model, {
+        'scl': ['PB6', 'PB8'], 'sda': ['PB7', 'PB9']
+      }),
+      PeripheralFixedResource('I2C1_T', i2c_target_model, {  # TODO shared resource w/ I2C controller
         'scl': ['PB6', 'PB8'], 'sda': ['PB7', 'PB9']
       }),
     ]).remap_pins(self.RESOURCE_PIN_REMAP)

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -86,7 +86,7 @@ class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit,
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty())
+    spi_model = SpiController(DigitalBidir.empty())
     i2c_model = I2cController(DigitalBidir.empty())
 
     return PinMapUtil([  # Table 5, partial table for 48-pin only

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -87,7 +87,7 @@ class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGene
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiMaster(DigitalBidir.empty())
-    i2c_model = I2cMaster(DigitalBidir.empty())
+    i2c_model = I2cController(DigitalBidir.empty())
 
     return PinMapUtil([  # Table 13, partial table for 48-pin only
       PinResource('PC13', {'PC13': dio_tc_model}),

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -86,7 +86,7 @@ class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGene
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty())
+    spi_model = SpiController(DigitalBidir.empty())
     i2c_model = I2cController(DigitalBidir.empty())
 
     return PinMapUtil([  # Table 13, partial table for 48-pin only

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -6,7 +6,7 @@ from electronics_abstract_parts import *
 
 @abstract_block
 class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGenerator):
-  """Base class for STM32F303 devices.
+  """Base class for STM32F303x6/8 devices (separate from STM32F303xB/C).
   Unlike other microcontrollers, this one also supports dev boards (Nucleo-32) which can be
   a power source, so there's a bit more complexity here."""
   RESOURCE_PIN_REMAP: Dict[str, str]
@@ -87,7 +87,9 @@ class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGene
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty())
+    # TODO SPI peripherals, which have fixed-pin CS lines
     i2c_model = I2cController(DigitalBidir.empty())
+    i2c_target_model = I2cTarget(DigitalBidir.empty())
 
     return PinMapUtil([  # Table 13, partial table for 48-pin only
       PinResource('PC13', {'PC13': dio_tc_model}),
@@ -151,7 +153,9 @@ class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGene
       PeripheralFixedResource('I2C1', i2c_model, {
         'scl': ['PA15', 'PB6', 'PB8'], 'sda': ['PA14', 'PB7', 'PB9']
       }),
-
+      PeripheralFixedResource('I2C1_T', i2c_target_model, {
+        'scl': ['PA15', 'PB6', 'PB8'], 'sda': ['PA14', 'PB7', 'PB9']
+      }),
       PeripheralFixedPin('SWD', SwdTargetPort(dio_ft_model), {  # TODO some are FTf pins
         'swdio': 'PA13', 'swclk': 'PA14', 'reset': 'NRST'  # note: SWO is PB3
       }),

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -52,7 +52,9 @@ class Nrf52840_Ios(Nrf52840_Interfaces, BaseIoControllerPinmapGenerator, Interna
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiController(DigitalBidir.empty(), (125, 32000) * kHertz)
+    spi_peripheral_model = SpiPeripheral(DigitalBidir.empty(), (125, 32000) * kHertz)  # tristated by CS pin
     i2c_model = I2cController(DigitalBidir.empty())
+    i2c_target_model = I2cTarget(DigitalBidir.empty())
     i2s_model = I2sController(DigitalBidir.empty())
 
     hf_io_pins = [
@@ -117,32 +119,47 @@ class Nrf52840_Ios(Nrf52840_Interfaces, BaseIoControllerPinmapGenerator, Interna
       PeripheralFixedPin('SWD', SwdTargetPort(dio_model), {
         'swclk': 'SWCLK', 'swdio': 'SWDIO', 'reset': 'P0.18'
       }),
-      PeripheralFixedPin('USB', UsbDevicePort(), {
+      PeripheralFixedPin('USBD', UsbDevicePort(), {
         'dp': 'D+', 'dm': 'D-'
       }),
 
-      PeripheralFixedResource('SPI0', spi_model, {
+      PeripheralFixedResource('SPIM0', spi_model, {
         'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
       }),
-      PeripheralFixedResource('SPI1', spi_model, {
+      PeripheralFixedResource('SPIM1', spi_model, {
         'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
       }),
-      PeripheralFixedResource('SPI2', spi_model, {
+      PeripheralFixedResource('SPIM2', spi_model, {
         'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
       }),
-      PeripheralFixedResource('SPI3', spi_model, {
+      PeripheralFixedResource('SPIM3', spi_model, {
         'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
       }),
-      PeripheralFixedResource('I2C0', i2c_model, {
+      PeripheralFixedResource('SPIS0', spi_peripheral_model, {  # TODO shared resource w/ SPI controller
+        'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
+      }),
+      PeripheralFixedResource('SPIS1', spi_peripheral_model, {  # TODO shared resource w/ SPI controller
+        'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
+      }),
+      PeripheralFixedResource('SPIS2', spi_peripheral_model, {  # TODO shared resource w/ SPI controller
+        'sck': hf_io_pins, 'miso': hf_io_pins, 'mosi': hf_io_pins,
+      }),
+      PeripheralFixedResource('TWIM0', i2c_model, {
         'scl': hf_io_pins, 'sda': hf_io_pins,
       }),
-      PeripheralFixedResource('I2C1', i2c_model, {
+      PeripheralFixedResource('TWIM1', i2c_model, {
         'scl': hf_io_pins, 'sda': hf_io_pins,
       }),
-      PeripheralFixedResource('UART0', uart_model, {
+      PeripheralFixedResource('TWIS0', i2c_target_model, {  # TODO shared resource w/ I2C controller
+        'scl': hf_io_pins, 'sda': hf_io_pins,
+      }),
+      PeripheralFixedResource('TWIS1', i2c_target_model, {  # TODO shared resource w/ I2C controller
+        'scl': hf_io_pins, 'sda': hf_io_pins,
+      }),
+      PeripheralFixedResource('UARTE0', uart_model, {
         'tx': hf_io_pins, 'rx': hf_io_pins,
       }),
-      PeripheralFixedResource('UART1', uart_model, {
+      PeripheralFixedResource('UARTE1', uart_model, {
         'tx': hf_io_pins, 'rx': hf_io_pins,
       }),
       PeripheralFixedResource('I2S', i2s_model, {

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -52,7 +52,7 @@ class Nrf52840_Ios(Nrf52840_Interfaces, BaseIoControllerPinmapGenerator, Interna
 
     uart_model = UartPort(DigitalBidir.empty())
     spi_model = SpiMaster(DigitalBidir.empty(), (125, 32000)*kHertz)
-    i2c_model = I2cMaster(DigitalBidir.empty())
+    i2c_model = I2cController(DigitalBidir.empty())
     i2s_model = I2sController(DigitalBidir.empty())
 
     hf_io_pins = [

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -51,7 +51,7 @@ class Nrf52840_Ios(Nrf52840_Interfaces, BaseIoControllerPinmapGenerator, Interna
     )
 
     uart_model = UartPort(DigitalBidir.empty())
-    spi_model = SpiMaster(DigitalBidir.empty(), (125, 32000)*kHertz)
+    spi_model = SpiController(DigitalBidir.empty(), (125, 32000) * kHertz)
     i2c_model = I2cController(DigitalBidir.empty())
     i2s_model = I2sController(DigitalBidir.empty())
 

--- a/electronics_lib/Oled_Er_Oled_022.py
+++ b/electronics_lib/Oled_Er_Oled_022.py
@@ -81,7 +81,7 @@ class Er_Oled022_1(Oled, GeneratorBlock):
         self.spi = self.Port(SpiSlave.empty(), optional=True)
         self.cs = self.Port(DigitalSink.empty(), optional=True)
         self.dc = self.Port(DigitalSink.empty(), optional=True)
-        self.i2c = self.Port(I2cSlave.empty(), optional=True)
+        self.i2c = self.Port(I2cTarget.empty(), optional=True)
         self.generator_param(self.spi.is_connected(), self.i2c.is_connected())
 
     def contents(self):

--- a/electronics_lib/Oled_Er_Oled_022.py
+++ b/electronics_lib/Oled_Er_Oled_022.py
@@ -78,7 +78,7 @@ class Er_Oled022_1(Oled, GeneratorBlock):
         self.vcc = self.Export(self.device.vcc)  # device power
         self.pwr = self.Export(self.device.vdd)  # logic power
         self.reset = self.Export(self.device.res)
-        self.spi = self.Port(SpiSlave.empty(), optional=True)
+        self.spi = self.Port(SpiPeripheral.empty(), optional=True)
         self.cs = self.Port(DigitalSink.empty(), optional=True)
         self.dc = self.Port(DigitalSink.empty(), optional=True)
         self.i2c = self.Port(I2cTarget.empty(), optional=True)

--- a/electronics_lib/Oled_Er_Oled_028.py
+++ b/electronics_lib/Oled_Er_Oled_028.py
@@ -60,7 +60,7 @@ class Er_Oled028_1_Device(InternalSubcircuit, Block):
         self.bs0 = self.Export(self.conn.pins.request('16').adapt_to(din_model))  # 3-wire (1) / 4-wire (0) serial
         self.connect(self.conn.pins.request('17').adapt_to(Ground()), self.vss)  # BS1, 0 for any serial
 
-        self.spi = self.Port(SpiSlave.empty())
+        self.spi = self.Port(SpiPeripheral.empty())
         self.connect(self.spi.sck, self.conn.pins.request('13').adapt_to(din_model))  # DB0
         self.connect(self.spi.mosi, self.conn.pins.request('12').adapt_to(din_model))  # DB1
 

--- a/electronics_lib/Oled_Er_Oled_091_3.py
+++ b/electronics_lib/Oled_Er_Oled_091_3.py
@@ -44,7 +44,7 @@ class Er_Oled_091_3_Device(InternalSubcircuit, Block):
             input_threshold_factor=(0.2, 0.8)
         )
 
-        self.spi = self.Port(SpiSlave.empty())
+        self.spi = self.Port(SpiPeripheral.empty())
         self.connect(self.spi.sck, self.conn.pins.request('11').adapt_to(din_model))
         self.connect(self.spi.mosi, self.conn.pins.request('12').adapt_to(din_model))
 

--- a/electronics_lib/Oled_Er_Oled_096_1_1.py
+++ b/electronics_lib/Oled_Er_Oled_096_1_1.py
@@ -88,7 +88,7 @@ class Er_Oled_096_1_1(Oled, GeneratorBlock):
         self.spi = self.Port(SpiSlave.empty(), optional=True)
         self.cs = self.Port(DigitalSink.empty(), optional=True)
         self.dc = self.Port(DigitalSink.empty(), optional=True)
-        self.i2c = self.Port(I2cSlave.empty(), optional=True)
+        self.i2c = self.Port(I2cTarget.empty(), optional=True)
         self.generator_param(self.spi.is_connected(), self.dc.is_connected(), self.i2c.is_connected())
 
     def contents(self):

--- a/electronics_lib/Oled_Er_Oled_096_1_1.py
+++ b/electronics_lib/Oled_Er_Oled_096_1_1.py
@@ -85,7 +85,7 @@ class Er_Oled_096_1_1(Oled, GeneratorBlock):
         self.gnd = self.Export(self.device.vss, [Common])
         self.pwr = self.Export(self.device.vdd, [Power])
         self.reset = self.Export(self.device.res)
-        self.spi = self.Port(SpiSlave.empty(), optional=True)
+        self.spi = self.Port(SpiPeripheral.empty(), optional=True)
         self.cs = self.Port(DigitalSink.empty(), optional=True)
         self.dc = self.Port(DigitalSink.empty(), optional=True)
         self.i2c = self.Port(I2cTarget.empty(), optional=True)

--- a/electronics_lib/Oled_Nhd_312_25664uc.py
+++ b/electronics_lib/Oled_Nhd_312_25664uc.py
@@ -71,7 +71,7 @@ class Nhd_312_25664uc(Oled, Block):
     self.reset = self.Export(self.device.nres)
     self.dc = self.Export(self.device.dc)
     self.cs = self.Export(self.device.ncs)
-    self.spi = self.Port(SpiSlave(DigitalBidir.empty()))
+    self.spi = self.Port(SpiPeripheral(DigitalBidir.empty()))
 
   def contents(self):
     super().contents()

--- a/electronics_lib/Rtc_Pcf2129.py
+++ b/electronics_lib/Rtc_Pcf2129.py
@@ -26,7 +26,7 @@ class Pcf2129_Device(InternalSubcircuit, FootprintBlock):
       output_thresholds=(0, self.pwr.link().voltage.upper()),
     )
 
-    self.spi = self.Port(SpiSlave(dio_model), [Output])
+    self.spi = self.Port(SpiPeripheral(dio_model), [Output])
     self.cs = self.Port(DigitalSink.from_bidir(dio_model))
 
     opendrain_model = DigitalSingleSource.low_from_supply(self.gnd)  # TODO -1 - 1 mAmp current limit?

--- a/electronics_lib/SdCards.py
+++ b/electronics_lib/SdCards.py
@@ -27,7 +27,7 @@ class SdCard(Memory):
                          0.75 * self.pwr.link().voltage.lower())
     )
 
-    self.spi = self.Port(SpiSlave(dio_model), [InOut])  # TODO does this port directionality make sense?
+    self.spi = self.Port(SpiPeripheral(dio_model), [InOut])  # TODO does this port directionality make sense?
     self.cs = self.Port(DigitalSink.from_bidir(dio_model))
 
 

--- a/electronics_lib/SpiMemory_93Lc.py
+++ b/electronics_lib/SpiMemory_93Lc.py
@@ -33,7 +33,7 @@ class E93Lc_B_Device(InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock
       voltage_limit_tolerance=(-0.6, 1),
       input_threshold_abs=(0.8, 2.0)  # Table 1-1, for Vcc > 2.7
     )
-    self.spi = self.Port(SpiSlave(dio_model, (0, 2)*MHertz))  # for Vcc >= 2.5
+    self.spi = self.Port(SpiPeripheral(dio_model, (0, 2) * MHertz))  # for Vcc >= 2.5
     self.cs = self.Port(dio_model)
 
     self.actual_size = self.Parameter(IntExpr())

--- a/electronics_lib/SpiMemory_W25q.py
+++ b/electronics_lib/SpiMemory_W25q.py
@@ -31,7 +31,7 @@ class W25q_Device(InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock):
       voltage_limit_tolerance=(-0.5, 0.4),
       input_threshold_factor=(0.3, 0.7)
     )
-    self.spi = self.Port(SpiSlave(dio_model, (0, 104)*MHertz))
+    self.spi = self.Port(SpiPeripheral(dio_model, (0, 104) * MHertz))
     self.cs = self.Port(dio_model)
 
     self.actual_size = self.Parameter(IntExpr())

--- a/electronics_lib/UsbInterface_Ft232h.py
+++ b/electronics_lib/UsbInterface_Ft232h.py
@@ -137,7 +137,7 @@ class Ft232EepromDriver(InternalSubcircuit, Block):
     self.pwr = self.Port(VoltageSink.empty())
     self.eeclk = self.Port(DigitalSink.empty())
     self.eedata = self.Port(DigitalBidir.empty())
-    self.spi = self.Port(SpiMaster.empty())
+    self.spi = self.Port(SpiController.empty())
 
   def contents(self):
     self.connect(self.eeclk, self.spi.sck)
@@ -164,7 +164,7 @@ class Ft232hl(Interface, GeneratorBlock):
 
     # connect one of UART, MPSSE, or ADBUS pins
     self.uart = self.Port(UartPort.empty(), optional=True)
-    self.mpsse = self.Port(SpiMaster.empty(), optional=True)
+    self.mpsse = self.Port(SpiController.empty(), optional=True)
     self.mpsse_cs = self.Port(DigitalSource.empty(), optional=True)
 
     self.adbus = self.Port(Vector(DigitalBidir.empty()))

--- a/electronics_model/I2cPort.py
+++ b/electronics_model/I2cPort.py
@@ -6,25 +6,27 @@ from .DigitalPorts import DigitalSink, DigitalSource, DigitalBidir, DigitalSingl
 
 
 class I2cLink(Link):
+  """I2C connection, using terminology from the auhtoritative NXP specification at
+  https://www.nxp.com/docs/en/user-guide/UM10204.pdf.
+  """
   def __init__(self) -> None:
-    # TODO support multi-master buses
     super().__init__()
 
     self.pull = self.Port(I2cPullupPort(), optional=True)
-    self.master = self.Port(I2cMaster(DigitalBidir.empty()))
-    self.devices = self.Port(Vector(I2cSlave(DigitalBidir.empty())))
+    self.controller = self.Port(I2cController(DigitalBidir.empty()))
+    self.targets = self.Port(Vector(I2cTarget(DigitalBidir.empty())))
 
-    self.addresses = self.Parameter(ArrayIntExpr(self.devices.flatten(lambda x: x.addresses)))
+    self.addresses = self.Parameter(ArrayIntExpr(self.targets.flatten(lambda x: x.addresses)))
 
     self.has_pull = self.Parameter(BoolExpr(self.pull.is_connected()))
 
   def contents(self) -> None:
     super().contents()
-    self.require(self.pull.is_connected() | self.master.has_pullup)
+    self.require(self.pull.is_connected() | self.controller.has_pullup)
     self.require(self.addresses.all_unique(), "conflicting addresses on I2C bus")
-    self.scl = self.connect(self.pull.scl, self.master.scl, self.devices.map_extract(lambda device: device.scl),
+    self.scl = self.connect(self.pull.scl, self.controller.scl, self.targets.map_extract(lambda device: device.scl),
                             flatten=True)
-    self.sda = self.connect(self.pull.sda, self.master.sda, self.devices.map_extract(lambda device: device.sda),
+    self.sda = self.connect(self.pull.sda, self.controller.sda, self.targets.map_extract(lambda device: device.sda),
                             flatten=True)
 
 
@@ -37,7 +39,7 @@ class I2cPullupPort(Bundle[I2cLink]):
     self.sda = self.Port(DigitalSingleSource(pullup_capable=True))
 
 
-class I2cMaster(Bundle[I2cLink]):
+class I2cController(Bundle[I2cLink]):
   link_type = I2cLink
 
   def __init__(self, model: Optional[DigitalBidir] = None, has_pullup: BoolLike = False) -> None:
@@ -51,17 +53,17 @@ class I2cMaster(Bundle[I2cLink]):
     self.has_pullup = self.Parameter(BoolExpr(has_pullup))
 
 
-class I2cSlaveBridge(PortBridge):
+class I2cTargetBridge(PortBridge):
   def __init__(self) -> None:
     super().__init__()
 
-    self.outer_port = self.Port(I2cSlave.empty())
-    self.inner_link = self.Port(I2cMaster(DigitalBidir.empty(), self.outer_port.link().has_pull))
+    self.outer_port = self.Port(I2cTarget.empty())
+    self.inner_link = self.Port(I2cController(DigitalBidir.empty(), self.outer_port.link().has_pull))
 
   def contents(self) -> None:
     super().contents()
 
-    self.outer_port.init_from(I2cSlave(DigitalBidir.empty(), self.inner_link.link().addresses))
+    self.outer_port.init_from(I2cTarget(DigitalBidir.empty(), self.inner_link.link().addresses))
 
     # this duplicates DigitalBidirBridge but mixing in the pullup
     self.scl_bridge = self.Block(DigitalSinkBridge())
@@ -73,9 +75,9 @@ class I2cSlaveBridge(PortBridge):
     self.connect(self.sda_bridge.inner_link, self.inner_link.sda)
 
 
-class I2cSlave(Bundle[I2cLink]):
+class I2cTarget(Bundle[I2cLink]):
   link_type = I2cLink
-  bridge_type = I2cSlaveBridge
+  bridge_type = I2cTargetBridge
 
   def __init__(self, model: Optional[DigitalBidir] = None, addresses: ArrayIntLike = []) -> None:
     """Addresses specified excluding the R/W bit (as a 7-bit number)"""
@@ -87,3 +89,8 @@ class I2cSlave(Bundle[I2cLink]):
 
     self.frequency_limit = self.Parameter(RangeExpr(RangeExpr.ALL))  # range of acceptable frequencies
     self.addresses = self.Parameter(ArrayIntExpr(addresses))
+
+
+# legacy names
+I2cMaster = I2cController
+I2cSlave = I2cTarget

--- a/electronics_model/SpiPort.py
+++ b/electronics_model/SpiPort.py
@@ -5,22 +5,30 @@ from .DigitalPorts import DigitalSink, DigitalSource, DigitalBidir
 
 
 class SpiLink(Link):
+  """Controller/peripheral naming conventions follow https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names/,
+  though SPI naming in general is a mess.
+  Unlike I2C, there is not an authoritative SPI specification.
+  Other names exist, including main/subnode (Wikipedia) and controller/target (NXP, following their I2C convention).
+
+  Internal link signal names are not considered part of the stable public API and may change
+  without a deprecation phase and backwards compatibility.
+  """
   def __init__(self) -> None:
     super().__init__()
-    self.master = self.Port(SpiMaster(DigitalBidir.empty()))
-    self.devices = self.Port(Vector(SpiSlave(DigitalBidir.empty())))
+    self.controller = self.Port(SpiController(DigitalBidir.empty()))
+    self.peripherals = self.Port(Vector(SpiPeripheral(DigitalBidir.empty())))
 
   def contents(self) -> None:
     super().contents()
-    self.sck = self.connect(self.master.sck, self.devices.map_extract(lambda device: device.sck),
+    self.sck = self.connect(self.controller.sck, self.peripherals.map_extract(lambda device: device.sck),
                             flatten=True)
-    self.miso = self.connect(self.master.miso, self.devices.map_extract(lambda device: device.miso),
+    self.miso = self.connect(self.controller.miso, self.peripherals.map_extract(lambda device: device.miso),
                              flatten=True)
-    self.mosi = self.connect(self.master.mosi, self.devices.map_extract(lambda device: device.mosi),
+    self.mosi = self.connect(self.controller.mosi, self.peripherals.map_extract(lambda device: device.mosi),
                              flatten=True)
 
 
-class SpiMaster(Bundle[SpiLink]):
+class SpiController(Bundle[SpiLink]):
   link_type = SpiLink
 
   def __init__(self, model: Optional[DigitalBidir] = None,
@@ -36,7 +44,7 @@ class SpiMaster(Bundle[SpiLink]):
     self.mode = self.Parameter(RangeExpr())  # modes supported, in [0, 3]  TODO: what about sparse modes?
 
 
-class SpiSlave(Bundle[SpiLink]):
+class SpiPeripheral(Bundle[SpiLink]):
   link_type = SpiLink
 
   def __init__(self, model: Optional[DigitalBidir] = None,
@@ -51,3 +59,8 @@ class SpiSlave(Bundle[SpiLink]):
 
     self.frequency_limit = self.Parameter(RangeExpr(frequency_limit))  # range of acceptable frequencies
     self.mode_limit = self.Parameter(RangeExpr())  # range of acceptable modes, in [0, 3]
+
+
+# legacy names
+SpiMaster = SpiController
+SpiSlave = SpiPeripheral

--- a/electronics_model/SpiPort.py
+++ b/electronics_model/SpiPort.py
@@ -38,7 +38,7 @@ class SpiController(Bundle[SpiLink]):
       model = DigitalBidir()  # ideal by default
     self.sck = self.Port(DigitalSource.from_bidir(model))
     self.mosi = self.Port(DigitalSource.from_bidir(model))
-    self.miso = self.Port(model)
+    self.miso = self.Port(DigitalSink.from_bidir(model))
 
     self.frequency = self.Parameter(RangeExpr(frequency))
     self.mode = self.Parameter(RangeExpr())  # modes supported, in [0, 3]  TODO: what about sparse modes?

--- a/electronics_model/__init__.py
+++ b/electronics_model/__init__.py
@@ -17,7 +17,8 @@ from .DigitalPorts import DigitalSource, DigitalSink, DigitalBidir, DigitalSingl
 from .DigitalPorts import DigitalBidirAdapterOpenDrain, DigitalBidirNotConnected
 from .AnalogPort import AnalogSource, AnalogSink, AnalogLink
 from .UartPort import UartPort, UartLink
-from .SpiPort import SpiMaster, SpiSlave, SpiLink
+from .SpiPort import SpiController, SpiPeripheral, SpiLink
+from .SpiPort import SpiMaster, SpiSlave  # legacy names
 from .I2cPort import I2cPullupPort, I2cController, I2cTarget, I2cLink
 from .I2cPort import I2cMaster, I2cSlave  # legacy names
 from .CanPort import CanControllerPort, CanTransceiverPort, CanLogicLink, CanPassivePort, CanDiffPort, CanDiffLink

--- a/electronics_model/__init__.py
+++ b/electronics_model/__init__.py
@@ -18,7 +18,8 @@ from .DigitalPorts import DigitalBidirAdapterOpenDrain, DigitalBidirNotConnected
 from .AnalogPort import AnalogSource, AnalogSink, AnalogLink
 from .UartPort import UartPort, UartLink
 from .SpiPort import SpiMaster, SpiSlave, SpiLink
-from .I2cPort import I2cPullupPort, I2cMaster, I2cSlave, I2cLink
+from .I2cPort import I2cPullupPort, I2cController, I2cTarget, I2cLink
+from .I2cPort import I2cMaster, I2cSlave  # legacy names
 from .CanPort import CanControllerPort, CanTransceiverPort, CanLogicLink, CanPassivePort, CanDiffPort, CanDiffLink
 from .DebugPorts import SwdHostPort, SwdTargetPort, SwdPullPort, SwdLink
 from .SpeakerPort import SpeakerDriverPort, SpeakerPort, SpeakerLink

--- a/electronics_model/test_bundle_netlist.py
+++ b/electronics_model/test_bundle_netlist.py
@@ -4,7 +4,7 @@ from edg_core import *
 from .CanPort import CanDiffPort
 from .CircuitBlock import FootprintBlock
 from .DigitalPorts import DigitalSource, DigitalSink
-from .SpiPort import SpiMaster, SpiSlave
+from .SpiPort import SpiController, SpiPeripheral
 from .UartPort import UartPort
 from .footprint import Pin, Block as FBlock  # TODO cleanup naming
 from .test_netlist import NetlistTestCase
@@ -14,7 +14,7 @@ class TestFakeSpiMaster(FootprintBlock):
   def __init__(self) -> None:
     super().__init__()
 
-    self.spi = self.Port(SpiMaster())
+    self.spi = self.Port(SpiController())
     self.cs_out_1 = self.Port(DigitalSource())
     self.cs_out_2 = self.Port(DigitalSource())
 
@@ -37,7 +37,7 @@ class TestFakeSpiSlave(FootprintBlock):
   def __init__(self) -> None:
     super().__init__()
 
-    self.spi = self.Port(SpiSlave())
+    self.spi = self.Port(SpiPeripheral())
     self.cs_in = self.Port(DigitalSink())
 
   def contents(self) -> None:
@@ -58,13 +58,13 @@ class TestSpiCircuit(Block):
   def contents(self) -> None:
     super().contents()
 
-    self.master = self.Block(TestFakeSpiMaster())
-    self.slave1 = self.Block(TestFakeSpiSlave())
-    self.slave2 = self.Block(TestFakeSpiSlave())
+    self.controller = self.Block(TestFakeSpiMaster())
+    self.peripheral1 = self.Block(TestFakeSpiSlave())
+    self.peripheral2 = self.Block(TestFakeSpiSlave())
 
-    self.spi_link = self.connect(self.master.spi, self.slave1.spi, self.slave2.spi)
-    self.cs1_link = self.connect(self.master.cs_out_1, self.slave1.cs_in)
-    self.cs2_link = self.connect(self.master.cs_out_2, self.slave2.cs_in)
+    self.spi_link = self.connect(self.controller.spi, self.peripheral1.spi, self.peripheral2.spi)
+    self.cs1_link = self.connect(self.controller.cs_out_1, self.peripheral1.cs_in)
+    self.cs2_link = self.connect(self.controller.cs_out_2, self.peripheral2.cs_in)
 
 
 class TestFakeUartBlock(FootprintBlock):
@@ -129,38 +129,38 @@ class BundleNetlistTestCase(unittest.TestCase):
     net = NetlistTestCase.generate_net(TestSpiCircuit)
 
     self.assertEqual(net.nets['cs1_link'], [
-      Pin('master', '0'),
-      Pin('slave1', '4'),
+      Pin('controller', '0'),
+      Pin('peripheral1', '4'),
     ])
     self.assertEqual(net.nets['cs2_link'], [
-      Pin('master', '1'),
-      Pin('slave2', '4'),
+      Pin('controller', '1'),
+      Pin('peripheral2', '4'),
     ])
     self.assertEqual(net.nets['spi_link.sck'], [
-      Pin('master', '2'),
-      Pin('slave1', '1'),
-      Pin('slave2', '1'),
+      Pin('controller', '2'),
+      Pin('peripheral1', '1'),
+      Pin('peripheral2', '1'),
     ])
     self.assertEqual(net.nets['spi_link.mosi'], [
-      Pin('master', '4'),
-      Pin('slave1', '2'),
-      Pin('slave2', '2'),
+      Pin('controller', '4'),
+      Pin('peripheral1', '2'),
+      Pin('peripheral2', '2'),
     ])
     self.assertEqual(net.nets['spi_link.miso'], [
-      Pin('master', '3'),
-      Pin('slave1', '3'),
-      Pin('slave2', '3'),
+      Pin('controller', '3'),
+      Pin('peripheral1', '3'),
+      Pin('peripheral2', '3'),
     ])
 
-    self.assertEqual(net.blocks['master'], FBlock('Resistor_SMD:R_Array_Concave_2x0603', 'R1', '', 'WeirdSpiMaster',
-                                                  ['master'], ['master'],
-                                                  ['electronics_model.test_bundle_netlist.TestFakeSpiMaster']))
-    self.assertEqual(net.blocks['slave1'], FBlock('Resistor_SMD:R_Array_Concave_2x0603', 'R2', '', 'WeirdSpiSlave',
-                                                  ['slave1'], ['slave1'],
-                                                  ['electronics_model.test_bundle_netlist.TestFakeSpiSlave']))
-    self.assertEqual(net.blocks['slave2'], FBlock('Resistor_SMD:R_Array_Concave_2x0603', 'R3', '', 'WeirdSpiSlave',
-                                                  ['slave2'], ['slave2'],
-                                                  ['electronics_model.test_bundle_netlist.TestFakeSpiSlave']))
+    self.assertEqual(net.blocks['controller'], FBlock('Resistor_SMD:R_Array_Concave_2x0603', 'R1', '', 'WeirdSpiMaster',
+                                                      ['controller'], ['controller'],
+                                                      ['electronics_model.test_bundle_netlist.TestFakeSpiMaster']))
+    self.assertEqual(net.blocks['peripheral1'], FBlock('Resistor_SMD:R_Array_Concave_2x0603', 'R2', '', 'WeirdSpiSlave',
+                                                       ['peripheral1'], ['peripheral1'],
+                                                       ['electronics_model.test_bundle_netlist.TestFakeSpiSlave']))
+    self.assertEqual(net.blocks['peripheral2'], FBlock('Resistor_SMD:R_Array_Concave_2x0603', 'R3', '', 'WeirdSpiSlave',
+                                                       ['peripheral2'], ['peripheral2'],
+                                                       ['electronics_model.test_bundle_netlist.TestFakeSpiSlave']))
 
   def test_uart_netlist(self) -> None:
     net = NetlistTestCase.generate_net(TestUartCircuit)

--- a/electronics_model/test_i2c_link.py
+++ b/electronics_model/test_i2c_link.py
@@ -45,11 +45,11 @@ class I2cNoPullTest(DesignTop):
 class I2cConflictTest(DesignTop):
   def __init__(self):
     super().__init__()
-    self.master = self.Block(I2cControllerBlock())
+    self.controller = self.Block(I2cControllerBlock())
     self.pull = self.Block(I2cPullupBlock())
     self.device1 = self.Block(I2cTargetBlock(1))
     self.device2 = self.Block(I2cTargetBlock(1))
-    self.link = self.connect(self.master.port, self.pull.port, self.device1.port, self.device2.port)
+    self.link = self.connect(self.controller.port, self.pull.port, self.device1.port, self.device2.port)
 
 
 class I2cTestCase(unittest.TestCase):

--- a/electronics_model/test_i2c_link.py
+++ b/electronics_model/test_i2c_link.py
@@ -3,10 +3,10 @@ import unittest
 from . import *
 
 
-class I2cMasterBlock(Block):
+class I2cControllerBlock(Block):
   def __init__(self):
     super().__init__()
-    self.port = self.Port(I2cMaster())
+    self.port = self.Port(I2cController())
 
 
 class I2cPullupBlock(Block):
@@ -15,40 +15,40 @@ class I2cPullupBlock(Block):
     self.port = self.Port(I2cPullupPort())
 
 
-class I2cDeviceBlock(Block):
+class I2cTargetBlock(Block):
   @init_in_parent
   def __init__(self, address: IntLike):
     super().__init__()
-    self.port = self.Port(I2cSlave(DigitalBidir(), [address]))
+    self.port = self.Port(I2cTarget(DigitalBidir(), [address]))
 
 
 class I2cTest(DesignTop):
   def __init__(self):
     super().__init__()
-    self.master = self.Block(I2cMasterBlock())
+    self.controller = self.Block(I2cControllerBlock())
     self.pull = self.Block(I2cPullupBlock())
-    self.device1 = self.Block(I2cDeviceBlock(1))
-    self.device2 = self.Block(I2cDeviceBlock(2))
-    self.link = self.connect(self.master.port, self.pull.port, self.device1.port, self.device2.port)
+    self.device1 = self.Block(I2cTargetBlock(1))
+    self.device2 = self.Block(I2cTargetBlock(2))
+    self.link = self.connect(self.controller.port, self.pull.port, self.device1.port, self.device2.port)
 
-    self.require(self.master.port.link().addresses == [1, 2], unchecked=True)
+    self.require(self.controller.port.link().addresses == [1, 2], unchecked=True)
 
 
 class I2cNoPullTest(DesignTop):
   def __init__(self):
     super().__init__()
-    self.master = self.Block(I2cMasterBlock())
-    self.device1 = self.Block(I2cDeviceBlock(1))
-    self.link = self.connect(self.master.port, self.device1.port)
+    self.controller = self.Block(I2cControllerBlock())
+    self.device1 = self.Block(I2cTargetBlock(1))
+    self.link = self.connect(self.controller.port, self.device1.port)
 
 
 class I2cConflictTest(DesignTop):
   def __init__(self):
     super().__init__()
-    self.master = self.Block(I2cMasterBlock())
+    self.master = self.Block(I2cControllerBlock())
     self.pull = self.Block(I2cPullupBlock())
-    self.device1 = self.Block(I2cDeviceBlock(1))
-    self.device2 = self.Block(I2cDeviceBlock(1))
+    self.device1 = self.Block(I2cTargetBlock(1))
+    self.device2 = self.Block(I2cTargetBlock(1))
     self.link = self.connect(self.master.port, self.pull.port, self.device1.port, self.device2.port)
 
 

--- a/examples/test_bldc_controller.py
+++ b/examples/test_bldc_controller.py
@@ -49,7 +49,7 @@ class I2cConnector(Connector, Block):
     self.pwr = self.Export(self.conn.pins.request('2').adapt_to(VoltageSink()),
                            [Power])
 
-    self.i2c = self.Port(I2cSlave(DigitalBidir.empty()), [InOut])
+    self.i2c = self.Port(I2cTarget(DigitalBidir.empty()), [InOut])
     self.connect(self.i2c.sda, self.conn.pins.request('3').adapt_to(DigitalBidir()))
     self.connect(self.i2c.scl, self.conn.pins.request('4').adapt_to(DigitalBidir()))
 

--- a/examples/test_usb_fpga_programmer.py
+++ b/examples/test_usb_fpga_programmer.py
@@ -9,7 +9,7 @@ class FpgaProgrammingHeader(Connector, Block):
     super().__init__()
     self.pwr = self.Port(VoltageSink.empty(), optional=True)
     self.gnd = self.Port(Ground.empty(), [Common])
-    self.spi = self.Port(SpiSlave.empty())
+    self.spi = self.Port(SpiPeripheral.empty())
     self.cs = self.Port(DigitalSink.empty())
     self.reset = self.Port(DigitalSink.empty())
 


### PR DESCRIPTION
Add I2C target and SPI peripheral ports as IoController ports. While these ports are less commonly used, microcontroller can be used as e.g. IO expanders. Coming soon in an example board...

These are exceptions:
- While RP2040 can run in SPI peripheral mode, it will not automatically tristate the data-out pin which is software controlled. The SPI peripheral definition is not included.
- While STM32 can run in SPI peripheral mode, the CS pins are restricted (not pin-matrix'd). Since CS pins are defined separately (#276) it may make it easy to mis-pin the device.
- It's a weird line to draw which may be re-explored later.

This also models SPI controllers and peripherals as distinct resources without a mutual exclusivity constraint as common on microcontrollers. Needs a deeper refactor into the pin resource system, #278 

Other changes:
- Update nRF52840 peripheral names to be consistent with datasheet peripheral instance names

Modernize port names as follows (keeping legacy names as an alias):
- This is not expected to break backwards compatibility.
- SpiMaster -> SpiController, SpiSlave -> SpiPeripheral, per https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names/ (note, there isn't one authoritative SPI standard, and different vendors use different terminologies including controller/target - this seems to be one of the efforts to create a broader standard)
  - Doesn't change MISO / MOSI port names for now, since this would break compatibility. A name alias in Python is possible, but this would break pin assignments which are string-based and would need dedicated aliasing capability (which may be added in the future - as other migrations are needed).
  - Port-side SDI/SDO naming may be better in terms of matching the datasheet (which seem to prefer the device-relative naming) and reducing transcription errors when building library parts, though may be less objectively unambiguous.
- I2cMaster -> I2cController, I2cSlave -> I2cTarget, per authoritative specification document https://www.nxp.com/docs/en/user-guide/UM10204.pdf
