### PR TITLE
Re-use host Python process when compiling from command line

### DIFF
--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -117,7 +117,7 @@ class AssignNamer() {
 }
 
 object Compiler {
-  final val kExpectedProtoVersion = 5
+  final val kExpectedProtoVersion = 6
 }
 
 /** Compiler for a particular design, with an associated library to elaborate references from.

--- a/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
@@ -12,13 +12,11 @@ import java.io.{PrintWriter, StringWriter}
   * compilation is running
   */
 class HostPythonInterface extends ProtobufInterface {
-  val responseType = edgrpc.HdlResponse
-
   protected val stdoutStream = new QueueStream()
   val outputStream = stdoutStream.getReader
 
   protected val outputDeserializer =
-    new ProtobufStreamDeserializer[edgrpc.HdlResponse](System.in, responseType, stdoutStream)
+    new ProtobufStreamDeserializer[edgrpc.HdlResponse](System.in, edgrpc.HdlResponse, stdoutStream)
   protected val outputSerializer = new ProtobufStreamSerializer[edgrpc.HdlRequest](System.out)
 
   override def write(message: edgrpc.HdlRequest): Unit = outputSerializer.write(message)
@@ -78,8 +76,7 @@ object CompilerServerMain {
       if (expectedMagicByte == -1) {
         System.exit(0) // end of stream, shut it down
       }
-
-      require(expectedMagicByte == ProtobufStdioSubprocess.kHeaderMagicByte || expectedMagicByte < 0)
+      require(expectedMagicByte == ProtobufStdioSubprocess.kHeaderMagicByte)
       val request = edgcompiler.CompilerRequest.parseDelimitedFrom(System.in)
 
       val protoInterface = new HostPythonInterface()

--- a/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
@@ -9,7 +9,7 @@ import edgir.elem.elem
 import edgir.ref.ref
 import edgir.schema.schema
 
-import java.io.{File, PrintWriter, StringWriter}
+import java.io.{PrintWriter, StringWriter}
 
 // a PythonInterface that uses the on-event hooks to forward stderr and stdout
 // without this, the compiler can freeze on large stdout/stderr data, possibly because of queue sizing

--- a/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
+++ b/compiler/src/main/scala/edg/compiler/CompilerServerMain.scala
@@ -71,6 +71,7 @@ object CompilerServerMain {
   }
 
   def main(args: Array[String]): Unit = {
+    val pyLib = new PythonInterfaceLibrary() // allow the library cache to persist across requests
     while (true) { // handle multiple requests sequentially in the same process
       val expectedMagicByte = System.in.read()
       if (expectedMagicByte == -1) {
@@ -94,7 +95,6 @@ object CompilerServerMain {
         Thread.sleep(kHdlVersionMismatchDelayMs)
       }
 
-      val pyLib = new PythonInterfaceLibrary()
       pyLib.withPythonInterface(compilerInterface) {
         val result = compile(request.get, pyLib)
 

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -59,7 +59,6 @@ class ProtobufStreamSerializer[MessageType <: scalapb.GeneratedMessage](stream: 
 trait ProtobufInterface {
   def write(message: edgrpc.HdlRequest): Unit
   def read(): edgrpc.HdlResponse
-  def finish(): Unit
 }
 
 class ProtobufStdioSubprocess(
@@ -107,8 +106,6 @@ class ProtobufStdioSubprocess(
     }
     outputDeserializer.read()
   }
-
-  override def finish() = shutdown()
 
   // Shuts down the stream and returns the exit value
   def shutdown(): Int = {

--- a/compiler/src/main/scala/edg/compiler/PythonInterface.scala
+++ b/compiler/src/main/scala/edg/compiler/PythonInterface.scala
@@ -65,8 +65,6 @@ class ProtobufStdioSubprocess(
     interpreter: String = "python",
     pythonPaths: Seq[String] = Seq()
 ) extends ProtobufInterface {
-  val responseType = edgrpc.HdlResponse
-
   private val submoduleSearchPaths = if (pythonPaths.nonEmpty) pythonPaths else Seq(".")
   private val isSubmoduled =
     submoduleSearchPaths.map { searchPath => // check if submoduled, if so prepend the submodule name
@@ -95,7 +93,7 @@ class ProtobufStdioSubprocess(
   val errorStream: InputStream = process.getErrorStream
 
   protected val outputDeserializer =
-    new ProtobufStreamDeserializer[edgrpc.HdlResponse](process.getInputStream, responseType, stdoutStream)
+    new ProtobufStreamDeserializer[edgrpc.HdlResponse](process.getInputStream, edgrpc.HdlResponse, stdoutStream)
   protected val outputSerializer = new ProtobufStreamSerializer[edgrpc.HdlRequest](process.getOutputStream)
 
   override def write(message: edgrpc.HdlRequest): Unit = outputSerializer.write(message)

--- a/compiler/src/main/scala/edg/util/QueueStream.scala
+++ b/compiler/src/main/scala/edg/util/QueueStream.scala
@@ -16,10 +16,9 @@ class QueueStream extends OutputStream {
 
   override def write(data: Int): Unit = queue.enqueue(data.toByte)
 
-  def getReader: Reader = new Reader
-
   class Reader extends InputStream {
     override def read(): Int = queue.dequeue()
     override def available(): Int = queue.length
   }
+  def getReader: Reader = new Reader
 }

--- a/compiler/src/main/scala/edg/util/QueueStream.scala
+++ b/compiler/src/main/scala/edg/util/QueueStream.scala
@@ -1,6 +1,6 @@
 package edg.util
 
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
 import collection.mutable
 
 /** Why the heck are we writing another QueueStream when we have things like Apache QueueInputStream?
@@ -11,12 +11,15 @@ import collection.mutable
   *
   * So here, yet another variation of Stream. Yay.
   */
-class QueueStream extends InputStream {
+class QueueStream extends OutputStream {
   protected val queue = mutable.Queue[Byte]()
 
-  override def read(): Int = queue.dequeue()
-  override def available(): Int = queue.length
+  override def write(data: Int): Unit = queue.enqueue(data.toByte)
 
-  // don't want to bother writing a separate OutputStream version, so the write methods are just stuffed in here
-  def write(data: Int): Unit = queue.enqueue(data.toByte)
+  def getReader: Reader = new Reader
+
+  class Reader extends InputStream {
+    override def read(): Int = queue.dequeue()
+    override def available(): Int = queue.length
+  }
 }

--- a/compiler/src/test/scala/edg/compiler/PythonInterfaceTest.scala
+++ b/compiler/src/test/scala/edg/compiler/PythonInterfaceTest.scala
@@ -12,8 +12,9 @@ class PythonInterfaceTest extends AnyFlatSpec {
     val compiledDir = new File(getClass.getResource("").getPath)
     // above returns compiler/target/scala-2.xx/test-classes/edg/compiler, get the root repo dir
     val repoDir = compiledDir.getParentFile.getParentFile.getParentFile.getParentFile.getParentFile.getParentFile
-    val pyIf = new PythonInterface(pythonPaths = Seq(repoDir.getAbsolutePath))
+    val pyProcess = new ProtobufStdioSubprocess(pythonPaths = Seq(repoDir.getAbsolutePath))
+    val pyIf = new PythonInterface(pyProcess)
     pyIf.indexModule("edg.core").getClass should equal(classOf[Errorable.Success[Seq[LibraryPath]]])
-    pyIf.shutdown() should equal(0)
+    pyProcess.shutdown() should equal(0)
   }
 }

--- a/edg/core/ScalaCompilerInterface.py
+++ b/edg/core/ScalaCompilerInterface.py
@@ -64,7 +64,7 @@ class CompiledDesign:
 
 
 class ScalaCompilerInstance:
-  kDevRelpath = "../../compiler/target/scala-2.13/edg-compiler-assembly-0.1-SNAPSHOTjar"
+  kDevRelpath = "../../compiler/target/scala-2.13/edg-compiler-assembly-0.1-SNAPSHOT.jar"
   kPrecompiledRelpath = "resources/edg-compiler-precompiled.jar"
 
   def __init__(self, *, suppress_stderr: bool = False):

--- a/edg/core/ScalaCompilerInterface.py
+++ b/edg/core/ScalaCompilerInterface.py
@@ -116,18 +116,18 @@ class ScalaCompilerInstance:
 
     # until the compiler gives back the response, this acts as the HDL server,
     # taking requests in the opposite direction
-    # assert self.process.stdin is not None
-    # assert self.process.stdout is not None
-    # hdl_request_deserializer = BufferDeserializer(edgrpc.HdlRequest, self.process.stdout)
-    # hdl_response_serializer = BufferSerializer[edgrpc.HdlResponse](self.process.stdin)
-    # while True:
-    #   sys.stdout.buffer.write(hdl_request_deserializer.read_stdout())
-    #   hdl_request = hdl_request_deserializer.read()
-    #   assert hdl_request is not None
-    #   hdl_response = process_request(hdl_request)
-    #   if hdl_response is None:
-    #     break
-    #   hdl_response_serializer.write(hdl_response)
+    assert self.process.stdin is not None
+    assert self.process.stdout is not None
+    hdl_request_deserializer = BufferDeserializer(edgrpc.HdlRequest, self.process.stdout)
+    hdl_response_serializer = BufferSerializer[edgrpc.HdlResponse](self.process.stdin)
+    while True:
+      sys.stdout.buffer.write(hdl_request_deserializer.read_stdout())
+      hdl_request = hdl_request_deserializer.read()
+      assert hdl_request is not None
+      hdl_response = process_request(hdl_request)
+      if hdl_response is None:
+        break
+      hdl_response_serializer.write(hdl_response)
 
     response_deserializer = BufferDeserializer(edgrpc.CompilerResult, self.process.stdout)
     result = response_deserializer.read()

--- a/edg/core/test_generator.py
+++ b/edg/core/test_generator.py
@@ -1,7 +1,9 @@
 import unittest
+from os import devnull
+from contextlib import redirect_stderr
 
 from . import *
-from .ScalaCompilerInterface import ScalaCompiler, ScalaCompilerInstance
+from .ScalaCompilerInterface import ScalaCompiler
 
 
 class TestGeneratorAssign(Block):
@@ -205,8 +207,6 @@ class GeneratorFailure(GeneratorBlock):
 
 class GeneratorFailureTestCase(unittest.TestCase):
   def test_metadata(self) -> None:
-    # if we don't suppress the output, the error from the generator propagates to the test console
-    compiler = ScalaCompilerInstance(suppress_stderr=True)
-    with self.assertRaises(CompilerCheckError) as context:
-      compiler.compile(TestGeneratorFailure)
-    compiler.close()  # if we don't close it, we get a ResourceWarning
+    with self.assertRaises(CompilerCheckError), \
+            open(devnull, 'w') as fnull, redirect_stderr(fnull):  # suppress generator error
+      self.compiled = ScalaCompiler.compile(TestGeneratorFailure)

--- a/edg/hdl_server/__main__.py
+++ b/edg/hdl_server/__main__.py
@@ -2,7 +2,7 @@ import importlib
 import inspect
 import sys
 from types import ModuleType
-from typing import Set, Type, Tuple, TypeVar, cast
+from typing import Set, Type, Tuple, TypeVar, cast, Optional
 
 from .. import edgir
 from .. import edgrpc
@@ -82,6 +82,67 @@ def class_from_library(elt: edgir.LibraryPath, expected_superclass: Type[Library
   return cls
 
 
+def process_request(request: edgrpc.HdlRequest) -> Optional[edgrpc.HdlResponse]:
+  response = edgrpc.HdlResponse()
+  if request.HasField('index_module'):
+    module = importlib.import_module(request.index_module.name)
+    library = LibraryElementIndexer()
+    indexed = [edgir.LibraryPath(target=edgir.LocalStep(name=indexed._static_def_name()))
+               for indexed in library.index_module(module)]
+    response.index_module.indexed.extend(indexed)
+    return response
+  elif request.HasField('get_library_element'):
+    cls = class_from_library(request.get_library_element.element,
+                             LibraryElement)  # type: ignore
+    obj, obj_proto = elaborate_class(cls)
+
+    response.get_library_element.element.CopyFrom(obj_proto)
+    if isinstance(obj, DesignTop):
+      obj.refinements().populate_proto(response.get_library_element.refinements)
+    return response
+  elif request.HasField('elaborate_generator'):
+    generator_type = class_from_library(request.elaborate_generator.element,
+                                        GeneratorBlock)
+    generator_obj = generator_type()
+
+    response.elaborate_generator.generated.CopyFrom(builder.elaborate_toplevel(
+      generator_obj,
+      is_generator=True,
+      generate_values=[(value.path, value.value) for value in request.elaborate_generator.values]))
+    return response
+  elif request.HasField('run_refinement'):
+    refinement_pass_class = class_from_library(request.run_refinement.refinement_pass,
+                                               BaseRefinementPass)  # type: ignore
+    refinement_pass = refinement_pass_class()
+
+    refinement_results = refinement_pass.run(
+      CompiledDesign.from_request(request.run_refinement.design, request.run_refinement.solvedValues))
+    response.run_refinement.SetInParent()
+    for path, refinement_result in refinement_results:
+      new_value = response.run_refinement.newValues.add()
+      new_value.path.CopyFrom(path)
+      new_value.value.CopyFrom(refinement_result)
+    return response
+  elif request.HasField('run_backend'):
+    backend_class = class_from_library(request.run_backend.backend,
+                                       BaseBackend)  # type: ignore
+    backend = backend_class()
+
+    backend_results = backend.run(
+      CompiledDesign.from_request(request.run_backend.design, request.run_backend.solvedValues),
+      dict(request.run_backend.arguments))
+    response.run_backend.SetInParent()
+    for path, backend_result in backend_results:
+      response_result = response.run_backend.results.add()
+      response_result.path.CopyFrom(path)
+      response_result.text = backend_result
+    return response
+  elif request.HasField('get_proto_version'):
+    response.get_proto_version = EDG_PROTO_VERSION
+    return response
+  else:
+    return None
+
 def run_server():
   stdin_deserializer = BufferDeserializer(edgrpc.HdlRequest, sys.stdin.buffer)
   stdout_serializer = BufferSerializer[edgrpc.HdlResponse](sys.stdout.buffer)
@@ -91,63 +152,14 @@ def run_server():
     if request is None:  # end of stream
       sys.exit(0)
 
-    response = edgrpc.HdlResponse()
     try:
-      if request.HasField('index_module'):
-        module = importlib.import_module(request.index_module.name)
-        library = LibraryElementIndexer()
-        indexed = [edgir.LibraryPath(target=edgir.LocalStep(name=indexed._static_def_name()))
-                   for indexed in library.index_module(module)]
-        response.index_module.indexed.extend(indexed)
-      elif request.HasField('get_library_element'):
-        cls = class_from_library(request.get_library_element.element,
-                                 LibraryElement)  # type: ignore
-        obj, obj_proto = elaborate_class(cls)
-
-        response.get_library_element.element.CopyFrom(obj_proto)
-        if isinstance(obj, DesignTop):
-          obj.refinements().populate_proto(response.get_library_element.refinements)
-      elif request.HasField('elaborate_generator'):
-        generator_type = class_from_library(request.elaborate_generator.element,
-                                            GeneratorBlock)
-        generator_obj = generator_type()
-
-        response.elaborate_generator.generated.CopyFrom(builder.elaborate_toplevel(
-          generator_obj,
-          is_generator=True,
-          generate_values=[(value.path, value.value) for value in request.elaborate_generator.values]))
-      elif request.HasField('run_refinement'):
-        refinement_pass_class = class_from_library(request.run_refinement.refinement_pass,
-                                                   BaseRefinementPass)  # type: ignore
-        refinement_pass = refinement_pass_class()
-
-        refinement_results = refinement_pass.run(
-          CompiledDesign.from_request(request.run_refinement.design, request.run_refinement.solvedValues))
-        response.run_refinement.SetInParent()
-        for path, refinement_result in refinement_results:
-          new_value = response.run_refinement.newValues.add()
-          new_value.path.CopyFrom(path)
-          new_value.value.CopyFrom(refinement_result)
-      elif request.HasField('run_backend'):
-        backend_class = class_from_library(request.run_backend.backend,
-                                           BaseBackend)  # type: ignore
-        backend = backend_class()
-
-        backend_results = backend.run(
-          CompiledDesign.from_request(request.run_backend.design, request.run_backend.solvedValues),
-          dict(request.run_backend.arguments))
-        response.run_backend.SetInParent()
-        for path, backend_result in backend_results:
-          response_result = response.run_backend.results.add()
-          response_result.path.CopyFrom(path)
-          response_result.text = backend_result
-      elif request.HasField('get_proto_version'):
-        response.get_proto_version = EDG_PROTO_VERSION
-      else:
+      response = process_request(request)
+      if response is None:
         raise RuntimeError(f"Unknown request {request}")
     except BaseException as e:
       import traceback
       # exception formatting from https://stackoverflow.com/questions/4564559/get-exception-description-and-stack-trace-which-caused-an-exception-all-as-a-st
+      response = edgrpc.HdlResponse()
       response.error.error = repr(e)
       response.error.traceback = "".join(traceback.TracebackException.from_exception(e).format())
       # also print it, to preserve the usual behavior of errors in Python

--- a/edg/hdl_server/__main__.py
+++ b/edg/hdl_server/__main__.py
@@ -136,7 +136,7 @@ def process_request(request: edgrpc.HdlRequest) -> Optional[edgrpc.HdlResponse]:
     elif request.HasField('get_proto_version'):
       response.get_proto_version = EDG_PROTO_VERSION
     else:
-      response = None
+      return None
   except BaseException as e:
     import traceback
     # exception formatting from https://stackoverflow.com/questions/4564559/get-exception-description-and-stack-trace-which-caused-an-exception-all-as-a-st
@@ -160,7 +160,7 @@ def run_server():
     if response is None:
       raise RuntimeError(f"Unknown request {request}")
 
-    sys.stdout.buffer.write(stdin_deserializer.read_stdout())
+    sys.stdout.buffer.write(stdin_deserializer.read_stdout())  # forward prints and stuff
     stdout_serializer.write(response)
 
 

--- a/edg/hdl_server/__main__.py
+++ b/edg/hdl_server/__main__.py
@@ -84,64 +84,68 @@ def class_from_library(elt: edgir.LibraryPath, expected_superclass: Type[Library
 
 def process_request(request: edgrpc.HdlRequest) -> Optional[edgrpc.HdlResponse]:
   response = edgrpc.HdlResponse()
-  if request.HasField('index_module'):
-    module = importlib.import_module(request.index_module.name)
-    library = LibraryElementIndexer()
-    indexed = [edgir.LibraryPath(target=edgir.LocalStep(name=indexed._static_def_name()))
-               for indexed in library.index_module(module)]
-    response.index_module.indexed.extend(indexed)
-    return response
-  elif request.HasField('get_library_element'):
-    cls = class_from_library(request.get_library_element.element,
-                             LibraryElement)  # type: ignore
-    obj, obj_proto = elaborate_class(cls)
+  try:
+    if request.HasField('index_module'):
+      module = importlib.import_module(request.index_module.name)
+      library = LibraryElementIndexer()
+      indexed = [edgir.LibraryPath(target=edgir.LocalStep(name=indexed._static_def_name()))
+                 for indexed in library.index_module(module)]
+      response.index_module.indexed.extend(indexed)
+    elif request.HasField('get_library_element'):
+      cls = class_from_library(request.get_library_element.element,
+                               LibraryElement)  # type: ignore
+      obj, obj_proto = elaborate_class(cls)
 
-    response.get_library_element.element.CopyFrom(obj_proto)
-    if isinstance(obj, DesignTop):
-      obj.refinements().populate_proto(response.get_library_element.refinements)
-    return response
-  elif request.HasField('elaborate_generator'):
-    generator_type = class_from_library(request.elaborate_generator.element,
-                                        GeneratorBlock)
-    generator_obj = generator_type()
+      response.get_library_element.element.CopyFrom(obj_proto)
+      if isinstance(obj, DesignTop):
+        obj.refinements().populate_proto(response.get_library_element.refinements)
+    elif request.HasField('elaborate_generator'):
+      generator_type = class_from_library(request.elaborate_generator.element,
+                                          GeneratorBlock)
+      generator_obj = generator_type()
 
-    response.elaborate_generator.generated.CopyFrom(builder.elaborate_toplevel(
-      generator_obj,
-      is_generator=True,
-      generate_values=[(value.path, value.value) for value in request.elaborate_generator.values]))
-    return response
-  elif request.HasField('run_refinement'):
-    refinement_pass_class = class_from_library(request.run_refinement.refinement_pass,
-                                               BaseRefinementPass)  # type: ignore
-    refinement_pass = refinement_pass_class()
+      response.elaborate_generator.generated.CopyFrom(builder.elaborate_toplevel(
+        generator_obj,
+        is_generator=True,
+        generate_values=[(value.path, value.value) for value in request.elaborate_generator.values]))
+    elif request.HasField('run_refinement'):
+      refinement_pass_class = class_from_library(request.run_refinement.refinement_pass,
+                                                 BaseRefinementPass)  # type: ignore
+      refinement_pass = refinement_pass_class()
 
-    refinement_results = refinement_pass.run(
-      CompiledDesign.from_request(request.run_refinement.design, request.run_refinement.solvedValues))
-    response.run_refinement.SetInParent()
-    for path, refinement_result in refinement_results:
-      new_value = response.run_refinement.newValues.add()
-      new_value.path.CopyFrom(path)
-      new_value.value.CopyFrom(refinement_result)
-    return response
-  elif request.HasField('run_backend'):
-    backend_class = class_from_library(request.run_backend.backend,
-                                       BaseBackend)  # type: ignore
-    backend = backend_class()
+      refinement_results = refinement_pass.run(
+        CompiledDesign.from_request(request.run_refinement.design, request.run_refinement.solvedValues))
+      response.run_refinement.SetInParent()
+      for path, refinement_result in refinement_results:
+        new_value = response.run_refinement.newValues.add()
+        new_value.path.CopyFrom(path)
+        new_value.value.CopyFrom(refinement_result)
+    elif request.HasField('run_backend'):
+      backend_class = class_from_library(request.run_backend.backend,
+                                         BaseBackend)  # type: ignore
+      backend = backend_class()
 
-    backend_results = backend.run(
-      CompiledDesign.from_request(request.run_backend.design, request.run_backend.solvedValues),
-      dict(request.run_backend.arguments))
-    response.run_backend.SetInParent()
-    for path, backend_result in backend_results:
-      response_result = response.run_backend.results.add()
-      response_result.path.CopyFrom(path)
-      response_result.text = backend_result
-    return response
-  elif request.HasField('get_proto_version'):
-    response.get_proto_version = EDG_PROTO_VERSION
-    return response
-  else:
-    return None
+      backend_results = backend.run(
+        CompiledDesign.from_request(request.run_backend.design, request.run_backend.solvedValues),
+        dict(request.run_backend.arguments))
+      response.run_backend.SetInParent()
+      for path, backend_result in backend_results:
+        response_result = response.run_backend.results.add()
+        response_result.path.CopyFrom(path)
+        response_result.text = backend_result
+    elif request.HasField('get_proto_version'):
+      response.get_proto_version = EDG_PROTO_VERSION
+    else:
+      response = None
+  except BaseException as e:
+    import traceback
+    # exception formatting from https://stackoverflow.com/questions/4564559/get-exception-description-and-stack-trace-which-caused-an-exception-all-as-a-st
+    response = edgrpc.HdlResponse()
+    response.error.error = repr(e)
+    response.error.traceback = "".join(traceback.TracebackException.from_exception(e).format())
+    # also print it, to preserve the usual behavior of errors in Python
+    traceback.print_exc()
+  return response
 
 def run_server():
   stdin_deserializer = BufferDeserializer(edgrpc.HdlRequest, sys.stdin.buffer)
@@ -152,18 +156,9 @@ def run_server():
     if request is None:  # end of stream
       sys.exit(0)
 
-    try:
-      response = process_request(request)
-      if response is None:
-        raise RuntimeError(f"Unknown request {request}")
-    except BaseException as e:
-      import traceback
-      # exception formatting from https://stackoverflow.com/questions/4564559/get-exception-description-and-stack-trace-which-caused-an-exception-all-as-a-st
-      response = edgrpc.HdlResponse()
-      response.error.error = repr(e)
-      response.error.traceback = "".join(traceback.TracebackException.from_exception(e).format())
-      # also print it, to preserve the usual behavior of errors in Python
-      traceback.print_exc()
+    response = process_request(request)
+    if response is None:
+      raise RuntimeError(f"Unknown request {request}")
 
     sys.stdout.buffer.write(stdin_deserializer.read_stdout())
     stdout_serializer.write(response)

--- a/edg/hdl_server/__main__.py
+++ b/edg/hdl_server/__main__.py
@@ -10,7 +10,7 @@ from ..core import *
 from ..core.Core import NonLibraryProperty
 
 
-EDG_PROTO_VERSION = 5
+EDG_PROTO_VERSION = 6
 
 
 class LibraryElementIndexer:


### PR DESCRIPTION
... instead of spawning a sub-process. This keeps namespaces consistent (in a way that spawning a subprocess wouldn't) and allows the use of a Python debugger. Resolves #362 

NOTE FOR DEBUGGING: the IDE (compile-design) does not yet support debugging, so you'll need to create a main stub (like bllinky_skeleton.py, as if running from the command line) and debug from that. But breakpoints do work.

Implementation-wise, this 'flips' the client / server role: after sending the design to compile to the server, the Python process then acts as an HDL server until receiving an empty request (denoting end of compilation), then waits for the compilation result. This also restructures the interface structure, notably bringing the core compiler interface structurally closer to the Python implementation, with a dedicated serializer / deserializer class (instead of it being monolithic).

This also refactors the compiler to eliminate error suppression, instead moving it into the generator test case (using redirect_stderr) which is the only place this functionality is used. This new structure also un-suppresses a warning in the test suite, which will be addressed separately.

Also bumps the compiler version.