### PR TITLE
Move I2cTarget and SpiPeripheral outside base IoController

### DIFF
--- a/electronics_abstract_parts/IdealIoController.py
+++ b/electronics_abstract_parts/IdealIoController.py
@@ -1,11 +1,13 @@
 from electronics_model import *
 from .Categories import IdealModel
 from .IoController import IoController
-from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s
+from .IoControllerInterfaceMixins import IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerDac, \
+    IoControllerCan, IoControllerUsb, IoControllerI2s, IoControllerWifi, IoControllerBluetooth, IoControllerBle
 
 
-class IdealIoController(IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, IoController, IdealModel,
-                        GeneratorBlock):
+class IdealIoController(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerDac, IoControllerCan,
+                        IoControllerUsb, IoControllerI2s, IoControllerWifi, IoControllerBluetooth, IoControllerBle,
+                        IoController, IdealModel, GeneratorBlock):
     """An ideal IO controller, with as many IOs as requested.
     Output have voltages at pwr/gnd, all other parameters are ideal."""
     def __init__(self) -> None:

--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -33,13 +33,10 @@ class BaseIoController(PinMappable, InternalBlock, Block):
     self._usb_mixin: Optional[IoControllerUsb] = None
     self._can_mixin: Optional[IoControllerCan] = None
 
-    self.spi_peripheral = self.Port(Vector(SpiPeripheral.empty()), optional=True)
-    self.i2c_target = self.Port(Vector(I2cTarget.empty()), optional=True)
-
     self.io_current_draw = self.Parameter(RangeExpr())  # total current draw for all leaf-level IO sinks
 
     self._io_ports: List[BasePort] = [  # ordered by assignment order, most restrictive should be first
-      self.adc, self.spi, self.i2c, self.uart, self.spi_peripheral, self.i2c_target, self.gpio]
+      self.adc, self.spi, self.i2c, self.uart, self.gpio]
 
   def __getattr__(self, item):
     # automatically materialize USB and CAN mixins on abstract classes, only if this is IoController

--- a/electronics_abstract_parts/IoControllerInterfaceMixins.py
+++ b/electronics_abstract_parts/IoControllerInterfaceMixins.py
@@ -2,6 +2,22 @@ from electronics_model import *
 from .IoController import BaseIoController, IoController
 
 
+class IoControllerSpiPeripheral(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.spi_peripheral = self.Port(Vector(SpiPeripheral.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.append(self.spi_peripheral))
+
+
+class IoControllerI2cTarget(BlockInterfaceMixin[BaseIoController]):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.i2c_target = self.Port(Vector(I2cTarget.empty()), optional=True)
+        self.implementation(lambda base: base._io_ports.append(self.i2c_target))
+
+
 class IoControllerDac(BlockInterfaceMixin[BaseIoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/electronics_abstract_parts/__init__.py
+++ b/electronics_abstract_parts/__init__.py
@@ -79,8 +79,8 @@ from .UsbBitBang import UsbBitBang
 
 from .IoController import BaseIoController, IoController, IoControllerPowerRequired
 from .IoController import BaseIoControllerPinmapGenerator, BaseIoControllerExportable
-from .IoControllerInterfaceMixins import IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, \
-    IoControllerDvp8
+from .IoControllerInterfaceMixins import IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerDac, \
+    IoControllerCan, IoControllerUsb, IoControllerI2s, IoControllerDvp8
 from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut
 from .IoControllerInterfaceMixins import IoControllerWifi, IoControllerBluetooth, IoControllerBle
 from .IoControllerProgramming import IoControllerWithSwdTargetConnector

--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -7,8 +7,9 @@ from .Microcontroller_Esp import HasEspProgramming
 
 
 @non_library
-class Esp32_Interfaces(IoControllerDac, IoControllerCan, IoControllerDvp8, IoControllerI2s, IoControllerWifi,
-                       IoControllerBle, IoControllerBluetooth, BaseIoController):
+class Esp32_Interfaces(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerDac, IoControllerCan,
+                       IoControllerDvp8, IoControllerI2s, IoControllerWifi, IoControllerBle, IoControllerBluetooth,
+                       BaseIoController):
   """Defines base interfaces for ESP32 microcontrollers"""
 
 

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -6,7 +6,8 @@ from .Microcontroller_Esp import HasEspProgramming
 
 
 @non_library
-class Esp32c3_Interfaces(IoControllerI2s, IoControllerWifi, IoControllerBle, BaseIoController):
+class Esp32c3_Interfaces(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerI2s, IoControllerWifi,
+                         IoControllerBle, BaseIoController):
   """Defines base interfaces for ESP32C3 microcontrollers"""
 
 

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -7,8 +7,8 @@ from .Microcontroller_Esp import HasEspProgramming
 
 
 @non_library
-class Esp32s3_Interfaces(IoControllerCan, IoControllerUsb, IoControllerI2s, IoControllerDvp8, IoControllerWifi,
-                         IoControllerBle, BaseIoController):
+class Esp32s3_Interfaces(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerCan, IoControllerUsb,
+                         IoControllerI2s, IoControllerDvp8, IoControllerWifi, IoControllerBle, BaseIoController):
   """Defines base interfaces for ESP32S3 microcontrollers"""
 
 

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -5,7 +5,7 @@ from .JlcPart import JlcPart
 
 
 @non_library
-class Lpc1549Base_Device(IoControllerI2cTarget, IoControllerSpiPeripheral, IoControllerDac, IoControllerCan,
+class Lpc1549Base_Device(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerDac, IoControllerCan,
                          IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, JlcPart,
                          FootprintBlock):
   PACKAGE: str  # package name for footprint(...)

--- a/electronics_lib/Microcontroller_Lpc1549.py
+++ b/electronics_lib/Microcontroller_Lpc1549.py
@@ -5,8 +5,9 @@ from .JlcPart import JlcPart
 
 
 @non_library
-class Lpc1549Base_Device(IoControllerDac, IoControllerCan, IoControllerUsb, BaseIoControllerPinmapGenerator,
-                         InternalSubcircuit, GeneratorBlock, JlcPart, FootprintBlock):
+class Lpc1549Base_Device(IoControllerI2cTarget, IoControllerSpiPeripheral, IoControllerDac, IoControllerCan,
+                         IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, JlcPart,
+                         FootprintBlock):
   PACKAGE: str  # package name for footprint(...)
   PART: str  # part name for footprint(...)
   LCSC_PART: str
@@ -335,9 +336,9 @@ class Lpc1549SwdPull(InternalSubcircuit, Block):
 
 
 @abstract_block
-class Lpc1549Base(Resettable, IoControllerDac, IoControllerCan, IoControllerUsb, Microcontroller,
-                  IoControllerWithSwdTargetConnector, WithCrystalGenerator, IoControllerPowerRequired,
-                  BaseIoControllerExportable, GeneratorBlock):
+class Lpc1549Base(Resettable, IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerDac, IoControllerCan,
+                  IoControllerUsb, Microcontroller, IoControllerWithSwdTargetConnector, WithCrystalGenerator,
+                  IoControllerPowerRequired, BaseIoControllerExportable, GeneratorBlock):
   DEVICE: Type[Lpc1549Base_Device] = Lpc1549Base_Device  # type: ignore
   DEFAULT_CRYSTAL_FREQUENCY = 12*MHertz(tol=0.005)
 

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -4,8 +4,8 @@ from electronics_abstract_parts import *
 from .JlcPart import JlcPart
 
 
-class Rp2040_Device(IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSubcircuit, GeneratorBlock, JlcPart,
-                    FootprintBlock):
+class Rp2040_Device(IoControllerI2cTarget, IoControllerUsb, BaseIoControllerPinmapGenerator, InternalSubcircuit,
+                    GeneratorBlock, JlcPart, FootprintBlock):
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 

--- a/electronics_lib/Microcontroller_Rp2040.py
+++ b/electronics_lib/Microcontroller_Rp2040.py
@@ -241,8 +241,8 @@ class Rp2040Usb(InternalSubcircuit, Block):
       UsbBitBang.digital_external_from_link(self.usb_rp.dp)))
 
 
-class Rp2040(Resettable, IoControllerUsb, Microcontroller, IoControllerWithSwdTargetConnector, WithCrystalGenerator,
-             IoControllerPowerRequired, BaseIoControllerExportable, GeneratorBlock):
+class Rp2040(Resettable, IoControllerI2cTarget, IoControllerUsb, Microcontroller, IoControllerWithSwdTargetConnector,
+             WithCrystalGenerator, IoControllerPowerRequired, BaseIoControllerExportable, GeneratorBlock):
   DEFAULT_CRYSTAL_FREQUENCY = 12*MHertz(tol=0.005)
 
   def __init__(self, **kwargs):

--- a/electronics_lib/Microcontroller_Stm32f103.py
+++ b/electronics_lib/Microcontroller_Stm32f103.py
@@ -5,7 +5,7 @@ from .JlcPart import JlcPart
 
 
 @abstract_block
-class Stm32f103Base_Device(IoControllerCan, IoControllerUsb, InternalSubcircuit, BaseIoControllerPinmapGenerator,
+class Stm32f103Base_Device(IoControllerI2cTarget, IoControllerCan, IoControllerUsb, InternalSubcircuit, BaseIoControllerPinmapGenerator,
                            GeneratorBlock, JlcPart, FootprintBlock):
   PACKAGE: str  # package name for footprint(...)
   PART: str  # part name for footprint(...)
@@ -262,8 +262,9 @@ class UsbDpPullUp(InternalSubcircuit, Block):
 
 
 @abstract_block
-class Stm32f103Base(Resettable, IoControllerCan, IoControllerUsb, Microcontroller, IoControllerWithSwdTargetConnector,
-                    WithCrystalGenerator, IoControllerPowerRequired, BaseIoControllerExportable, GeneratorBlock):
+class Stm32f103Base(Resettable, IoControllerI2cTarget, IoControllerCan, IoControllerUsb, Microcontroller,
+                    IoControllerWithSwdTargetConnector, WithCrystalGenerator, IoControllerPowerRequired,
+                    BaseIoControllerExportable, GeneratorBlock):
   DEVICE: Type[Stm32f103Base_Device] = Stm32f103Base_Device  # type: ignore
   DEFAULT_CRYSTAL_FREQUENCY = 12*MHertz(tol=0.005)
 

--- a/electronics_lib/Microcontroller_Stm32f303.py
+++ b/electronics_lib/Microcontroller_Stm32f303.py
@@ -5,7 +5,7 @@ from electronics_abstract_parts import *
 
 
 @non_library
-class Stm32f303_Ios(IoControllerDac, IoControllerCan, BaseIoControllerPinmapGenerator):
+class Stm32f303_Ios(IoControllerI2cTarget, IoControllerDac, IoControllerCan, BaseIoControllerPinmapGenerator):
   """Base class for STM32F303x6/8 devices (separate from STM32F303xB/C).
   Unlike other microcontrollers, this one also supports dev boards (Nucleo-32) which can be
   a power source, so there's a bit more complexity here."""

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -6,7 +6,8 @@ from .JlcPart import JlcPart
 
 
 @non_library
-class Nrf52840_Interfaces(IoControllerUsb, IoControllerI2s, IoControllerBle, BaseIoController):
+class Nrf52840_Interfaces(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerUsb, IoControllerI2s,
+                          IoControllerBle, BaseIoController):
   """Defines base interfaces for nRF52840 microcontrollers"""
 
 

--- a/examples/test_robotcrawler.py
+++ b/examples/test_robotcrawler.py
@@ -102,7 +102,8 @@ class RobotCrawler(RobotCrawlerSpec, JlcBoardTop):
         self.i2c,
         imp.Block(I2cPullup()), imp.Block(I2cTestPoint()))
       self.connect(self.i2c, self.imu.i2c,
-                   self.mcu_servo.i2c_target.request('i2c'), self.mcu_test.i2c_target.request('i2c'))
+                   self.mcu_servo.with_mixin(IoControllerI2cTarget()).i2c_target.request('i2c'),
+                   self.mcu_test.with_mixin(IoControllerI2cTarget()).i2c_target.request('i2c'))
 
       self.connect(self.v3v3, self.imu.vdd, self.imu.vddio)
       self.connect(self.gnd, self.imu.gnd)


### PR DESCRIPTION
Although these are supported almost universally, these are much less commonly used and add visual clutter in the IDE block diagram, especially in connect mode where they are an available connect like their controller port counterparts.