### PR TITLE
Cleanup type hierarchy / categorization

### DIFF
--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -34,6 +34,7 @@ class VoltageRegulator(PowerConditioner):
                  "Output voltage must be within spec")
 
 
+@non_library
 class VoltageRegulatorEnableWrapper(Resettable, VoltageRegulator, GeneratorBlock):
   """Implementation mixin for a voltage regulator wrapper block where the inner device has a reset/enable pin
   (active-high enable / active-low shutdown) that is automatically tied high if not externally connected.

--- a/electronics_abstract_parts/DigitalAmplifiers.py
+++ b/electronics_abstract_parts/DigitalAmplifiers.py
@@ -143,7 +143,7 @@ class HalfBridgeNFet(PowerSwitch, Block):
     )))
 
 
-class OpenDrainDriver(Block):
+class OpenDrainDriver(PowerSwitch, Block):
   """NFET configured as an open-drain driver. Potentially useful for voltage translation applications."""
   @init_in_parent
   def __init__(self, max_rds: FloatLike = 1*Ohm, frequency: RangeLike = RangeExpr.ZERO) -> None:

--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -9,7 +9,7 @@ from .Categories import ProgrammableController
 
 
 @abstract_block
-class BaseIoController(PinMappable, Block):
+class BaseIoController(PinMappable, InternalBlock, Block):
   """An abstract IO controller block, that takes power input and provides a grab-bag of common IOs.
   A base interface for microcontrollers and microcontroller-like devices (eg, FPGAs).
   Pin assignments are handled via refinements and can be assigned to pins' allocated names.

--- a/electronics_abstract_parts/SmdStandardPackage.py
+++ b/electronics_abstract_parts/SmdStandardPackage.py
@@ -4,7 +4,7 @@ from electronics_abstract_parts import PartsTableFootprintSelector, PartsTableRo
 from electronics_model import *
 
 @abstract_block
-class SmdStandardPackage(Block):
+class SmdStandardPackage(InternalBlock, Block):
   """A base mixin for any device that can generate into a standard SMT package, the 0402/0603/0805/etc series.
   This provides a parameter that can be globally set to specify a minimum package size.
   Devices may generate into nonstandard packages, those are not affected.
@@ -51,7 +51,7 @@ class SmdStandardPackage(Block):
 
 
 @non_library
-class SmdStandardPackageSelector(PartsTableFootprintSelector, SmdStandardPackage):
+class SmdStandardPackageSelector(SmdStandardPackage, PartsTableFootprintSelector):
   SMD_FOOTPRINT_MAP: Dict[str, Optional[str]]  # subclass-defined, maps standard packages (e.g., 0402) to footprints
 
   def __init__(self, *args, **kwargs):

--- a/electronics_abstract_parts/SmdStandardPackage.py
+++ b/electronics_abstract_parts/SmdStandardPackage.py
@@ -4,7 +4,7 @@ from electronics_abstract_parts import PartsTableFootprintSelector, PartsTableRo
 from electronics_model import *
 
 @abstract_block
-class SmdStandardPackage(InternalBlock, Block):
+class SmdStandardPackage(Block):
   """A base mixin for any device that can generate into a standard SMT package, the 0402/0603/0805/etc series.
   This provides a parameter that can be globally set to specify a minimum package size.
   Devices may generate into nonstandard packages, those are not affected.

--- a/electronics_lib/BoostConverter_TexasInstruments.py
+++ b/electronics_lib/BoostConverter_TexasInstruments.py
@@ -48,6 +48,7 @@ class Tps61040(VoltageRegulatorEnableWrapper, DiscreteBoostConverter):
   def contents(self):
     super().contents()
 
+    self.require(self.output_voltage >= self.pwr_in.link().voltage)  # it's a boost converter
     self.assign(self.frequency, 1*MHertz(tol=0))  # up to 1 MHz, can be lower
 
     with self.implicit_connect(

--- a/electronics_lib/FanConnector.py
+++ b/electronics_lib/FanConnector.py
@@ -2,7 +2,7 @@ from electronics_abstract_parts import *
 
 
 @abstract_block_default(lambda: CpuFan3Pin)
-class CpuFanConnector(Block):
+class CpuFanConnector(Connector, Block):
     """Abstract block for a 3-pin CPU fan connector."""
     def __init__(self):
         super().__init__()

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -4,7 +4,7 @@ from electronics_abstract_parts import *
 from .JlcPart import JlcPart
 
 
-@abstract_block
+@non_library
 class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, BaseIoControllerPinmapGenerator,
                          InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock):
   PACKAGE: str  # package name for footprint(...)

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -4,7 +4,7 @@ from typing import *
 from electronics_abstract_parts import *
 
 
-@abstract_block
+@non_library
 class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGenerator):
   """Base class for STM32F303x6/8 devices (separate from STM32F303xB/C).
   Unlike other microcontrollers, this one also supports dev boards (Nucleo-32) which can be
@@ -162,7 +162,7 @@ class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGene
     ]).remap_pins(self.RESOURCE_PIN_REMAP)
 
 
-@abstract_block
+@non_library
 class Stm32f303_Device(Stm32f303_Ios, IoController, InternalSubcircuit, GeneratorBlock, FootprintBlock):
   """STM32F303 chip.
   TODO IMPLEMENT ME"""

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -10,7 +10,7 @@ class Nrf52840_Interfaces(IoControllerUsb, IoControllerI2s, IoControllerBle, Bas
   """Defines base interfaces for nRF52840 microcontrollers"""
 
 
-@abstract_block
+@non_library
 class Nrf52840_Ios(Nrf52840_Interfaces, BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, FootprintBlock):
   """nRF52840 IO mappings
   https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.7.pdf"""


### PR DESCRIPTION
Add non_library tags (to prevent some items from showing up in the library browser) and categorization superclasses.
Also add a output-voltage-greater-than-input constraint to the Tps61040 boost converter.