### PR TITLE
Store post-refinement-only params and ports in design

### DIFF
--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -117,16 +117,7 @@ object EdgirUtils {
     )
   }
 
-  def metaToStrSeq(meta: common.Metadata): Seq[String] = {
-    ???
-  }
-
-  // Converts a Metadata object to a string-to-string Map structure, inverse of strMapToMeta.
-  // Checks are strict, this crashes on invalidly formatted data
-  def metaToStrMap(meta: common.Metadata): Map[String, String] = {
-    meta.getMembers.node.map { case (k, v) => k -> v.getTextLeaf }
-  }
-
+  // Similar for strSeqToMeta, but for a sequence of strings, preserving order.
   def strSeqToMeta(strMap: Iterable[String]): common.Metadata = {
     common.Metadata(meta =
       common.Metadata.Meta.Members(common.Metadata.Members(
@@ -135,6 +126,16 @@ object EdgirUtils {
         }.toMap
       ))
     )
+  }
+
+  // Converts a Metadata object to a string-to-string Map structure, inverse of strMapToMeta.
+  // Checks are strict, this crashes on invalidly formatted data
+  def metaToStrMap(meta: common.Metadata): Map[String, String] = {
+    meta.getMembers.node.map { case (k, v) => k -> v.getTextLeaf }
+  }
+
+  def metaToStrSeq(meta: common.Metadata): Seq[String] = {
+    meta.getMembers.node.map { case (k, v) => k.toInt -> v.getTextLeaf }.toSeq.sortBy(_._1).map(_._2)
   }
 
   def metaInsertItem(base: Option[common.Metadata], key: String, value: common.Metadata): Option[common.Metadata] = {

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -117,6 +117,10 @@ object EdgirUtils {
     )
   }
 
+  def metaToStrSeq(meta: common.Metadata): Seq[String] = {
+    ???
+  }
+
   // Converts a Metadata object to a string-to-string Map structure, inverse of strMapToMeta.
   // Checks are strict, this crashes on invalidly formatted data
   def metaToStrMap(meta: common.Metadata): Map[String, String] = {

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -159,6 +159,7 @@ object EdgirUtils {
                   (members1.node.get(key), members2.node.get(key)) match {
                     case (Some(value1), None) => key -> value1
                     case (None, Some(value2)) => key -> value2
+                    case (Some(value1), Some(value2)) if value1 == value2 => key -> value1
                     case _ => throw new IllegalArgumentException("cannot merge metadata with conflicting keys ")
                   }
                 }.toMap

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -122,4 +122,24 @@ object EdgirUtils {
   def metaToStrMap(meta: common.Metadata): Map[String, String] = {
     meta.getMembers.node.map { case (k, v) => k -> v.getTextLeaf }
   }
+
+  def strSeqToMeta(strMap: Iterable[String]): common.Metadata = {
+    common.Metadata(meta =
+      common.Metadata.Meta.Members(common.Metadata.Members(
+        node = strMap.zipWithIndex.map { case (value, i) =>
+          i.toString -> common.Metadata(meta = common.Metadata.Meta.TextLeaf(value))
+        }.toMap
+      ))
+    )
+  }
+
+  def metaInsertItem(base: Option[common.Metadata], key: String, value: common.Metadata): Option[common.Metadata] = {
+    val baseMeta = base match {
+      case None => common.Metadata()
+      case Some(meta) => meta
+    }
+    require(baseMeta.meta.isMembers || baseMeta.meta.isEmpty) // must not be any other type that can be overwritten
+    require(!baseMeta.getMembers.node.contains(key))
+    Some(baseMeta.update(_.members.node :+= ((key, value))))
+  }
 }

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -116,4 +116,10 @@ object EdgirUtils {
       ))
     )
   }
+
+  // Converts a Metadata object to a string-to-string Map structure, inverse of strMapToMeta.
+  // Checks are strict, this crashes on invalidly formatted data
+  def metaToStrMap(meta: common.Metadata): Map[String, String] = {
+    meta.getMembers.node.map { case (k, v) => k -> v.getTextLeaf }
+  }
 }

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -107,17 +107,8 @@ object EdgirUtils {
     }
   }
 
-  // Converts a string-to-string Map to a Metadata structure, for serializing data within the compiler.
+  // Converts a iterable of String (preserving order) to a Metadata structure, for serializing data internally.
   // Not meant to be a stable part of the public API, this format may change.
-  def strMapToMeta(strMap: Map[String, String]): common.Metadata = {
-    common.Metadata(meta =
-      common.Metadata.Meta.Members(common.Metadata.Members(
-        node = strMap.map { case (k, v) => k -> common.Metadata(meta = common.Metadata.Meta.TextLeaf(v)) }
-      ))
-    )
-  }
-
-  // Similar for strSeqToMeta, but for a sequence of strings, preserving order.
   def strSeqToMeta(strMap: Iterable[String]): common.Metadata = {
     common.Metadata(meta =
       common.Metadata.Meta.Members(common.Metadata.Members(
@@ -128,12 +119,7 @@ object EdgirUtils {
     )
   }
 
-  // Converts a Metadata object to a string-to-string Map structure, inverse of strMapToMeta.
-  // Checks are strict, this crashes on invalidly formatted data
-  def metaToStrMap(meta: common.Metadata): Map[String, String] = {
-    meta.getMembers.node.map { case (k, v) => k -> v.getTextLeaf }
-  }
-
+  // Inverse of strSeqToMeta, including strict checks (will crash on badly formatted data)
   def metaToStrSeq(meta: common.Metadata): Seq[String] = {
     meta.getMembers.node.map { case (k, v) => k.toInt -> v.getTextLeaf }.toSeq.sortBy(_._1).map(_._2)
   }

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -1,5 +1,6 @@
 package edg
 
+import edgir.common.common
 import edgir.ref.ref
 import edgir.expr.expr
 
@@ -104,5 +105,15 @@ object EdgirUtils {
         connection.withExported(exported)
       case _ => throw new IllegalArgumentException
     }
+  }
+
+  // Converts a string-to-string Map to a Metadata structure, for serializing data within the compiler.
+  // Not meant to be a stable part of the public API, this format may change.
+  def strMapToMeta(strMap: Map[String, String]): common.Metadata = {
+    common.Metadata(meta =
+      common.Metadata.Meta.Members(common.Metadata.Members(
+        node = strMap.map { case (k, v) => k -> common.Metadata(meta = common.Metadata.Meta.TextLeaf(v)) }
+      ))
+    )
   }
 }

--- a/compiler/src/main/scala/edg/EdgirUtils.scala
+++ b/compiler/src/main/scala/edg/EdgirUtils.scala
@@ -147,4 +147,15 @@ object EdgirUtils {
     require(!baseMeta.getMembers.node.contains(key))
     Some(baseMeta.update(_.members.node :+= ((key, value))))
   }
+
+  // from the meta field, returns the key metadata (if the metadata exists and is a dict with the field), or None
+  def metaGetItem(base: Option[common.Metadata], key: String): Option[common.Metadata] = {
+    base match {
+      case Some(meta) => meta.meta match {
+        case common.Metadata.Meta.Members(members) => members.node.get(key)
+        case _ => None
+      }
+      case None => None
+    }
+  }
 }

--- a/compiler/src/main/scala/edg/ElemBuilder.scala
+++ b/compiler/src/main/scala/edg/ElemBuilder.scala
@@ -105,6 +105,7 @@ object ElemBuilder {
         constraints: SeqMap[String, expr.ValueExpr] = SeqMap(),
         prerefine: String = "",
         prerefineMixins: Seq[String] = Seq(),
+        meta: Option[Map[String, common.Metadata]] = None,
     ): elem.BlockLike = elem.BlockLike(`type` =
       elem.BlockLike.Type.Hierarchy(elem.HierarchyBlock(
         params = params.toPb,
@@ -122,7 +123,10 @@ object ElemBuilder {
           case "" => None
           case prerefine => Some(LibraryPath(prerefine))
         },
-        prerefineMixins = prerefineMixins.map(LibraryPath(_))
+        prerefineMixins = prerefineMixins.map(LibraryPath(_)),
+        meta = meta.map(map =>
+          common.Metadata(meta = common.Metadata.Meta.Members(common.Metadata.Members(node = map.toMap)))
+        )
       ))
     )
   }

--- a/compiler/src/main/scala/edg/wir/BlockLike.scala
+++ b/compiler/src/main/scala/edg/wir/BlockLike.scala
@@ -25,11 +25,14 @@ class Block(
     val unrefinedType: Option[ref.LibraryPath],
     val unrefinedMixins: Seq[ref.LibraryPath]
 ) extends BlockLike
-    with HasMutablePorts with HasMutableBlocks with HasMutableLinks with HasMutableConstraints with HasParams {
+    with HasMutablePorts with HasMutableBlocks with HasMutableLinks with HasMutableConstraints with HasParams
+    with HasMutableMetadata {
   override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
   override protected val blocks: mutable.SeqMap[String, BlockLike] = parseBlocks(pb.blocks)
   override protected val links: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
   override protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
+
+  override protected def initMetadata() = pb.meta
 
   // creates a copy of this object
   override def cloned: Block = {
@@ -75,6 +78,7 @@ class Block(
       blocks = blocks.view.mapValues(_.toPb).to(SeqMap).toPb,
       links = links.view.mapValues(_.toPb).to(SeqMap).toPb,
       constraints = constraints.toPb,
+      meta = metadata,
     )
   }
 

--- a/compiler/src/main/scala/edg/wir/BlockLike.scala
+++ b/compiler/src/main/scala/edg/wir/BlockLike.scala
@@ -1,6 +1,7 @@
 package edg.wir
 
 import edg.EdgirUtils.SimpleLibraryPath
+import edgir.common.common
 import edgir.elem.elem
 import edgir.expr.expr
 import edgir.init.init
@@ -27,12 +28,11 @@ class Block(
 ) extends BlockLike
     with HasMutablePorts with HasMutableBlocks with HasMutableLinks with HasMutableConstraints with HasParams
     with HasMutableMetadata {
-  override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
-  override protected val blocks: mutable.SeqMap[String, BlockLike] = parseBlocks(pb.blocks)
-  override protected val links: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
-  override protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
-
-  override protected def initMetadata() = pb.meta
+  override protected def initPorts: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
+  override protected def initBlocks: mutable.SeqMap[String, BlockLike] = parseBlocks(pb.blocks)
+  override protected def initLinks: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
+  override protected def initConstraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
+  override protected def initMetadata: Option[common.Metadata] = pb.meta
 
   // creates a copy of this object
   override def cloned: Block = {

--- a/compiler/src/main/scala/edg/wir/BlockLike.scala
+++ b/compiler/src/main/scala/edg/wir/BlockLike.scala
@@ -29,11 +29,11 @@ class Block(
 ) extends BlockLike
     with HasMutablePorts with HasMutableBlocks with HasMutableLinks with HasMutableConstraints with HasParams
     with HasMutableMetadata {
-  override protected def initPorts: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
-  override protected def initBlocks: mutable.SeqMap[String, BlockLike] = parseBlocks(pb.blocks)
-  override protected def initLinks: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
-  override protected def initConstraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
-  override protected def initMetadata: Option[common.Metadata] = pb.meta
+  override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
+  override protected val blocks: mutable.SeqMap[String, BlockLike] = parseBlocks(pb.blocks)
+  override protected val links: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
+  override protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
+  override protected var metadata: Option[common.Metadata] = pb.meta
 
   // creates a copy of this object
   override def cloned: Block = {

--- a/compiler/src/main/scala/edg/wir/BlockLike.scala
+++ b/compiler/src/main/scala/edg/wir/BlockLike.scala
@@ -1,5 +1,6 @@
 package edg.wir
 
+import edg.EdgirUtils
 import edg.EdgirUtils.SimpleLibraryPath
 import edgir.common.common
 import edgir.elem.elem
@@ -45,6 +46,7 @@ class Block(
     cloned.links.addAll(links.map { case (name, link) => name -> link.cloned })
     cloned.constraints.clear()
     cloned.constraints.addAll(constraints)
+    cloned.metadata = metadata
     cloned
   }
 
@@ -113,6 +115,7 @@ class Generator(
     cloned.constraints.clear()
     cloned.constraints.addAll(constraints)
     cloned.generatedPb = generatedPb
+    cloned.metadata = metadata
     cloned
   }
 
@@ -147,6 +150,7 @@ class Generator(
     blocks.addAll(parseBlocks(pb.blocks))
     links.addAll(parseLinks(pb.links))
     constraints.addAll(parseConstraints(pb.constraints))
+    metadata = EdgirUtils.mergeMeta(metadata, pb.meta)
 
     generatedPb = Some(pb)
 
@@ -166,6 +170,7 @@ class Generator(
       blocks = blocks.view.mapValues(_.toPb).to(SeqMap).toPb,
       links = links.view.mapValues(_.toPb).to(SeqMap).toPb,
       constraints = constraints.to(SeqMap).toPb,
+      meta = metadata,
     )
   }
 }

--- a/compiler/src/main/scala/edg/wir/LinkLike.scala
+++ b/compiler/src/main/scala/edg/wir/LinkLike.scala
@@ -5,6 +5,7 @@ import edg.wir.ProtoUtil._
 import edgir.init.init
 import edgir.elem.elem
 import edgir.expr.expr
+import edgir.expr.expr.ValueExpr
 import edgir.ref.ref
 import edgir.ref.ref.LibraryPath
 
@@ -19,9 +20,9 @@ sealed trait LinkLike extends Pathable {
   */
 class Link(pb: elem.Link) extends LinkLike
     with HasMutablePorts with HasMutableLinks with HasMutableConstraints with HasParams {
-  override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
-  override protected val links: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
-  override protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
+  override protected def initPorts: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
+  override protected def initLinks: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
+  override protected def initConstraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
 
   override def cloned: Link = {
     val cloned = new Link(pb)
@@ -70,9 +71,9 @@ class Link(pb: elem.Link) extends LinkLike
 class LinkArray(pb: elem.LinkArray) extends LinkLike
     with HasMutablePorts with HasMutableLinks with HasMutableConstraints {
   require(pb.ports.isEmpty && pb.links.isEmpty && pb.constraints.isEmpty, "link array may not start elaborated")
-  override protected val ports = mutable.SeqMap[String, PortLike]()
-  override protected val links = mutable.SeqMap[String, LinkLike]()
-  override protected val constraints = mutable.SeqMap[String, expr.ValueExpr]()
+  override protected def initPorts: mutable.SeqMap[String, PortLike] = mutable.SeqMap[String, PortLike]()
+  override protected def initLinks: mutable.SeqMap[String, LinkLike] = mutable.SeqMap[String, LinkLike]()
+  override protected def initConstraints: mutable.SeqMap[String, ValueExpr] = mutable.SeqMap[String, expr.ValueExpr]()
 
   var model: Option[Link] = None
 

--- a/compiler/src/main/scala/edg/wir/LinkLike.scala
+++ b/compiler/src/main/scala/edg/wir/LinkLike.scala
@@ -20,9 +20,9 @@ sealed trait LinkLike extends Pathable {
   */
 class Link(pb: elem.Link) extends LinkLike
     with HasMutablePorts with HasMutableLinks with HasMutableConstraints with HasParams {
-  override protected def initPorts: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
-  override protected def initLinks: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
-  override protected def initConstraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
+  override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
+  override protected val links: mutable.SeqMap[String, LinkLike] = parseLinks(pb.links)
+  override protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = parseConstraints(pb.constraints)
 
   override def cloned: Link = {
     val cloned = new Link(pb)
@@ -71,9 +71,9 @@ class Link(pb: elem.Link) extends LinkLike
 class LinkArray(pb: elem.LinkArray) extends LinkLike
     with HasMutablePorts with HasMutableLinks with HasMutableConstraints {
   require(pb.ports.isEmpty && pb.links.isEmpty && pb.constraints.isEmpty, "link array may not start elaborated")
-  override protected def initPorts: mutable.SeqMap[String, PortLike] = mutable.SeqMap[String, PortLike]()
-  override protected def initLinks: mutable.SeqMap[String, LinkLike] = mutable.SeqMap[String, LinkLike]()
-  override protected def initConstraints: mutable.SeqMap[String, ValueExpr] = mutable.SeqMap[String, expr.ValueExpr]()
+  override protected val ports: mutable.SeqMap[String, PortLike] = mutable.SeqMap[String, PortLike]()
+  override protected val links: mutable.SeqMap[String, LinkLike] = mutable.SeqMap[String, LinkLike]()
+  override protected val constraints: mutable.SeqMap[String, ValueExpr] = mutable.SeqMap[String, expr.ValueExpr]()
 
   var model: Option[Link] = None
 

--- a/compiler/src/main/scala/edg/wir/Mixins.scala
+++ b/compiler/src/main/scala/edg/wir/Mixins.scala
@@ -1,6 +1,7 @@
 package edg.wir
 
 import edg.wir.ProtoUtil._
+import edgir.common.common
 import edgir.ref.ref
 import edgir.elem.elem
 import edgir.expr.expr
@@ -15,7 +16,8 @@ trait HasClass {
 }
 
 trait HasMutablePorts {
-  protected val ports: mutable.SeqMap[String, PortLike]
+  protected val ports: mutable.SeqMap[String, PortLike] = initPorts
+  protected def initPorts: mutable.SeqMap[String, PortLike]
 
   def getPorts: SeqMap[String, PortLike] = ports.to(SeqMap)
   def elaborate(name: String, port: PortLike): Unit = {
@@ -30,7 +32,8 @@ trait HasMutablePorts {
 }
 
 trait HasMutableBlocks extends HasClass {
-  protected val blocks: mutable.SeqMap[String, BlockLike]
+  protected val blocks: mutable.SeqMap[String, BlockLike] = initBlocks
+  protected def initBlocks: mutable.SeqMap[String, BlockLike]
 
   def getBlocks: SeqMap[String, BlockLike] = blocks.to(SeqMap)
   def elaborate(name: String, block: BlockLike): Unit = {
@@ -50,7 +53,8 @@ trait HasMutableBlocks extends HasClass {
 }
 
 trait HasMutableLinks {
-  protected val links: mutable.SeqMap[String, LinkLike]
+  protected val links: mutable.SeqMap[String, LinkLike] = initLinks
+  protected def initLinks: mutable.SeqMap[String, LinkLike]
 
   def getLinks: SeqMap[String, LinkLike] = links.to(SeqMap)
   def elaborate(name: String, link: LinkLike): Unit = {
@@ -73,7 +77,8 @@ trait HasMutableLinks {
 trait HasMutableConstraints {
   import edg.util.SeqMapUtils
 
-  protected val constraints: mutable.SeqMap[String, expr.ValueExpr]
+  protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = initConstraints
+  protected def initConstraints: mutable.SeqMap[String, expr.ValueExpr] // implement me
 
   def getConstraints: SeqMap[String, expr.ValueExpr] = constraints.to(SeqMap)
 
@@ -100,12 +105,12 @@ trait HasParams extends HasClass {
 }
 
 trait HasMutableMetadata {
-  protected var metadata: Option[edgir.common.common.Metadata] = initMetadata()
+  protected var metadata: Option[common.Metadata] = initMetadata
 
-  protected def initMetadata(): Option[edgir.common.common.Metadata] // implement me
+  protected def initMetadata: Option[common.Metadata] // implement me
 
   // replaces the metadata in-place, it is up to the upper layer to do this composably (eg, map-aware)
-  def mapMetadata(fn: Option[edgir.common.common.Metadata] => Option[edgir.common.common.Metadata]): Unit = {
+  def mapMetadata(fn: Option[common.Metadata] => Option[edgir.common.common.Metadata]): Unit = {
     metadata = fn(metadata)
   }
 }

--- a/compiler/src/main/scala/edg/wir/Mixins.scala
+++ b/compiler/src/main/scala/edg/wir/Mixins.scala
@@ -98,3 +98,14 @@ trait HasMutableConstraints {
 trait HasParams extends HasClass {
   def getParams: SeqMap[String, init.ValInit]
 }
+
+trait HasMutableMetadata {
+  protected var metadata: Option[edgir.common.common.Metadata] = initMetadata()
+
+  protected def initMetadata(): Option[edgir.common.common.Metadata] // implement me
+
+  // replaces the metadata in-place, it is up to the upper layer to do this composably (eg, map-aware)
+  def mapMetadata(fn: Option[edgir.common.common.Metadata] => Option[edgir.common.common.Metadata]): Unit = {
+    metadata = fn(metadata)
+  }
+}

--- a/compiler/src/main/scala/edg/wir/Mixins.scala
+++ b/compiler/src/main/scala/edg/wir/Mixins.scala
@@ -16,8 +16,7 @@ trait HasClass {
 }
 
 trait HasMutablePorts {
-  protected val ports: mutable.SeqMap[String, PortLike] = initPorts
-  protected def initPorts: mutable.SeqMap[String, PortLike]
+  protected val ports: mutable.SeqMap[String, PortLike]
 
   def getPorts: SeqMap[String, PortLike] = ports.to(SeqMap)
   def elaborate(name: String, port: PortLike): Unit = {
@@ -32,8 +31,7 @@ trait HasMutablePorts {
 }
 
 trait HasMutableBlocks extends HasClass {
-  protected val blocks: mutable.SeqMap[String, BlockLike] = initBlocks
-  protected def initBlocks: mutable.SeqMap[String, BlockLike]
+  protected val blocks: mutable.SeqMap[String, BlockLike]
 
   def getBlocks: SeqMap[String, BlockLike] = blocks.to(SeqMap)
   def elaborate(name: String, block: BlockLike): Unit = {
@@ -53,8 +51,7 @@ trait HasMutableBlocks extends HasClass {
 }
 
 trait HasMutableLinks {
-  protected val links: mutable.SeqMap[String, LinkLike] = initLinks
-  protected def initLinks: mutable.SeqMap[String, LinkLike]
+  protected val links: mutable.SeqMap[String, LinkLike]
 
   def getLinks: SeqMap[String, LinkLike] = links.to(SeqMap)
   def elaborate(name: String, link: LinkLike): Unit = {
@@ -77,8 +74,7 @@ trait HasMutableLinks {
 trait HasMutableConstraints {
   import edg.util.SeqMapUtils
 
-  protected val constraints: mutable.SeqMap[String, expr.ValueExpr] = initConstraints
-  protected def initConstraints: mutable.SeqMap[String, expr.ValueExpr] // implement me
+  protected val constraints: mutable.SeqMap[String, expr.ValueExpr]
 
   def getConstraints: SeqMap[String, expr.ValueExpr] = constraints.to(SeqMap)
 
@@ -105,9 +101,7 @@ trait HasParams extends HasClass {
 }
 
 trait HasMutableMetadata {
-  protected var metadata: Option[common.Metadata] = initMetadata
-
-  protected def initMetadata: Option[common.Metadata] // implement me
+  protected var metadata: Option[common.Metadata]
 
   // replaces the metadata in-place, it is up to the upper layer to do this composably (eg, map-aware)
   def mapMetadata(fn: Option[common.Metadata] => Option[edgir.common.common.Metadata]): Unit = {

--- a/compiler/src/main/scala/edg/wir/PortLike.scala
+++ b/compiler/src/main/scala/edg/wir/PortLike.scala
@@ -57,7 +57,7 @@ class Port(pb: elem.Port) extends PortLike
 
 class Bundle(pb: elem.Bundle) extends PortLike
     with HasMutablePorts with HasParams {
-  override protected def initPorts: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
+  override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
 
   override def cloned: Bundle = {
     val cloned = new Bundle(pb)
@@ -96,7 +96,7 @@ class Bundle(pb: elem.Bundle) extends PortLike
 }
 
 class PortArray(pb: elem.PortArray) extends PortLike with HasMutablePorts {
-  override protected def initPorts: mutable.SeqMap[String, PortLike] = mutable.LinkedHashMap()
+  override protected val ports: mutable.SeqMap[String, PortLike] = mutable.LinkedHashMap()
   var portsSet = false // allow empty port arrays
 
   pb.contains match {

--- a/compiler/src/main/scala/edg/wir/PortLike.scala
+++ b/compiler/src/main/scala/edg/wir/PortLike.scala
@@ -57,7 +57,7 @@ class Port(pb: elem.Port) extends PortLike
 
 class Bundle(pb: elem.Bundle) extends PortLike
     with HasMutablePorts with HasParams {
-  override protected val ports: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
+  override protected def initPorts: mutable.SeqMap[String, PortLike] = parsePorts(pb.ports)
 
   override def cloned: Bundle = {
     val cloned = new Bundle(pb)
@@ -96,7 +96,7 @@ class Bundle(pb: elem.Bundle) extends PortLike
 }
 
 class PortArray(pb: elem.PortArray) extends PortLike with HasMutablePorts {
-  override protected val ports: mutable.SeqMap[String, PortLike] = mutable.LinkedHashMap()
+  override protected def initPorts: mutable.SeqMap[String, PortLike] = mutable.LinkedHashMap()
   var portsSet = false // allow empty port arrays
 
   pb.contains match {

--- a/compiler/src/test/scala/edg/EdgirUtilsTest.scala
+++ b/compiler/src/test/scala/edg/EdgirUtilsTest.scala
@@ -1,0 +1,18 @@
+package edg
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class EdgirUtilsTest extends AnyFlatSpec {
+  behavior.of("metadata utils")
+
+  it should "roundtrip Map" in {
+    val testdata = Map("a" -> "b", "c" -> "d")
+    EdgirUtils.metaToStrMap(EdgirUtils.strMapToMeta(testdata)) should equal(testdata)
+  }
+
+  it should "roundtrip Seq" in {
+    val testdata = Seq("a", "b", "c", "d")
+//    EdgirUtils.metaToStrSeq(EdgirUtils.strSeqToMeta(testdata)) should equal(testdata)
+  }
+}

--- a/compiler/src/test/scala/edg/EdgirUtilsTest.scala
+++ b/compiler/src/test/scala/edg/EdgirUtilsTest.scala
@@ -6,11 +6,6 @@ import org.scalatest.matchers.should.Matchers._
 class EdgirUtilsTest extends AnyFlatSpec {
   behavior.of("metadata utils")
 
-  it should "roundtrip Map" in {
-    val testdata = Map("a" -> "b", "c" -> "d")
-    EdgirUtils.metaToStrMap(EdgirUtils.strMapToMeta(testdata)) should equal(testdata)
-  }
-
   it should "roundtrip Seq" in {
     val testdata = Seq("a", "1", "b", "c", "3", "d")
     EdgirUtils.metaToStrSeq(EdgirUtils.strSeqToMeta(testdata)) should equal(testdata)

--- a/compiler/src/test/scala/edg/EdgirUtilsTest.scala
+++ b/compiler/src/test/scala/edg/EdgirUtilsTest.scala
@@ -12,7 +12,7 @@ class EdgirUtilsTest extends AnyFlatSpec {
   }
 
   it should "roundtrip Seq" in {
-    val testdata = Seq("a", "b", "c", "d")
-//    EdgirUtils.metaToStrSeq(EdgirUtils.strSeqToMeta(testdata)) should equal(testdata)
+    val testdata = Seq("a", "1", "b", "c", "3", "d")
+    EdgirUtils.metaToStrSeq(EdgirUtils.strSeqToMeta(testdata)) should equal(testdata)
   }
 }

--- a/compiler/src/test/scala/edg/compiler/CompilerBlockMixinTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerBlockMixinTest.scala
@@ -1,6 +1,6 @@
 package edg.compiler
 
-import edg.CompilerTestUtil
+import edg.{CompilerTestUtil, EdgirUtils}
 import edg.ElemBuilder._
 import edg.ExprBuilder.Ref
 import edg.wir.ProtoUtil.BlockProtoToSeqMap
@@ -197,7 +197,11 @@ class CompilerBlockMixinTest extends AnyFlatSpec with CompilerTestUtil {
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "sinkPort"),
             "mixinPort" -> Port.Port(selfClass = "sinkPort"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq()),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq()),
+          ))
         ),
       ),
       links = SeqMap(
@@ -270,7 +274,11 @@ class CompilerBlockMixinTest extends AnyFlatSpec with CompilerTestUtil {
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "sinkPort"),
             "mixinPort" -> Port.Port(selfClass = "sinkPort"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq("mixinPort")),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq()),
+          ))
         ),
       ),
       links = SeqMap(

--- a/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerRefinementTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import matchers.should.Matchers._
 import edg.ElemBuilder._
 import edg.ExprBuilder.{Ref, ValInit, ValueExpr}
-import edg.{CompilerTestUtil, wir}
+import edg.{CompilerTestUtil, EdgirUtils, wir}
 import edg.wir.{DesignPath, IndirectDesignPath, IndirectStep, Refinements}
 
 import scala.collection.SeqMap
@@ -121,7 +121,11 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
           ),
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "port"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq()),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq("subParam")),
+          ))
         ),
       )
     ))
@@ -167,7 +171,11 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
           ),
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "port"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq()),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq("subParam")),
+          ))
         ),
       )
     ))
@@ -302,7 +310,11 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
           ),
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "port"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq()),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq("subParam")),
+          ))
         ),
       )
     ))
@@ -324,7 +336,11 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
           ),
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "port"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq()),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq("subParam")),
+          ))
         ),
       )
     ))
@@ -360,7 +376,11 @@ class CompilerRefinementTest extends AnyFlatSpec with CompilerTestUtil {
           ),
           ports = SeqMap(
             "port" -> Port.Port(selfClass = "port"),
-          )
+          ),
+          meta = Some(Map(
+            "refinedNewPorts" -> EdgirUtils.strSeqToMeta(Seq()),
+            "refinedNewParams" -> EdgirUtils.strSeqToMeta(Seq("subParam")),
+          ))
         ),
       )
     ))


### PR DESCRIPTION
... in the metadata field for now, structure is non-API-stable.

Infrastructure used to pass this data to the block diagram visualizer, which should render non-interactable ports differently.

Add utility functions for working with metadata:
- Seq[String] to metadata and inverse operation
- Insertion and retrieving fields from metadata, if structured as members.node
- Merge metadata - valid for dict only, only performs merges one level deep
