### PR TITLE
Allow unnamed elements in error messages

### DIFF
--- a/edg/core/Array.py
+++ b/edg/core/Array.py
@@ -130,7 +130,7 @@ class Vector(BaseVector, Generic[VectorType]):
     return self._elts.items()
 
   # unlike most other LibraryElement types, the names are stored in _elts and _allocates
-  def _name_of_child(self, subelt: Any) -> str:
+  def _name_of_child(self, subelt: Any, allow_unknown: bool = False) -> str:
     from .HierarchyBlock import Block
     block_parent = self._block_parent()
     assert isinstance(block_parent, Block)
@@ -141,7 +141,10 @@ class Vector(BaseVector, Generic[VectorType]):
       for (name, elt) in self._elts.items():
         if subelt is elt:
           return name
-      raise ValueError(f"no name for {subelt}")
+      if allow_unknown:
+        return f"(unknown {subelt.__class__.__name__})"
+      else:
+        raise ValueError(f"no name for {subelt}")
     elif builder.get_enclosing_block() is block_parent._parent:
       # in block enclosing the block defining this port (allocate required)
       for (i, (suggested_name, allocate_elt)) in enumerate(self._requests):
@@ -150,7 +153,10 @@ class Vector(BaseVector, Generic[VectorType]):
             return suggested_name
           else:
             return f"_allocate_{i}"
-      raise ValueError(f"allocated elt not found {subelt}")
+      if allow_unknown:
+        return f"(unknown {subelt.__class__.__name__})"
+      else:
+        raise ValueError(f"allocated elt not found {subelt}")
     else:
       raise ValueError(f"unknown context of array")
 

--- a/edg/core/Blocks.py
+++ b/edg/core/Blocks.py
@@ -88,7 +88,7 @@ class Connection():
       if is_export:
         (ext_port, int_port) = is_export
         if ext_port._get_initializers([]):
-          raise UnconnectableError(f"Connected boundary port {ext_port._name_from(self.parent)} may not have initializers")
+          raise UnconnectableError(f"Connected boundary port {ext_port._name_from(self.parent, allow_unknown=True)} may not have initializers")
         return  # is an export, not a connection
 
     # otherwise, is a link-mediated connection
@@ -111,19 +111,19 @@ class Connection():
       if isinstance(self.parent, Block):  # check if bridge is needed
         if port._block_parent() is self.parent:
           if port._get_initializers([]):
-            raise UnconnectableError(f"Connected boundary port {port._name_from(self.parent)} may not have initializers")
+            raise UnconnectableError(f"Connected boundary port {port._name_from(self.parent, allow_unknown=True)} may not have initializers")
           if not isinstance(port, Port):
-            raise UnconnectableError(f"Can't generate bridge for non-Port {port._name_from(self.parent)}")
+            raise UnconnectableError(f"Can't generate bridge for non-Port {port._name_from(self.parent, allow_unknown=True)}")
 
           bridge = port._bridge()
           if bridge is None:
-            raise UnconnectableError(f"No bridge for {port._name_from(self.parent)}")
+            raise UnconnectableError(f"No bridge for {port._name_from(self.parent, allow_unknown=True)}")
           link_facing_port = self.bridged_ports[port] = bridge.inner_link
         else:
           link_facing_port = port
       elif isinstance(self.parent, Link):  # links don't bridge, all ports are treated as internal
         if port._block_parent() is not self.parent:
-          raise UnconnectableError(f"Port {port._name_from(self.parent)} not in containing link")
+          raise UnconnectableError(f"Port {port._name_from(self.parent, allow_unknown=True)} not in containing link")
         link_facing_port = port
       else:
         raise ValueError(f"unknown parent {self.parent}")
@@ -134,13 +134,13 @@ class Connection():
 
       # allocate the connection
       if self._baseport_leaf_type(link_facing_port).link_type is not type(link):
-        raise UnconnectableError(f"Can't connect {port._name_from(self.parent)} to link of type {type(link)}")
+        raise UnconnectableError(f"Can't connect {port._name_from(self.parent, allow_unknown=True)} to link of type {type(link)}")
       port_type = type(self._baseport_leaf_type(link_facing_port))
       allocatable_link_ports = self.available_link_ports_by_type.get(port_type, None)
       if allocatable_link_ports is None:
-        raise UnconnectableError(f"No link port for {port._name_from(self.parent)} of type {port_type}")
+        raise UnconnectableError(f"No link port for {port._name_from(self.parent, allow_unknown=True)} of type {port_type}")
       if not allocatable_link_ports:
-        raise UnconnectableError(f"No remaining link ports to {port._name_from(self.parent)}")
+        raise UnconnectableError(f"No remaining link ports to {port._name_from(self.parent, allow_unknown=True)}")
 
       allocated_link_port = allocatable_link_ports[0]
       if isinstance(allocated_link_port, BaseVector):  # array on link side, can connected multiple ports

--- a/edg/core/Core.py
+++ b/edg/core/Core.py
@@ -214,22 +214,28 @@ class LibraryElement(Refable, metaclass=ElementMeta):
       self.manager.add_element(name, value)
     super().__setattr__(name, value)
 
-  def _name_of_child(self, subelt: Any) -> str:
+  def _name_of_child(self, subelt: Any, allow_unknown: bool = False) -> str:
     self_name = self.manager.name_of(subelt)
     if self_name is not None:
       return self_name
     else:
-      raise ValueError(f"no name for {subelt}")
+      if allow_unknown:
+        return f"(unknown {subelt.__class__.__name__})"
+      else:
+        raise ValueError(f"no name for {subelt}")
 
-  def _path_from(self, base: LibraryElement) -> List[str]:
+  def _path_from(self, base: LibraryElement, allow_unknown: bool = False) -> List[str]:
     if base is self:
       return []
     else:
       assert self._parent is not None, "can't get path / name for non-bound element"
-      return self._parent._path_from(base) + [self._parent._name_of_child(self)]
+      return self._parent._path_from(base, allow_unknown) + [self._parent._name_of_child(self, allow_unknown)]
 
-  def _name_from(self, base: LibraryElement) -> str:
-    return '.'.join(self._path_from(base))
+  def _name_from(self, base: LibraryElement, allow_unknown: bool = False) -> str:
+    """Returns the path name to (inclusive) this element from some starting point.
+    allow_unknown allows elements that haven't been assigned a name yet to not crash,
+    this is useful when called from an error so the _name_from error doesn't stomp the real error."""
+    return '.'.join(self._path_from(base, allow_unknown))
 
   @classmethod
   def _static_def_name(cls) -> str:


### PR DESCRIPTION
Prior, exceptions that use _name_of that had an unknown element would stack-trace with the _name_of. This could happen, for instance, during an invalid implicit connect before the Block is assigned a name. This adds an optional argument to _name_of to auto-generate unknown names for elements.

The generate unknown names behavior isn't default for cases where the name must be valid (as opposed to only being helpfully informative).