### PR TITLE
improve categorization

### DIFF
--- a/edg/abstract_parts/AbstractCapacitor.py
+++ b/edg/abstract_parts/AbstractCapacitor.py
@@ -355,7 +355,7 @@ class CombinedCapacitorElement(Capacitor):  # to avoid an abstract part error
     self.assign(self.actual_capacitance, self.capacitance)  # fake it, since a combined capacitance is handwavey
 
 
-class CombinedCapacitor(PassiveComponent, MultipackBlock, GeneratorBlock):
+class CombinedCapacitor(MultipackDevice, MultipackBlock, GeneratorBlock):
   """A packed capacitor that combines multiple individual capacitors into a single component,
   with the sum of or taking the max of the constituent capacitances."""
   @init_in_parent

--- a/edg/abstract_parts/AbstractLed.py
+++ b/edg/abstract_parts/AbstractLed.py
@@ -278,7 +278,7 @@ class IndicatorSinkPackedRgbLedElement(IndicatorSinkLed):
     super().__init__(current_draw=RangeExpr())
 
 
-class IndicatorSinkPackedRgbLed(Light, MultipackBlock):
+class IndicatorSinkPackedRgbLed(MultipackDevice, MultipackBlock):
   def __init__(self):
     super().__init__()
 

--- a/edg/abstract_parts/AbstractOpamp.py
+++ b/edg/abstract_parts/AbstractOpamp.py
@@ -1,7 +1,7 @@
 from typing import Mapping, Tuple, List, NamedTuple
 
 from ..electronics_model import *
-from .Categories import Analog
+from .Categories import Analog, MultipackDevice
 
 
 @abstract_block
@@ -32,7 +32,7 @@ class OpampElement(Opamp):
 
 
 @abstract_block
-class MultipackOpamp(Analog, MultipackBlock):
+class MultipackOpamp(MultipackDevice, MultipackBlock):
   """Base class for packed opamps - devices that have multiple opamps in a single package,
   with shared power and ground connections. Typically used with the multipack feature to
   fit individual opamps across the design hierarchy into one of these."""

--- a/edg/abstract_parts/AbstractResistorArray.py
+++ b/edg/abstract_parts/AbstractResistorArray.py
@@ -14,7 +14,7 @@ class ResistorArrayElement(Resistor):  # to avoid an abstract part error
 
 
 @abstract_block
-class ResistorArray(PassiveComponent, MultipackBlock):
+class ResistorArray(MultipackDevice, MultipackBlock):
   """An n-element resistor array, where all resistors have the same resistance and power rating."""
   @init_in_parent
   def __init__(self, count: IntLike = 0) -> None:  # 0 means 'size automatically'

--- a/edg/abstract_parts/Categories.py
+++ b/edg/abstract_parts/Categories.py
@@ -86,6 +86,22 @@ class DigitalToAnalog(Interface):
 
 
 @abstract_block
+class SpeakerDriver(Interface):
+  pass
+
+
+@abstract_block
+class IoExpander(Interface):
+  pass
+
+
+@abstract_block
+class BitBangAdapter(Interface):
+  """Adapters that break out a structured Bundle to component wires, useful when bit-banging those protocols"""
+  pass
+
+
+@abstract_block
 class Radiofrequency(Block):
   """Radiofrequency devices."""
   pass
@@ -195,12 +211,39 @@ class EnvironmentalSensor(Sensor):
 
 
 @abstract_block
+class TemperatureSensor(EnvironmentalSensor):
+  pass
+
+
+@abstract_block
+class HumiditySensor(EnvironmentalSensor):
+  pass
+
+
+@abstract_block
+class PressureSensor(EnvironmentalSensor):
+  """Sensors measuring ambient pressure"""
+  pass
+
+
+@abstract_block
+class GasSensor(EnvironmentalSensor):
+  """Sensors measuring gas concentration, including non-particle IAQ, TVOC, eCO2, and CO2 sensors."""
+  pass
+
+
+@abstract_block
 class LightSensor(Sensor):
   pass
 
 
 @abstract_block
 class Magnetometer(Sensor):
+  pass
+
+
+@abstract_block
+class Microphone(Sensor):
   pass
 
 
@@ -224,6 +267,13 @@ class Protection(Block):
 @abstract_block
 class Testing(Block):
   """Blocks for testing (eg, test points) and programming (eg, programming headers)."""
+  pass
+
+
+@abstract_block
+class MultipackDevice(Block):
+  """A multipack device (e.g., dualpack opamp, quadpack resistor array) which blocks across the design
+  can be merged into."""
   pass
 
 

--- a/edg/abstract_parts/UsbBitBang.py
+++ b/edg/abstract_parts/UsbBitBang.py
@@ -5,7 +5,7 @@ from .Categories import *
 from .AbstractResistor import Resistor
 
 
-class UsbBitBang(Interface, Block):
+class UsbBitBang(BitBangAdapter, Block):
   """Bit-bang circuit for USB, from the UPduino3.0 circuit and for 3.3v.
   Presumably generalizes to any digital pin that can be driven fast enough.
 

--- a/edg/abstract_parts/__init__.py
+++ b/edg/abstract_parts/__init__.py
@@ -10,13 +10,15 @@ from .Categories import DiscreteApplication
 from .Categories import Analog, OpampApplication
 from .Categories import Filter, AnalogFilter, DigitalFilter
 from .Categories import Microcontroller, Fpga, Memory, RealtimeClock, Radiofrequency
-from .Categories import Interface, AnalogToDigital, DigitalToAnalog
+from .Categories import Interface, AnalogToDigital, DigitalToAnalog, SpeakerDriver, IoExpander, BitBangAdapter
 from .Categories import PowerConditioner, PowerSwitch, MotorDriver, BrushedMotorDriver, BldcDriver
 from .Categories import PowerSource, Connector, ProgrammingConnector
 from .Categories import HumanInterface, Display, Lcd, Oled, EInk, Light
-from .Categories import Sensor, CurrentSensor, Accelerometer, Gyroscope, Magnetometer, DistanceSensor, Camera, \
-    EnvironmentalSensor, LightSensor
+from .Categories import Sensor, CurrentSensor, Accelerometer, Gyroscope, Magnetometer, DistanceSensor, Microphone, \
+    Camera, LightSensor
+from .Categories import EnvironmentalSensor, TemperatureSensor, HumiditySensor, PressureSensor, GasSensor
 from .Categories import Label, Testing, TypedJumper, TypedTestPoint, InternalSubcircuit, DeprecatedBlock, Mechanical
+from .Categories import MultipackDevice
 
 from .ESeriesUtil import ESeriesUtil
 from .SmdStandardPackage import SmdStandardPackage, SmdStandardPackageSelector

--- a/edg/core/Generator.py
+++ b/edg/core/Generator.py
@@ -134,6 +134,7 @@ class GeneratorBlock(Block):
     return self._def_to_proto()
 
 
+@non_library
 class DefaultExportBlock(GeneratorBlock):
   """EXPERIMENTAL UTILITY CLASS. There needs to be a cleaner way to address this eventually,
   perhaps as a core compiler construct.

--- a/edg/parts/EnvironmentalSensor_Bme680.py
+++ b/edg/parts/EnvironmentalSensor_Bme680.py
@@ -41,7 +41,7 @@ class Bme680_Device(InternalSubcircuit, FootprintBlock, JlcPart):
         self.assign(self.actual_basic_part, False)
 
 
-class Bme680(EnvironmentalSensor, DefaultExportBlock):
+class Bme680(TemperatureSensor, HumiditySensor, PressureSensor, GasSensor, DefaultExportBlock):
     """Gas (indoor air quality), pressure, temperature, and humidity sensor.
     Humidity accuracy /-3% RH, pressure noise 0.12 Pa, temperature accuracy +/-0.5 C @ 25C"""
     def __init__(self):

--- a/edg/parts/EnvironmentalSensor_Sensirion.py
+++ b/edg/parts/EnvironmentalSensor_Sensirion.py
@@ -34,7 +34,7 @@ class Shtc3_Device(InternalSubcircuit, FootprintBlock, JlcPart):
         self.assign(self.actual_basic_part, False)
 
 
-class Shtc3(EnvironmentalSensor, Block):
+class Shtc3(TemperatureSensor, HumiditySensor, Block):
     """Humidity and temperature sensor with +/-2% RH and +/-0.2C"""
     def __init__(self):
         super().__init__()

--- a/edg/parts/EnvironmentalSensor_Ti.py
+++ b/edg/parts/EnvironmentalSensor_Ti.py
@@ -36,7 +36,7 @@ class Hdc1080_Device(InternalSubcircuit, FootprintBlock, JlcPart):
         self.assign(self.actual_basic_part, False)
 
 
-class Hdc1080(EnvironmentalSensor, Block):
+class Hdc1080(TemperatureSensor, HumiditySensor, Block):
     """Temperature and humidity sensor with +/- 0.2C and +/- 2% RH typical accuracy"""
     def __init__(self):
         super().__init__()
@@ -95,7 +95,7 @@ class Tmp1075n_Device(InternalSubcircuit, FootprintBlock, JlcPart, GeneratorBloc
         self.assign(self.actual_basic_part, False)
 
 
-class Tmp1075n(EnvironmentalSensor, Block):
+class Tmp1075n(TemperatureSensor, Block):
     """Temperature sensor with 0.25C typical accuracy"""
     @init_in_parent
     def __init__(self, addr_lsb: IntLike = 0):

--- a/edg/parts/IoExpander_Pca9554.py
+++ b/edg/parts/IoExpander_Pca9554.py
@@ -78,7 +78,7 @@ class Pca9554_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
     self.assign(self.lcsc_part, 'C86803')
 
 
-class Pca9554(Interface, PinMappable):
+class Pca9554(IoExpander, PinMappable):
   """8 bit I2C IO expander"""
   @init_in_parent
   def __init__(self, addr_lsb: IntLike = 0) -> None:

--- a/edg/parts/IoExpander_Pcf8574.py
+++ b/edg/parts/IoExpander_Pcf8574.py
@@ -78,7 +78,7 @@ class Pcf8574_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
     self.assign(self.lcsc_part, "C86832")
 
 
-class Pcf8574(Interface, PinMappable):
+class Pcf8574(IoExpander, PinMappable):
   """8 bit I2C IO expander with 'quasi-bidirectional IOs'"""
   @init_in_parent
   def __init__(self, addr_lsb: IntLike = 0) -> None:

--- a/edg/parts/Microphone_Sd18ob261.py
+++ b/edg/parts/Microphone_Sd18ob261.py
@@ -44,7 +44,7 @@ class Sd18ob261_Device(InternalSubcircuit, JlcPart, FootprintBlock):
         self.assign(self.actual_basic_part, False)
 
 
-class Sd18ob261(Interface, GeneratorBlock):
+class Sd18ob261(Microphone, GeneratorBlock):
     """SD18OB261-060 PDM microphone, probably footprint-compatible with similar Knowles devices.
     Application circuit is not specified in the datasheet, this uses the one from SPH0655LM4H
     (single 0.1uF decap)."""

--- a/edg/parts/SpeakerDriver_Analog.py
+++ b/edg/parts/SpeakerDriver_Analog.py
@@ -39,7 +39,7 @@ class Lm4871_Device(InternalSubcircuit, FootprintBlock):
         )
 
 
-class Lm4871(Interface, Block):
+class Lm4871(SpeakerDriver, Block):
     def __init__(self):
         super().__init__()
         # TODO should be a SpeakerDriver abstract part
@@ -128,7 +128,7 @@ class Tpa2005d1_Device(InternalSubcircuit, JlcPart, FootprintBlock):
         self.assign(self.actual_basic_part, False)
 
 
-class Tpa2005d1(Interface, GeneratorBlock):
+class Tpa2005d1(SpeakerDriver, GeneratorBlock):
     """TPA2005D1 configured in single-ended input mode.
     Possible semi-pin-compatible with PAM8302AASCR (C113367), but which has internal resistor."""
     @init_in_parent
@@ -232,7 +232,7 @@ class Pam8302a_Device(InternalSubcircuit, JlcPart, FootprintBlock):
         self.assign(self.actual_basic_part, False)
 
 
-class Pam8302a(Interface):
+class Pam8302a(SpeakerDriver, Block):
     """PAM8302A configured in single-ended input mode."""
     @init_in_parent
     def __init__(self):

--- a/edg/parts/SpeakerDriver_Max98357a.py
+++ b/edg/parts/SpeakerDriver_Max98357a.py
@@ -74,7 +74,7 @@ class Max98357a_Device(InternalSubcircuit, JlcPart, PartsTableFootprint, PartsTa
         self.assign(self.lcsc_part, jlc_part)
         self.assign(self.actual_basic_part, False)
 
-class Max98357a(Interface, Block):
+class Max98357a(SpeakerDriver, Block):
     """MAX98357A I2S speaker driver with default gain."""
     @init_in_parent
     def __init__(self):


### PR DESCRIPTION
Resolves #312 

- Add subcategorizations of Interface and EnvironmentalSensor
- Add MultipackDevice categorization, which replaces any prior categorization - multipack devices should not be used in the context of a normal block