### PR TITLE
Schematic import multiline value support

### DIFF
--- a/edg/electronics_model/KiCadSchematicBlock.py
+++ b/edg/electronics_model/KiCadSchematicBlock.py
@@ -201,6 +201,7 @@ class KiCadSchematicBlock(Block):
                 value_suffixes = [int(name[5:]) for name in symbol.properties.keys()
                                   if name.startswith('Value') and len(name) > 5]
                 if len(value_suffixes):  # support fake-multiline values with Value2, Value3, ...
+                  assert min(value_suffixes) == 2, "additional Values must start at 2"
                   max_value = max(value_suffixes)
                   for suffix in range(2, max_value + 1):  # starts at Value2
                     assert f'Value{suffix}' in symbol.properties, f"missing Value{suffix} of Value{max_value}"

--- a/edg/electronics_model/resources/test_kicad_import_inline.kicad_sch
+++ b/edg/electronics_model/resources/test_kicad_import_inline.kicad_sch
@@ -1,220 +1,614 @@
-(kicad_sch (version 20211123) (generator eeschema)
-
-  (uuid b55f6c44-5d5d-4524-bb86-893662f64598)
-
-  (paper "A4")
-
-  (title_block
-    (title "Simple Circuit")
-    (date "2022-08-02")
-    (rev "v01")
-  )
-
-  (lib_symbols
-    (symbol "Device:C" (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (id 0) (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (id 1) (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (id 2) (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (id 3) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (id 4) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (id 5) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (id 6) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default) (color 0 0 0 0))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default) (color 0 0 0 0))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (id 0) (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (id 1) (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (id 2) (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (id 3) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (id 4) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (id 5) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (id 6) (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default) (color 0 0 0 0))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 91.44 96.52) (diameter 0) (color 0 0 0 0)
-    (uuid 21362588-9ca4-4df5-aaff-e66a21a01f68)
-  )
-
-  (wire (pts (xy 91.44 86.36) (xy 91.44 96.52))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 03903112-54ec-4875-b5c3-fcc4ec71e52c)
-  )
-  (wire (pts (xy 111.76 86.36) (xy 111.76 96.52))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 36780335-0429-4c3d-8635-e5ed12711612)
-  )
-  (wire (pts (xy 104.14 86.36) (xy 111.76 86.36))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 3b4c322b-7512-4787-a5f9-2684210df4f3)
-  )
-  (wire (pts (xy 74.93 96.52) (xy 80.01 96.52))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 4902dc83-92f4-47f2-ad47-efdda384a841)
-  )
-  (wire (pts (xy 91.44 86.36) (xy 96.52 86.36))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 4f1c1eac-36d8-440f-b4fc-e04c50ea8c7a)
-  )
-  (wire (pts (xy 87.63 96.52) (xy 91.44 96.52))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 7affbfd1-3b77-4468-baac-310ca0e0aad7)
-  )
-  (wire (pts (xy 109.22 96.52) (xy 111.76 96.52))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid 887ec3e8-1522-42b6-a4e7-8d9f0f5e559f)
-  )
-  (wire (pts (xy 91.44 96.52) (xy 101.6 96.52))
-    (stroke (width 0) (type default) (color 0 0 0 0))
-    (uuid d68ed73e-45b3-441c-84c3-918bed62b055)
-  )
-
-  (label "node" (at 91.44 86.36 180)
-    (effects (font (size 1.27 1.27)) (justify right bottom))
-    (uuid c7d8a50c-4fee-4f62-ac07-94d27775fe21)
-  )
-  (label "GND" (at 111.76 86.36 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid f8594364-7085-4d63-b6db-0503245aaae3)
-  )
-
-  (global_label "PORT_A" (shape input) (at 74.93 96.52 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 0da1a194-de46-4113-bdca-98125569a602)
-    (property "Intersheet References" "${INTERSHEET_REFS}" (id 0) (at 65.6226 96.4406 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 100.33 86.36 90) (unit 1)
-    (in_bom yes) (on_board yes)
-    (uuid 1baff40e-08de-469f-a254-3c085c13e6e4)
-    (property "Reference" "R2" (id 0) (at 100.33 81.28 90))
-    (property "Value" "#Resistor(51*Ohm(tol=0.05))" (id 1) (at 100.33 83.82 90))
-    (property "Footprint" "" (id 2) (at 100.33 88.138 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (id 3) (at 100.33 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a02f0f34-dddc-4832-be11-3b9e6c331cdd))
-    (pin "2" (uuid fe6d2a99-fc91-45f3-ada1-7b7ef0e61489))
-  )
-
-  (symbol (lib_id "Device:R") (at 83.82 96.52 90) (unit 1)
-    (in_bom yes) (on_board yes)
-    (uuid 691e9d02-a5cc-48a1-b9c1-b97da20de9cd)
-    (property "Reference" "R1" (id 0) (at 83.82 91.44 90))
-    (property "Value" "#Resistor(51*Ohm(tol=0.05))" (id 1) (at 83.82 93.98 90))
-    (property "Footprint" "" (id 2) (at 83.82 98.298 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (id 3) (at 83.82 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 56f3fe65-5ef1-4a6e-a200-e361ef623390))
-    (pin "2" (uuid d1b5af45-82ec-44b9-9f8d-7e6fa037126d))
-  )
-
-  (symbol (lib_id "Device:C") (at 105.41 96.52 90) (unit 1)
-    (in_bom yes) (on_board yes)
-    (uuid e8ed392d-e797-4a51-a62e-0d0cb2854712)
-    (property "Reference" "C1" (id 0) (at 105.41 92.71 90))
-    (property "Value" "#Capacitor(47*uFarad(tol=0.2), (0, 6.3)*Volt)" (id 1) (at 105.41 100.33 90))
-    (property "Footprint" "" (id 2) (at 109.22 95.5548 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (id 3) (at 105.41 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 88ed38ec-3347-43aa-9c34-35b1de8a4093))
-    (pin "2" (uuid a92039b9-3ae8-441f-b647-2b89d7689c58))
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
-
-  (symbol_instances
-    (path "/e8ed392d-e797-4a51-a62e-0d0cb2854712"
-      (reference "C1") (unit 1) (value "#Capacitor(47*uFarad(tol=0.2), (0, 6.3)*Volt)") (footprint "")
-    )
-    (path "/691e9d02-a5cc-48a1-b9c1-b97da20de9cd"
-      (reference "R1") (unit 1) (value "#Resistor(51*Ohm(tol=0.05))") (footprint "")
-    )
-    (path "/1baff40e-08de-469f-a254-3c085c13e6e4"
-      (reference "R2") (unit 1) (value "#Resistor(51*Ohm(tol=0.05))") (footprint "")
-    )
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "b55f6c44-5d5d-4524-bb86-893662f64598")
+	(paper "A4")
+	(title_block
+		(title "Simple Circuit")
+		(date "2022-08-02")
+		(rev "v01")
+	)
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:R"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 91.44 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21362588-9ca4-4df5-aaff-e66a21a01f68")
+	)
+	(wire
+		(pts
+			(xy 91.44 86.36) (xy 91.44 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03903112-54ec-4875-b5c3-fcc4ec71e52c")
+	)
+	(wire
+		(pts
+			(xy 111.76 86.36) (xy 111.76 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "36780335-0429-4c3d-8635-e5ed12711612")
+	)
+	(wire
+		(pts
+			(xy 104.14 86.36) (xy 111.76 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b4c322b-7512-4787-a5f9-2684210df4f3")
+	)
+	(wire
+		(pts
+			(xy 74.93 96.52) (xy 80.01 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4902dc83-92f4-47f2-ad47-efdda384a841")
+	)
+	(wire
+		(pts
+			(xy 91.44 86.36) (xy 96.52 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4f1c1eac-36d8-440f-b4fc-e04c50ea8c7a")
+	)
+	(wire
+		(pts
+			(xy 87.63 96.52) (xy 91.44 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7affbfd1-3b77-4468-baac-310ca0e0aad7")
+	)
+	(wire
+		(pts
+			(xy 109.22 96.52) (xy 111.76 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "887ec3e8-1522-42b6-a4e7-8d9f0f5e559f")
+	)
+	(wire
+		(pts
+			(xy 91.44 96.52) (xy 101.6 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d68ed73e-45b3-441c-84c3-918bed62b055")
+	)
+	(label "node"
+		(at 91.44 86.36 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c7d8a50c-4fee-4f62-ac07-94d27775fe21")
+	)
+	(label "GND"
+		(at 111.76 86.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f8594364-7085-4d63-b6db-0503245aaae3")
+	)
+	(global_label "PORT_A"
+		(shape input)
+		(at 74.93 96.52 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0da1a194-de46-4113-bdca-98125569a602")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 65.6226 96.4406 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 100.33 86.36 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1baff40e-08de-469f-a254-3c085c13e6e4")
+		(property "Reference" "R2"
+			(at 100.33 81.28 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "#Resistor(51*Ohm(tol=0.05))"
+			(at 100.33 83.82 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 100.33 88.138 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 100.33 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 100.33 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a02f0f34-dddc-4832-be11-3b9e6c331cdd")
+		)
+		(pin "2"
+			(uuid "fe6d2a99-fc91-45f3-ada1-7b7ef0e61489")
+		)
+		(instances
+			(project ""
+				(path "/b55f6c44-5d5d-4524-bb86-893662f64598"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 83.82 96.52 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "691e9d02-a5cc-48a1-b9c1-b97da20de9cd")
+		(property "Reference" "R1"
+			(at 83.82 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "#Resistor(51*Ohm(tol=0.05))"
+			(at 83.82 93.98 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 83.82 98.298 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 83.82 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 83.82 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "56f3fe65-5ef1-4a6e-a200-e361ef623390")
+		)
+		(pin "2"
+			(uuid "d1b5af45-82ec-44b9-9f8d-7e6fa037126d")
+		)
+		(instances
+			(project ""
+				(path "/b55f6c44-5d5d-4524-bb86-893662f64598"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 105.41 96.52 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e8ed392d-e797-4a51-a62e-0d0cb2854712")
+		(property "Reference" "C1"
+			(at 105.41 92.71 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "#Capacitor(47*uFarad(tol=0.2),"
+			(at 105.41 100.33 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 109.22 95.5548 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 105.41 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 105.41 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value2" "(0, 6.3)*Volt)"
+			(at 101.346 102.87 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "1"
+			(uuid "88ed38ec-3347-43aa-9c34-35b1de8a4093")
+		)
+		(pin "2"
+			(uuid "a92039b9-3ae8-441f-b647-2b89d7689c58")
+		)
+		(instances
+			(project ""
+				(path "/b55f6c44-5d5d-4524-bb86-893662f64598"
+					(reference "C1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/edg/electronics_model/resources/test_kicad_import_inline_badmultiline.kicad_sch
+++ b/edg/electronics_model/resources/test_kicad_import_inline_badmultiline.kicad_sch
@@ -1,0 +1,614 @@
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "b55f6c44-5d5d-4524-bb86-893662f64598")
+	(paper "A4")
+	(title_block
+		(title "Simple Circuit")
+		(date "2022-08-02")
+		(rev "v01")
+	)
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:R"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 91.44 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21362588-9ca4-4df5-aaff-e66a21a01f68")
+	)
+	(wire
+		(pts
+			(xy 91.44 86.36) (xy 91.44 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03903112-54ec-4875-b5c3-fcc4ec71e52c")
+	)
+	(wire
+		(pts
+			(xy 111.76 86.36) (xy 111.76 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "36780335-0429-4c3d-8635-e5ed12711612")
+	)
+	(wire
+		(pts
+			(xy 104.14 86.36) (xy 111.76 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b4c322b-7512-4787-a5f9-2684210df4f3")
+	)
+	(wire
+		(pts
+			(xy 74.93 96.52) (xy 80.01 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4902dc83-92f4-47f2-ad47-efdda384a841")
+	)
+	(wire
+		(pts
+			(xy 91.44 86.36) (xy 96.52 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4f1c1eac-36d8-440f-b4fc-e04c50ea8c7a")
+	)
+	(wire
+		(pts
+			(xy 87.63 96.52) (xy 91.44 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7affbfd1-3b77-4468-baac-310ca0e0aad7")
+	)
+	(wire
+		(pts
+			(xy 109.22 96.52) (xy 111.76 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "887ec3e8-1522-42b6-a4e7-8d9f0f5e559f")
+	)
+	(wire
+		(pts
+			(xy 91.44 96.52) (xy 101.6 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d68ed73e-45b3-441c-84c3-918bed62b055")
+	)
+	(label "node"
+		(at 91.44 86.36 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c7d8a50c-4fee-4f62-ac07-94d27775fe21")
+	)
+	(label "GND"
+		(at 111.76 86.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f8594364-7085-4d63-b6db-0503245aaae3")
+	)
+	(global_label "PORT_A"
+		(shape input)
+		(at 74.93 96.52 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0da1a194-de46-4113-bdca-98125569a602")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 65.6226 96.4406 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 100.33 86.36 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1baff40e-08de-469f-a254-3c085c13e6e4")
+		(property "Reference" "R2"
+			(at 100.33 81.28 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "#Resistor(51*Ohm(tol=0.05))"
+			(at 100.33 83.82 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 100.33 88.138 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 100.33 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 100.33 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a02f0f34-dddc-4832-be11-3b9e6c331cdd")
+		)
+		(pin "2"
+			(uuid "fe6d2a99-fc91-45f3-ada1-7b7ef0e61489")
+		)
+		(instances
+			(project ""
+				(path "/b55f6c44-5d5d-4524-bb86-893662f64598"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 83.82 96.52 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "691e9d02-a5cc-48a1-b9c1-b97da20de9cd")
+		(property "Reference" "R1"
+			(at 83.82 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "#Resistor(51*Ohm(tol=0.05))"
+			(at 83.82 93.98 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 83.82 98.298 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 83.82 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 83.82 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "56f3fe65-5ef1-4a6e-a200-e361ef623390")
+		)
+		(pin "2"
+			(uuid "d1b5af45-82ec-44b9-9f8d-7e6fa037126d")
+		)
+		(instances
+			(project ""
+				(path "/b55f6c44-5d5d-4524-bb86-893662f64598"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 105.41 96.52 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e8ed392d-e797-4a51-a62e-0d0cb2854712")
+		(property "Reference" "C1"
+			(at 105.41 92.71 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "#Capacitor(47*uFarad(tol=0.2),"
+			(at 105.41 100.33 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 109.22 95.5548 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 105.41 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 105.41 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value1" "(0, 6.3)*Volt)"
+			(at 101.346 102.87 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "1"
+			(uuid "88ed38ec-3347-43aa-9c34-35b1de8a4093")
+		)
+		(pin "2"
+			(uuid "a92039b9-3ae8-441f-b647-2b89d7689c58")
+		)
+		(instances
+			(project ""
+				(path "/b55f6c44-5d5d-4524-bb86-893662f64598"
+					(reference "C1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+)

--- a/edg/electronics_model/test_kicad_import.py
+++ b/edg/electronics_model/test_kicad_import.py
@@ -49,6 +49,14 @@ class KiCadInlineBlock(KiCadSchematicBlock):
         self.import_kicad(self.file_path("resources", "test_kicad_import_inline.kicad_sch"))
 
 
+class KiCadInlineBlockBadMultiline(KiCadSchematicBlock):
+    """Schematic with bad multiline definition, starting before Value2"""
+    def __init__(self) -> None:
+        super().__init__()
+        self.PORT_A = self.Port(Passive())
+        self.import_kicad(self.file_path("resources", "test_kicad_import_inline_badmultiline.kicad_sch"))
+
+
 class KiCadInlineVarsBlock(KiCadSchematicBlock):
     """Block that has its implementation completely defined in KiCad, using inline Python that references
     local variables defined in the HDL."""
@@ -136,6 +144,10 @@ class KiCadImportProtoTestCase(unittest.TestCase):
 
     def test_inline_block(self):
         self.check_connectivity(KiCadInlineBlock)
+
+    def test_inline_badmultiline(self):
+        with self.assertRaises(AssertionError):
+            self.check_connectivity(KiCadInlineBlockBadMultiline)
 
     def test_inline_vars_block(self):
         self.check_connectivity(KiCadInlineVarsBlock)

--- a/getting_started_schimport.md
+++ b/getting_started_schimport.md
@@ -128,7 +128,8 @@ Finally, while the capacitors and resistor parameters can be parsed by value, th
 >    Typically, these are Passive-typed.
 > 2. **HDL instantiation** (like with the BJT), where the symbol has neither footprint or value, but a Block whose name matches the symbol refdes and with a defined symbol to port mapping: the existing Block is connected as described in the schematic.
 > 3. **Inline HDL** (not shown, but could be done with the BJT), where a Block's value contains HDL code prefixed with a `#`, and the resulting Block defines a symbol to port mapping.
->    For the BJT, instead of instantiating the Block in `contents(...)`, you could instead have set the value in the schematic to `Bjt.Npn((0, 5)*Volt, 0*Amp(tol=0))`.
+>    For the BJT, instead of instantiating the Block in `contents(...)`, you could instead have set the value in the schematic to `#Bjt.Npn((0, 5)*Volt, 0*Amp(tol=0))`.
+>    - Multi-line values are supported using the `Value2`, `Value3`, ... fields.
 > 4. **Blackboxing** (like with the HX711 chip), where the symbol has a footprint defined: a Block is created with all Passive ports.
 >
 > See the [reference section](#reference) below for KiCad symbols for value parsing, HDL instantiation, or inline HDL.  


### PR DESCRIPTION
Hacked in by concatenating Value2, Value3, ... fields if they exist. Fields must start at Value2 and be contiguous. This should allow better-looking schematic-defined blocks with more complex logic.