### PR TITLE
Disallow inner connects

### DIFF
--- a/edg/core/Blocks.py
+++ b/edg/core/Blocks.py
@@ -219,7 +219,7 @@ class DescriptionString():
       self.ref = ref
       self.units = units
 
-    def set_elt_proto(self, pb, ref_map):
+    def set_elt_proto(self, pb, ref_map=None):
       new_phrase = pb.description.add()
       new_phrase.param.path.CopyFrom(ref_map[self.ref])
       new_phrase.param.unit = self.units

--- a/edg/core/Blocks.py
+++ b/edg/core/Blocks.py
@@ -554,7 +554,10 @@ class BaseBlock(HasMetadata, Generic[BaseBlockEdgirType]):
         enclosing_block = port._block_parent()
         assert enclosing_block is not None
         if enclosing_block._parent is not self:
-          raise UnconnectableError("Inaccessible port for connection")
+          raise UnconnectableError("Inaccessible port: must be own port or inner block port")
+        if not(port._parent is enclosing_block or \
+                (isinstance(port._parent, Vector) and port._parent._parent is enclosing_block)):
+          raise UnconnectableError("Inaccessible port: cannot connect inner ports on inner blocks")
       self._connects_by_port[port] = connect
     connect.add_ports(connects_ports_new)
 

--- a/edg/core/test_bundle.py
+++ b/edg/core/test_bundle.py
@@ -1,4 +1,3 @@
-from typing import *
 import unittest
 
 from . import *

--- a/edg/core/test_connect_bundle.py
+++ b/edg/core/test_connect_bundle.py
@@ -1,0 +1,26 @@
+import unittest
+
+from . import *
+from .HdlUserExceptions import UnconnectableError
+from .test_elaboration_common import TestBlockSource
+from .test_bundle import TestBundle
+
+
+class TestInner(Block):
+    def __init__(self) -> None:
+        super().__init__()
+        self.port = self.Port(TestBundle())
+
+
+class TestInvalidOuter(Block):
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner = self.Block(TestInner())
+        self.source = self.Block(TestBlockSource())
+        self.connect(self.inner.port.a, self.source.source)
+
+
+class BundleConnectError(unittest.TestCase):
+    def test_contains_param(self) -> None:
+        with self.assertRaises(UnconnectableError):
+            TestInvalidOuter()._elaborated_def_to_proto()

--- a/edg/core/test_connect_bundle.py
+++ b/edg/core/test_connect_bundle.py
@@ -20,7 +20,7 @@ class TestInvalidOuter(Block):
         self.connect(self.inner.port.a, self.source.source)
 
 
-class BundleConnectError(unittest.TestCase):
-    def test_contains_param(self) -> None:
+class BundleInnerConnectError(unittest.TestCase):
+    def test_connect_error(self) -> None:
         with self.assertRaises(UnconnectableError):
             TestInvalidOuter()._elaborated_def_to_proto()


### PR DESCRIPTION
Adds a frontend error so it doesn't result in a confusing compiler internal error.

Also fixes an unrelated type annotation issue flagged by a new version of mypy.