### PR TITLE
Compile progress

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -775,7 +775,7 @@ class Compiler private (
     }
 
     // Queue up sub-trees that need elaboration - needs to be post-generate for generators
-    val subblockProgress = progress / block.getBlocks.size
+    val subblockProgress = progress / (block.getBlocks.size + 1)
     currentProgress += subblockProgress
     progressFn.foreach(_(currentProgress))
     block.getBlocks.foreach { case (innerBlockName, innerBlock) =>

--- a/compiler/src/main/scala/edg/compiler/CompilerError.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerError.scala
@@ -21,9 +21,9 @@ object CompilerError {
     override def toIr: edgcompiler.ErrorRecord = {
       val missingStr = "missing " + missing.map(_.toString).mkString(", ")
       val (kind, path) = record match {
-        case ElaborateRecord.ExpandBlock(path, _) =>
+        case ElaborateRecord.ExpandBlock(path, _, _) =>
           (f"Uncompiled block, $missingStr", Some(path.asIndirect.toLocalPath))
-        case ElaborateRecord.Block(path) => (f"Uncompiled block, $missingStr", Some(path.asIndirect.toLocalPath))
+        case ElaborateRecord.Block(path, _) => (f"Uncompiled block, $missingStr", Some(path.asIndirect.toLocalPath))
         case ElaborateRecord.Link(path) => (f"Uncompiled link, $missingStr", Some(path.asIndirect.toLocalPath))
         case ElaborateRecord.LinkArray(path) =>
           (f"Uncompiled link array, $missingStr", Some(path.asIndirect.toLocalPath))

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialBlockTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialBlockTest.scala
@@ -141,7 +141,8 @@ class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
       CompilerError.Unelaborated(
         ElaborateRecord.ExpandBlock(
           DesignPath() + "source" + "inner",
-          ElemBuilder.LibraryPath("sourceBlock")
+          ElemBuilder.LibraryPath("sourceBlock"),
+          0.5f
         ),
         Set()
       )
@@ -160,7 +161,8 @@ class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
       CompilerError.Unelaborated(
         ElaborateRecord.ExpandBlock(
           DesignPath() + "source" + "inner",
-          ElemBuilder.LibraryPath("sourceBlock")
+          ElemBuilder.LibraryPath("sourceBlock"),
+          0.5f
         ),
         Set()
       )
@@ -187,7 +189,8 @@ class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
       CompilerError.Unelaborated(
         ElaborateRecord.ExpandBlock(
           DesignPath() + "source" + "inner",
-          ElemBuilder.LibraryPath("sourceBlock")
+          ElemBuilder.LibraryPath("sourceBlock"),
+          0.5f
         ),
         Set()
       )

--- a/compiler/src/test/scala/edg/compiler/CompilerPartialBlockTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerPartialBlockTest.scala
@@ -142,7 +142,7 @@ class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
         ElaborateRecord.ExpandBlock(
           DesignPath() + "source" + "inner",
           ElemBuilder.LibraryPath("sourceBlock"),
-          0.5f
+          1.0f / 6
         ),
         Set()
       )
@@ -162,7 +162,7 @@ class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
         ElaborateRecord.ExpandBlock(
           DesignPath() + "source" + "inner",
           ElemBuilder.LibraryPath("sourceBlock"),
-          0.5f
+          1.0f / 6
         ),
         Set()
       )
@@ -190,7 +190,7 @@ class CompilerPartialBlockTest extends AnyFlatSpec with CompilerTestUtil {
         ElaborateRecord.ExpandBlock(
           DesignPath() + "source" + "inner",
           ElemBuilder.LibraryPath("sourceBlock"),
-          0.5f
+          1.0f / 6
         ),
         Set()
       )


### PR DESCRIPTION
Adds an optional progressFn to Compiler, which is regularly called and updated with the overall compilation progress.

Each block has some progress value, defined as the total compilation progress (0-1) completed when the block and its subtree are fully compiled. The top block's progress value is 1, and each block's progress is the parent's progress divided by the immediate number of siblings plus 1 (the extra 1 is for the parent itself - updated when the block is compiled).

In practice this isn't linear, since units of work get progressively smaller, but it's probably better than nothing.