### PR TITLE
Add XIAO ESP32C3, prototype docstring improvement for some devices

### DIFF
--- a/electronics_abstract_parts/AbstractPowerConverters.py
+++ b/electronics_abstract_parts/AbstractPowerConverters.py
@@ -9,8 +9,13 @@ from .Resettable import Resettable
 
 @abstract_block_default(lambda: IdealVoltageRegulator)
 class VoltageRegulator(PowerConditioner):
-  """Base class for all DC-DC voltage regulators with shared ground (non-isolated).
-  Can produce an output voltage lower than, equal to, or greater than its input voltage."""
+  """Structural abstract base class for DC-DC voltage regulators with shared ground (non-isolated).
+  This takes some input voltage and produces a stable voltage at output_voltage on its output.
+
+  While this abstract class does not define any limitations on the output voltage, subclasses and concrete
+  implementations commonly have restrictions, for example linear regulators can only produce voltages lower
+  than the input voltage.
+  """
   @init_in_parent
   def __init__(self, output_voltage: RangeLike) -> None:
     super().__init__()
@@ -58,7 +63,12 @@ class VoltageRegulatorEnableWrapper(Resettable, VoltageRegulator, GeneratorBlock
 
 @abstract_block_default(lambda: IdealLinearRegulator)
 class LinearRegulator(VoltageRegulator):
-  """Linear regulator, including supporting components in application circuit like capacitors if needed"""
+  """Structural abstract base class for linear regulators, a voltage regulator that can produce some
+  output voltage lower than its input voltage (minus some dropout) by 'burning' the excess voltage as heat.
+
+  Compared to switching converters like buck and boost converters, linear regulators usually have lower
+  complexity, lower parts count, and higher stability. However, depending on the application, they are
+  typically less efficient, and at higher loads may require thermal design considerations."""
 
 
 @abstract_block

--- a/electronics_abstract_parts/IoController.py
+++ b/electronics_abstract_parts/IoController.py
@@ -190,7 +190,17 @@ def makeIdealIoController():  # needed to avoid circular import
 
 @abstract_block_default(makeIdealIoController)
 class IoController(ProgrammableController, BaseIoController):
-  """An abstract, generic IO controller with optional common IOs and power ports."""
+  """Structural abstract base class for a programmable controller chip (including microcontrollers that take firmware,
+  and FPGAs that take gateware).
+
+  This provides the model of a grab bag of IOs on its structural interface, and supports common peripherals as
+  Vectors of GPIO, ADC, I2C, and SPI. The pin_assigns argument can be used to specify how to map Vector elements
+  to physical (by footprint pin number) or logical pins (by pin name).
+  Less common peripheral types like CAN and DAC can be added with mixins.
+
+  This defines a power input port that powers the device, though the IoControllerPowerOut mixin can be used
+  for a controller that provides power, for example a development board powered from onboard USB.
+  """
   def __init__(self, *awgs, **kwargs) -> None:
     super().__init__(*awgs, **kwargs)
 

--- a/electronics_lib/LinearRegulators.py
+++ b/electronics_lib/LinearRegulators.py
@@ -105,6 +105,9 @@ class Ldl1117_Device(InternalSubcircuit, LinearRegulatorDevice, GeneratorBlock, 
 
 
 class Ldl1117(LinearRegulator):
+  """A series of fixed-output, general-purpose, low-dropout linear regulators in SOT-223 and
+  supporting up to 18V input and 1.2A draw.
+  """
   def contents(self) -> None:
     with self.implicit_connect(
         ImplicitConnect(self.gnd, [Common]),

--- a/electronics_lib/Microcontroller_Esp32c3.py
+++ b/electronics_lib/Microcontroller_Esp32c3.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import *
 
 from electronics_abstract_parts import *
@@ -86,7 +87,7 @@ class Esp32c3_Ios(Esp32c3_Interfaces, BaseIoControllerPinmapGenerator):
 
 
 @abstract_block
-class Esp32c3_Base(Esp32c3_Interfaces, InternalSubcircuit, BaseIoControllerPinmapGenerator):
+class Esp32c3_Base(Esp32c3_Ios, InternalSubcircuit, BaseIoControllerPinmapGenerator):
   """Base class for ESP32-C3 series devices, with RISC-V core, 2.4GHz WiF,i, BLE5.
   PlatformIO: use board ID esp32-c3-devkitm-1
 
@@ -393,7 +394,7 @@ class Esp32c3(Microcontroller, Radiofrequency, HasEspProgramming, Resettable, Es
 
 
 class Xiao_Esp32c3(IoControllerUsbOut, IoControllerPowerOut, Esp32c3_Ios, IoController, GeneratorBlock,
-                             FootprintBlock):
+                   FootprintBlock):
   """ESP32-C3 development board, a tiny development (21x17.5mm) daughterboard with a RISC-V microcontroller
   supporting WiFi and BLE. Has an onboard USB connector, so this can also source power.
 

--- a/electronics_lib/SwitchMatrix.py
+++ b/electronics_lib/SwitchMatrix.py
@@ -4,9 +4,11 @@ from electronics_abstract_parts import *
 
 
 class SwitchMatrix(HumanInterface, GeneratorBlock):
-  """A switch matrix that generates (rows * cols) switches while only using max(rows, cols) IOs, by arranging
-  them in a matrix, having the driver drive one col low at a time and reading which rows are low
-  (with all cols weakly pulled high).
+  """A switch matrix, such as for a keyboard, that generates (nrows * ncols) switches while only
+  using max(nrows, ncols) IOs.
+
+  Internally, the switches are in a matrix, with the driver driving one col low at a time while
+  reading which rows are low (with the other cols weakly pulled high).
   This uses the Switch abstract class, which can be refined into e.g. a tactile switch or mechanical keyswitch.
 
   This generates per-switch diodes which allows multiple keys to be pressed simultaneously.

--- a/electronics_lib/__init__.py
+++ b/electronics_lib/__init__.py
@@ -78,7 +78,7 @@ from .Microcontroller_Esp import HasEspProgramming
 from .Microcontroller_Esp import EspAutoProgram
 from .Microcontroller_Esp32 import Esp32_Wroom_32, Freenove_Esp32_Wrover
 from .Microcontroller_Esp32s3 import Esp32s3_Wroom_1, Freenove_Esp32s3_Wroom
-from .Microcontroller_Esp32c3 import Esp32c3_Wroom02, Esp32c3
+from .Microcontroller_Esp32c3 import Esp32c3_Wroom02, Esp32c3, Xiao_Esp32c3
 from .Microcontroller_Rp2040 import Rp2040
 from .Fpga_Ice40up import Ice40up5k_Sg48
 


### PR DESCRIPTION
Add the XIAO ESP32C3 microcontroller dev board (power input and output modes). Untested. Note, since the ESP32C3 has a lot of pins needed for boot, only 6 of the 11 IO pins end up usable.

Improves the docstring for these classes:
- Abstract IoController
- Abstract VoltageRegulator
- Abstract LinearRegulator
- Ldl1117
- SwitchMatrix