### PR TITLE
Automatically materialize USB and CAN mixins for compatibility

### DIFF
--- a/examples/test_can_adapter.py
+++ b/examples/test_can_adapter.py
@@ -30,10 +30,9 @@ class CanAdapter(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()),
-                                       self.mcu.with_mixin(IoControllerUsb()).usb.request())
-      (self.xcvr, ), self.can_chain = self.chain(self.mcu.with_mixin(IoControllerCan()).can.request('can'),
-                                                 imp.Block(Iso1050dub()))
+      # this uses the legacy / simple (non-mixin) USB and CAN IO style
+      (self.usb_esd, ), _ = self.chain(self.usb.usb, imp.Block(UsbEsdDiode()), self.mcu.usb.request())
+      (self.xcvr, ), self.can_chain = self.chain(self.mcu.can.request('can'), imp.Block(Iso1050dub()))
 
       (self.sw_usb, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw_usb'))
       (self.sw_can, ), _ = self.chain(imp.Block(DigitalSwitch()), self.mcu.gpio.request('sw_can'))

--- a/examples/test_datalogger.py
+++ b/examples/test_datalogger.py
@@ -51,10 +51,10 @@ class Datalogger(BoardTop):
     ) as imp:
       self.mcu = imp.Block(IoController())
 
-      self.connect(self.mcu.with_mixin(IoControllerUsb()).usb.request(), self.usb_conn.usb)
+      # this uses the legacy / simple (non-mixin) USB and CAN IO style
+      self.connect(self.mcu.usb.request(), self.usb_conn.usb)
 
-      (self.can, ), _ = self.chain(self.mcu.with_mixin(IoControllerCan()).can.request('can'),
-                                   imp.Block(CalSolCanBlock()))
+      (self.can, ), _ = self.chain(self.mcu.can.request('can'), imp.Block(CalSolCanBlock()))
 
       # TODO need proper support for exported unconnected ports
       self.can_gnd_load = self.Block(DummyVoltageSink())


### PR DESCRIPTION
Legacy code had CAN and USB on all IoControllers, but mixins changed that (because USB and CAN are not universal peripherals) which was a breaking change. This automatically materializes the USB and CAN mixins when requested using legacy-style code, by overloading `__getattr__(...)`. This should also correctly encode the requirement for mixins as part of the block type.

Likely examples and tutorials will continue using the old-style (non-mixin) USB syntax for simplicity.