### PR TITLE
Clean up microcontrollers

### DIFF
--- a/electronics_lib/Microcontroller_Esp32.py
+++ b/electronics_lib/Microcontroller_Esp32.py
@@ -134,7 +134,7 @@ class Esp32_Ios(Esp32_Interfaces, BaseIoControllerPinmapGenerator):
 
 
 @abstract_block
-class Esp32_Base(Esp32_Ios, IoController, InternalSubcircuit, GeneratorBlock):
+class Esp32_Base(Esp32_Ios, InternalSubcircuit, GeneratorBlock):
   """Base class for ESP32 series microcontrollers with WiFi and Bluetooth (classic and LE)
 
   Chip datasheet: https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf
@@ -144,8 +144,8 @@ class Esp32_Base(Esp32_Ios, IoController, InternalSubcircuit, GeneratorBlock):
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.pwr.init_from(self._vdd_model())
-    self.gnd.init_from(Ground())
+    self.pwr = self.Port(self._vdd_model(), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     dio_model = self._dio_model(self.pwr, self.gnd)
     self.chip_pu = self.Port(dio_model)  # power control, must NOT be left floating, table 1
@@ -173,7 +173,7 @@ class Esp32_Base(Esp32_Ios, IoController, InternalSubcircuit, GeneratorBlock):
     }).remap(self.SYSTEM_PIN_REMAP)
 
 
-class Esp32_Wroom_32_Device(IoControllerPowerRequired, Esp32_Base, FootprintBlock, JlcPart):
+class Esp32_Wroom_32_Device(Esp32_Base, FootprintBlock, JlcPart):
   """ESP32-WROOM-32 module
 
   Module datasheet: https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32e_esp32-wroom-32ue_datasheet_en.pdf

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -12,7 +12,7 @@ class Esp32c3_Interfaces(IoControllerSpiPeripheral, IoControllerI2cTarget, IoCon
 
 
 @abstract_block
-class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequired, BaseIoControllerPinmapGenerator):
+class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, BaseIoControllerPinmapGenerator):
   """Base class for ESP32-C3 series devices, with RISC-V core, 2.4GHz WiF,i, BLE5.
   PlatformIO: use board ID esp32-c3-devkitm-1
 
@@ -21,11 +21,11 @@ class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, IoControllerPowerRequ
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.pwr.init_from(VoltageSink(
+    self.pwr = self.Port(VoltageSink(
       voltage_limits=(3.0, 3.6)*Volt,  # section 4.2
       current_draw=(0.001, 335)*mAmp + self.io_current_draw.upper()  # section 4.6, from power off to RF active
-    ))
-    self.gnd.init_from(Ground())
+    ), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     self._dio_model = DigitalBidir.from_supply(  # table 4.4
       self.gnd, self.pwr,

--- a/electronics_lib/Microcontroller_Esp32s3.py
+++ b/electronics_lib/Microcontroller_Esp32s3.py
@@ -140,7 +140,7 @@ class Esp32s3_Ios(Esp32s3_Interfaces, BaseIoControllerPinmapGenerator):
 
 
 @abstract_block
-class Esp32s3_Base(Esp32s3_Ios, IoControllerPowerRequired, InternalSubcircuit, GeneratorBlock):
+class Esp32s3_Base(Esp32s3_Ios, InternalSubcircuit, GeneratorBlock):
   """Base class for ESP32-S3 series microcontrollers with WiFi and Bluetooth (classic and LE)
   and AI acceleration
 
@@ -165,8 +165,8 @@ class Esp32s3_Base(Esp32s3_Ios, IoControllerPowerRequired, InternalSubcircuit, G
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.pwr.init_from(self._vdd_model())
-    self.gnd.init_from(Ground())
+    self.pwr = self.Port(self._vdd_model(), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     dio_model = self._dio_model(self.gnd, self.pwr)
     self.chip_pu = self.Port(dio_model)  # table 2-5, power up/down control, do NOT leave floating
@@ -174,7 +174,7 @@ class Esp32s3_Base(Esp32s3_Ios, IoControllerPowerRequired, InternalSubcircuit, G
     self.uart0 = self.Port(UartPort(dio_model), optional=True)  # programming
 
 
-class Esp32s3_Wroom_1_Device(Esp32s3_Base, IoControllerPowerRequired, FootprintBlock, JlcPart):
+class Esp32s3_Wroom_1_Device(Esp32s3_Base, FootprintBlock, JlcPart):
   SYSTEM_PIN_REMAP: Dict[str, Union[str, List[str]]] = {
     'VDD': '2',
     'GND': ['1', '40', '41'],  # 41 is EP

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -283,6 +283,7 @@ class Holyiot_18010(Microcontroller, Radiofrequency, Resettable, Nrf52840_Interf
     self.connect(self.reset_node, self.ic.nreset)
 
   def generate(self):
+    super().generate()
     if self.get(self.reset.is_connected()):
       self.connect(self.reset, self.ic.nreset)
 

--- a/electronics_lib/Microcontroller_nRF52840.py
+++ b/electronics_lib/Microcontroller_nRF52840.py
@@ -7,7 +7,7 @@ from .JlcPart import JlcPart
 
 @non_library
 class Nrf52840_Interfaces(IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerUsb, IoControllerI2s,
-                          IoControllerBle, BaseIoController):
+                          IoControllerBle):
   """Defines base interfaces for nRF52840 microcontrollers"""
 
 
@@ -170,7 +170,7 @@ class Nrf52840_Ios(Nrf52840_Interfaces, BaseIoControllerPinmapGenerator, Interna
 
 
 @abstract_block
-class Nrf52840_Base(Nrf52840_Ios, IoControllerPowerRequired, InternalSubcircuit, GeneratorBlock):
+class Nrf52840_Base(Nrf52840_Ios, InternalSubcircuit, GeneratorBlock):
   SYSTEM_PIN_REMAP: Dict[str, Union[str, List[str]]]  # pin name in base -> pin name(s)
 
   def _gnd_vddio(self) -> Tuple[Port[VoltageLink], Port[VoltageLink]]:
@@ -187,8 +187,8 @@ class Nrf52840_Base(Nrf52840_Ios, IoControllerPowerRequired, InternalSubcircuit,
   def __init__(self, **kwargs) -> None:
     super().__init__(**kwargs)
 
-    self.pwr.init_from(self._vdd_model())
-    self.gnd.init_from(Ground())
+    self.pwr = self.Port(self._vdd_model(), [Power])
+    self.gnd = self.Port(Ground(), [Common])
 
     self.pwr_usb = self.Port(VoltageSink(
       voltage_limits=(4.35, 5.5)*Volt,


### PR DESCRIPTION
Removes IoController from supertypes of internal chip blocks.
Also fixes one of the nRF52840 module that was missing a generate super call.