### PR TITLE
String add ops, optional test point naming

### DIFF
--- a/.github/workflows/pr-scala.yml
+++ b/.github/workflows/pr-scala.yml
@@ -34,9 +34,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: install dependencies
-      run: |
-        pip install protobuf sexpdata Deprecated
-
+      run: pip install -r requirements.txt
     - name: sbt test
       run: cd compiler && sbt -v +test
 

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -116,7 +116,7 @@ class AssignNamer() {
 }
 
 object Compiler {
-  final val kExpectedProtoVersion = 2
+  final val kExpectedProtoVersion = 3
 }
 
 /** Compiler for a particular design, with an associated library to elaborate references from.

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -31,6 +31,7 @@ object ExprEvaluate {
           case (FloatValue(lhs), FloatPromotable(rhs)) => FloatValue(lhs + rhs)
           case (FloatPromotable(lhs), FloatValue(rhs)) => FloatValue(lhs + rhs)
           case (IntValue(lhs), IntValue(rhs)) => IntValue(lhs + rhs)
+          case (TextValue(lhs), TextValue(rhs)) => TextValue(lhs + rhs)
           case _ =>
             throw new ExprEvaluateException(s"Unknown binary operand types in $lhs ${binary.op} $rhs from $binary")
         }

--- a/edg_core/Binding.py
+++ b/edg_core/Binding.py
@@ -311,7 +311,7 @@ class BinaryOpBinding(Binding):
   def __init__(self,
                lhs: ConstraintExpr,
                rhs: ConstraintExpr,
-               op: Union[NumericOp,BoolOp,EqOp,OrdOp,RangeSetOp]):
+               op: Union[NumericOp, BoolOp, EqOp, OrdOp, RangeSetOp]):
     self.op_map = {
       # Numeric
       NumericOp.add: edgir.BinaryExpr.ADD,

--- a/edg_core/ConstraintExpr.py
+++ b/edg_core/ConstraintExpr.py
@@ -193,7 +193,7 @@ class NumLikeExpr(ConstraintExpr[WrappedType, NumLikeCastable], Generic[WrappedT
   def _create_binary_op(cls,
                         lhs: SelfType,
                         rhs: SelfType,
-                        op: Union[NumericOp,RangeSetOp]) -> SelfType:
+                        op: Union[NumericOp, RangeSetOp]) -> SelfType:
     """Creates a new expression that is the result of a binary operation on inputs"""
     if type(lhs) != type(rhs):
       raise TypeError(f"op args must be of same type, "
@@ -472,6 +472,16 @@ class StringExpr(ConstraintExpr[str, StringLike]):
   def _is_lit(self) -> bool:
     assert self._is_bound()
     return isinstance(self.binding, StringLiteralBinding)
+
+  def __add__(self, rhs: StringLike) -> StringExpr:
+    rhs_typed = self._to_expr_type(rhs)
+    assert self._is_bound() and rhs_typed._is_bound()
+    return self._new_bind(BinaryOpBinding(self, rhs_typed, NumericOp.add))
+
+  def __radd__(self, lhs: StringLike) -> StringExpr:
+    lhs_typed = self._to_expr_type(lhs)
+    assert lhs_typed._is_bound() and self._is_bound()
+    return self._new_bind(BinaryOpBinding(self, lhs_typed, NumericOp.add))
 
 
 class AssignExpr(ConstraintExpr[None, None]):

--- a/edg_hdl_server/__main__.py
+++ b/edg_hdl_server/__main__.py
@@ -10,7 +10,7 @@ from edg_core import *
 from edg_core.Core import NonLibraryProperty
 
 
-EDG_PROTO_VERSION = 2
+EDG_PROTO_VERSION = 3
 
 
 class LibraryElementIndexer:

--- a/electronics_abstract_parts/AbstractTestPoint.py
+++ b/electronics_abstract_parts/AbstractTestPoint.py
@@ -58,6 +58,7 @@ class DigitalTestPoint(BaseTypedTestPoint, Block):
 
 class DigitalArrayTestPoint(TypedTestPoint, GeneratorBlock):
   """Creates an array of Digital test points, sized from the port array's connections."""
+  @init_in_parent
   def __init__(self, name: StringLike = ''):
     super().__init__()
     self.io = self.Port(Vector(DigitalSink.empty()), [InOut])

--- a/examples/BldcController/BldcController.net
+++ b/examples/BldcController/BldcController.net
@@ -166,7 +166,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "_mcu_i2c_i2c_link.sda")
   (footprint "edg:TestPoint_TE_RCT_0805")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))

--- a/examples/IotKnob/IotKnob.net
+++ b/examples/IotKnob/IotKnob.net
@@ -243,7 +243,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "i2c_chain_0.sda")
   (footprint "edg:TestPoint_TE_RCT_0805")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))

--- a/examples/RobotCrawler/RobotCrawler.net
+++ b/examples/RobotCrawler/RobotCrawler.net
@@ -826,7 +826,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "i2c_chain_0.sda")
   (footprint "edg:TestPoint_TE_RCT_0805")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))

--- a/examples/RobotDriver/RobotDriver.net
+++ b/examples/RobotDriver/RobotDriver.net
@@ -375,7 +375,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "i2c_chain_0.sda")
   (footprint "edg:TestPoint_TE_RCT_0805")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))

--- a/examples/RobotDriver3/RobotDriver3.net
+++ b/examples/RobotDriver3/RobotDriver3.net
@@ -298,7 +298,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "i2c_chain_0.sda")
   (footprint "edg:TestPoint_TE_RCT_0805")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))

--- a/examples/SevenSegment/SevenSegment.net
+++ b/examples/SevenSegment/SevenSegment.net
@@ -331,7 +331,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "i2c_chain_0.sda")
   (footprint "edg:TestPoint_TE_RCT_0805")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))

--- a/examples/TofArray/TofArray.net
+++ b/examples/TofArray/TofArray.net
@@ -551,7 +551,7 @@
   (sheetpath (names "/i2c_tp/") (tstamps "/07770242/"))
   (tstamps "08f50286"))
 (comp (ref "i2c_tp.tp_sda")
-  (value "i2c_tp._io_sda_link")
+  (value "i2c_chain_0.sda")
   (footprint "TestPoint:TestPoint_Keystone_5015_Micro-Minature")
   (property (name "Sheetname") (value "i2c_tp"))
   (property (name "Sheetfile") (value "electronics_abstract_parts.AbstractTestPoint.I2cTestPoint"))


### PR DESCRIPTION
Add + operator to StringExpr, including compiler support and a versioning bump.

Allow optional specification of test point names. If unspecified, it defaults to the link name.

Also update CI definition to avoid a flakey test