### PR TITLE
Add AA battery stack to library and Vin to Xiao RP2040

### DIFF
--- a/edg/abstract_parts/AbstractDevices.py
+++ b/edg/abstract_parts/AbstractDevices.py
@@ -17,6 +17,6 @@ class Battery(PowerSource):
     self.capacity = self.ArgParameter(capacity)
     self.actual_capacity = self.Parameter(RangeExpr())
 
-    self.require(self.pwr.voltage_out.within(voltage))
+    self.require(self.pwr.voltage_out.within(voltage + self.gnd.link().voltage))
     self.require(self.pwr.current_limits.contains(current))
     self.require(self.actual_capacity.upper() >= capacity)

--- a/edg/abstract_parts/AbstractResistor.py
+++ b/edg/abstract_parts/AbstractResistor.py
@@ -157,7 +157,7 @@ class PulldownResistor(DiscreteApplication):
       DigitalSource.pulldown_from_supply(self.gnd)
     ), [InOut])
 
-  def connected(self, gnd: Optional[Port[VoltageLink]] = None, io: Optional[Port[DigitalLink]] = None) -> \
+  def connected(self, gnd: Optional[Port[GroundLink]] = None, io: Optional[Port[DigitalLink]] = None) -> \
       'PulldownResistor':
     """Convenience function to connect both ports, returning this object so it can still be given a name."""
     if gnd is not None:

--- a/edg/abstract_parts/IoControllerInterfaceMixins.py
+++ b/edg/abstract_parts/IoControllerInterfaceMixins.py
@@ -91,7 +91,7 @@ class IoControllerPowerOut(BlockInterfaceMixin[IoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.pwr_out = self.Port(VoltageSource.empty(), optional=True,
-                                 doc="Power output port, typically of the device's Vdd or VddIO rail; must be used with gnd_out")
+                                 doc="Power output port, typically of the device's Vdd or VddIO rail at 3.3v")
 
 
 class IoControllerUsbOut(BlockInterfaceMixin[IoController]):
@@ -99,4 +99,12 @@ class IoControllerUsbOut(BlockInterfaceMixin[IoController]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.vusb_out = self.Port(VoltageSource.empty(), optional=True,
-                                  doc="Power output port of the device's Vbus, typically 5v; must be used with gnd_out")
+                                  doc="Power output port of the device's Vbus, typically 5v")
+
+
+class IoControllerVin(BlockInterfaceMixin[IoController]):
+    """IO controller mixin that provides a >=5v input to the device, typically upstream of the Vbus-to-3.3 regulator."""
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.pwr_vin = self.Port(VoltageSink.empty(), optional=True,
+                                 doc="Power input pin, typically rated for 5v or a bit beyond.")

--- a/edg/abstract_parts/PassiveFilters.py
+++ b/edg/abstract_parts/PassiveFilters.py
@@ -51,7 +51,7 @@ class PullupDelayRc(DigitalFilter, Block):
     self.io = self.Export(self.rc.output.adapt_to(DigitalSource.pullup_from_supply(self.pwr)), [Output])
     self.gnd = self.Export(self.rc.gnd.adapt_to(Ground()), [Common])
 
-  def connected(self, *, gnd: Optional[Port[VoltageLink]] = None, pwr: Optional[Port[VoltageLink]] = None,
+  def connected(self, *, gnd: Optional[Port[GroundLink]] = None, pwr: Optional[Port[VoltageLink]] = None,
                 io: Optional[Port[DigitalLink]] = None) -> 'PullupDelayRc':
     """Convenience function to connect both ports, returning this object so it can still be given a name."""
     if gnd is not None:

--- a/edg/abstract_parts/__init__.py
+++ b/edg/abstract_parts/__init__.py
@@ -97,7 +97,7 @@ from .IoController import BaseIoController, IoController, IoControllerPowerRequi
 from .IoControllerExportable import BaseIoControllerExportable
 from .IoControllerInterfaceMixins import IoControllerSpiPeripheral, IoControllerI2cTarget, IoControllerTouchDriver,\
     IoControllerDac, IoControllerCan, IoControllerUsb, IoControllerI2s, IoControllerDvp8
-from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut
+from .IoControllerInterfaceMixins import IoControllerPowerOut, IoControllerUsbOut, IoControllerVin
 from .IoControllerInterfaceMixins import IoControllerWifi, IoControllerBluetooth, IoControllerBle
 from .IoControllerProgramming import IoControllerWithSwdTargetConnector
 from .IoControllerMixins import WithCrystalGenerator

--- a/edg/electronics_model/CircuitBlock.py
+++ b/edg/electronics_model/CircuitBlock.py
@@ -9,7 +9,7 @@ from ..core.ConstraintExpr import Refable
 from .KiCadImportableBlock import KiCadImportableBlock
 
 
-CircuitLinkType = TypeVar('CircuitLinkType', bound=Link)
+CircuitLinkType = TypeVar('CircuitLinkType', bound=Link, covariant=True)
 class CircuitPort(Port[CircuitLinkType], Generic[CircuitLinkType]):
   """Electrical connection that represents a single port into a single copper net"""
   pass

--- a/edg/electronics_model/DigitalPorts.py
+++ b/edg/electronics_model/DigitalPorts.py
@@ -471,7 +471,7 @@ class DigitalBidir(DigitalBase):
 class DigitalSingleSourceFake:
   @staticmethod
   @deprecated("use DigitalSource.sink_from_supply")
-  def low_from_supply(neg: Port[VoltageLink], is_pulldown: bool = False) -> DigitalSource:
+  def low_from_supply(neg: Port[GroundLink], is_pulldown: bool = False) -> DigitalSource:
     if not is_pulldown:
       return DigitalSource.low_from_supply(neg)
     else:

--- a/edg/electronics_model/DigitalPorts.py
+++ b/edg/electronics_model/DigitalPorts.py
@@ -309,7 +309,7 @@ class DigitalSource(DigitalBase):
     self._bridged_internal: BoolExpr = self.Parameter(BoolExpr(_bridged_internal))
 
   @staticmethod
-  def low_from_supply(neg: Port[VoltageLink], *, current_limits: RangeLike = RangeExpr.ALL) -> DigitalSource:
+  def low_from_supply(neg: Port[GroundLink], *, current_limits: RangeLike = RangeExpr.ALL) -> DigitalSource:
     return DigitalSource(
       voltage_out=neg.link().voltage,
       current_limits=current_limits,
@@ -329,7 +329,7 @@ class DigitalSource(DigitalBase):
     )
 
   @staticmethod
-  def pulldown_from_supply(neg: Port[VoltageLink]) -> DigitalSource:
+  def pulldown_from_supply(neg: Port[GroundLink]) -> DigitalSource:
     return DigitalSource(
       voltage_out=neg.link().voltage,
       output_thresholds=(neg.link().voltage.upper(), float('inf')),

--- a/edg/electronics_model/GroundPort.py
+++ b/edg/electronics_model/GroundPort.py
@@ -95,7 +95,7 @@ class GroundAdapterAnalogSource(CircuitPortAdapter['AnalogSource']):
         ))
 
 
-class Ground(CircuitPort):
+class Ground(CircuitPort[GroundLink]):
     link_type = GroundLink
     bridge_type = GroundBridge
 
@@ -118,7 +118,7 @@ class Ground(CircuitPort):
         self.voltage_limits = self.Parameter(RangeExpr(voltage_limits))
 
 
-class GroundReference(CircuitPort):
+class GroundReference(CircuitPort[GroundLink]):
     link_type = GroundLink
 
     def __init__(self, voltage_out: RangeLike = RangeExpr.ZERO) -> None:

--- a/edg/parts/Batteries.py
+++ b/edg/parts/Batteries.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from ..abstract_parts import *
 
@@ -57,8 +57,8 @@ class Li18650(Battery, FootprintBlock):
 class AaBattery(Battery, FootprintBlock):
   """AA battery holder supporting alkaline and rechargeable chemistries."""
   @init_in_parent
-  def __init__(self, voltage: RangeLike = (0.9, 1.6)*Volt, *args,
-               actual_voltage: RangeLike = (0.9, 1.6)*Volt, **kwargs):
+  def __init__(self, voltage: RangeLike = (1.0, 1.6)*Volt, *args,
+               actual_voltage: RangeLike = (1.0, 1.6)*Volt, **kwargs):
     super().__init__(voltage, *args, **kwargs)
     self.gnd.init_from(Ground())
     self.pwr.init_from(VoltageSource(
@@ -84,8 +84,8 @@ class AaBattery(Battery, FootprintBlock):
 class AaBatteryStack(Battery, GeneratorBlock):
     """AA Alkaline battery stack that generates batteries in series"""
     @init_in_parent
-    def __init__(self, count: IntLike = 1, *, cell_actual_voltage: RangeLike = (0.9, 1.6)*Volt):
-        super().__init__()
+    def __init__(self, count: IntLike = 1, *, cell_actual_voltage: RangeLike = (1.0, 1.6)*Volt):
+        super().__init__(voltage=Range.all())  # no voltage spec passed in
         self.count = self.ArgParameter(count)
         self.cell_actual_voltage = self.ArgParameter(cell_actual_voltage)
         self.generator_param(self.count)
@@ -93,13 +93,19 @@ class AaBatteryStack(Battery, GeneratorBlock):
     def generate(self):
         super().generate()
         prev_cell: Optional[AaBattery] = None
+        prev_capacity_min: Union[FloatExpr, float] = float('inf')
+        prev_capacity_max: Union[FloatExpr, float] = float('inf')
         self.cell = ElementDict[AaBattery]()
         for i in range(self.get(self.count)):
           self.cell[i] = cell = self.Block(AaBattery(actual_voltage=self.cell_actual_voltage))
-          if prev_cell is None:  # direct connect to gnd
+          if prev_cell is None:  # first cell, direct connect to gnd
             self.connect(self.gnd, cell.gnd)
           else:
-            self.connect(prev_cell.pwr.as_ground(), cell.gnd)
+            self.connect(prev_cell.pwr.as_ground(self.pwr.link().current_drawn), cell.gnd)
+            prev_capacity_min = cell.actual_capacity.lower().min(prev_capacity_min)
+            prev_capacity_max=  cell.actual_capacity.upper().min(prev_capacity_max)
+          prev_cell = cell
 
         assert prev_cell is not None, "must generate >=1 cell"
         self.connect(self.pwr, prev_cell.pwr)
+        self.assign(self.actual_capacity, (prev_capacity_min, prev_capacity_max))

--- a/edg/parts/Microcontroller_Rp2040.py
+++ b/edg/parts/Microcontroller_Rp2040.py
@@ -432,6 +432,7 @@ class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, IoControllerVin, Rp2
 
     self.pwr_vin.init_from(VoltageSink(  # based on RS3236-3.3
       voltage_limits=(3.3*1.025 + 0.55, 7.5)*Volt,  # output * tolerance + dropout @ 300mA
+      current_draw=RangeExpr()
     ))
     self.vusb_out.init_from(VoltageSource(
       voltage_out=UsbConnector.USB2_VOLTAGE_RANGE,
@@ -447,7 +448,7 @@ class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, IoControllerVin, Rp2
     ))
     self.require(~self.pwr_out.is_connected() | ~self.pwr.is_connected(), "cannot use both 3.3v out and 3.3v in")
     self.assign(self.pwr_vin.current_draw, self.pwr_out.is_connected().then_else(  # prop output current draw
-      self.pwr_out.link().current_drawn, (0, 0)
+      self.pwr_out.link().current_drawn, (0, 0)*Amp
     ))
 
     self.generator_param(self.pwr.is_connected())

--- a/edg/parts/Microcontroller_Rp2040.py
+++ b/edg/parts/Microcontroller_Rp2040.py
@@ -372,7 +372,8 @@ class Rp2040(Resettable, Rp2040_Interfaces, Microcontroller, IoControllerWithSwd
     return len(self.get(self.usb.requested())) > 0 or super()._crystal_required()
 
 
-class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, Rp2040_Ios, IoController, GeneratorBlock, FootprintBlock):
+class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, IoControllerVin, Rp2040_Ios, IoController, GeneratorBlock,
+                  FootprintBlock):
   """RP2040 development board, a tiny development (21x17.5mm) daughterboard.
   Has an onboard USB connector, so this can also source power.
 
@@ -382,6 +383,7 @@ class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, Rp2040_Ios, IoContro
   The 'Seeed Studio XIAO Series Library' must have been added as a footprint library of the same name.
 
   Pinning data: https://www.seeedstudio.com/blog/wp-content/uploads/2022/08/Seeed-Studio-XIAO-Series-Package-and-PCB-Design.pdf
+  Internal data: https://files.seeedstudio.com/wiki/XIAO-RP2040/res/Seeed-Studio-XIAO-RP2040-v1.3.pdf
   """
   SYSTEM_PIN_REMAP: Dict[str, Union[str, List[str]]] = {
     'VDD': '12',
@@ -411,8 +413,6 @@ class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, Rp2040_Ios, IoContro
 
   def _system_pinmap(self) -> Dict[str, CircuitPort]:
     if self.get(self.pwr.is_connected()):  # board sinks power
-      self.require(~self.vusb_out.is_connected(), "can't source USB power if power input connected")
-      self.require(~self.pwr_out.is_connected(), "can't source 3v3 power if power input connected")
       return VariantPinRemapper({
         'VDD': self.pwr,
         'GND': self.gnd,
@@ -430,13 +430,24 @@ class Xiao_Rp2040(IoControllerUsbOut, IoControllerPowerOut, Rp2040_Ios, IoContro
     self.gnd.init_from(Ground())
     self.pwr.init_from(self._iovdd_model())
 
+    self.pwr_vin.init_from(VoltageSink(  # based on RS3236-3.3
+      voltage_limits=(3.3*1.025 + 0.55, 7.5)*Volt,  # output * tolerance + dropout @ 300mA
+    ))
     self.vusb_out.init_from(VoltageSource(
       voltage_out=UsbConnector.USB2_VOLTAGE_RANGE,
       current_limits=UsbConnector.USB2_CURRENT_LIMITS
     ))
+    self.require(~self.pwr_vin.is_connected() | ~self.vusb_out.is_connected(), "cannot use both VUsb out and VUsb in")
+    self.require((self.pwr_vin.is_connected() | self.vusb_out.is_connected()).implies(~self.pwr.is_connected()),
+                 "cannot use 3.3v input if VUsb used")
+
     self.pwr_out.init_from(VoltageSource(
       voltage_out=3.3*Volt(tol=0.05),  # tolerance is a guess
       current_limits=UsbConnector.USB2_CURRENT_LIMITS
+    ))
+    self.require(~self.pwr_out.is_connected() | ~self.pwr.is_connected(), "cannot use both 3.3v out and 3.3v in")
+    self.assign(self.pwr_vin.current_draw, self.pwr_out.is_connected().then_else(  # prop output current draw
+      self.pwr_out.link().current_drawn, (0, 0)
     ))
 
     self.generator_param(self.pwr.is_connected())

--- a/edg/parts/PowerConditioning.py
+++ b/edg/parts/PowerConditioning.py
@@ -254,7 +254,7 @@ class PriorityPowerOr(PowerConditioner, KiCadSchematicBlock, Block):
         'gnd': Ground(),
       })
 
-  def connected_from(self, gnd: Optional[Port[VoltageLink]] = None, pwr_hi: Optional[Port[VoltageLink]] = None,
+  def connected_from(self, gnd: Optional[Port[GroundLink]] = None, pwr_hi: Optional[Port[VoltageLink]] = None,
                      pwr_lo: Optional[Port[VoltageLink]] = None) -> 'PriorityPowerOr':
     """Convenience function to connect ports, returning this object so it can still be given a name."""
     if gnd is not None:

--- a/edg/parts/__init__.py
+++ b/edg/parts/__init__.py
@@ -18,7 +18,7 @@ from .JlcBjt import JlcBjt
 from .JlcFet import JlcFet, JlcSwitchFet
 from .CustomDiode import CustomDiode
 from .CustomFet import CustomFet
-from .Batteries import Cr2032, Li18650, AABattery
+from .Batteries import Cr2032, Li18650, AaBattery, AaBatteryStack
 from .Switches import SmtSwitch, SmtSwitchRa, KailhSocket
 from .RotaryEncoder_Alps import Ec11eWithSwitch, Ec11j15WithSwitch, Ec05e
 from .RotaryEncoder_Bourns import Pec11s

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -20,7 +20,7 @@ class TestBlinkyEmpty(SimpleBoardTop):
 class TestBlinkyBasicBattery(SimpleBoardTop):
   """The simplest cirucit, a microcontroller dev board with a LED, powered from a battery"""
   def contents(self) -> None:
-    self.bat = self.Block(AaBatteryStack(3))
+    self.bat = self.Block(AaBatteryStack(4))
     self.mcu = self.Block(Xiao_Rp2040())
     self.led = self.Block(IndicatorLed())
 

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -17,6 +17,19 @@ class TestBlinkyEmpty(SimpleBoardTop):
   pass
 
 
+class TestBlinkyBasicBattery(SimpleBoardTop):
+  """The simplest cirucit, a microcontroller dev board with a LED, powered from a battery"""
+  def contents(self) -> None:
+    self.bat = self.Block(AaBatteryStack(3))
+    self.mcu = self.Block(Xiao_Rp2040())
+    self.led = self.Block(IndicatorLed())
+
+    self.connect(self.mcu.pwr_vin, self.bat.pwr)
+    self.connect(self.mcu.gnd, self.bat.gnd)
+    self.connect(self.led.signal, self.mcu.gpio.request())
+    self.connect(self.mcu.gnd, self.led.gnd)
+
+
 class TestBlinkyIncomplete(SimpleBoardTop):
   def contents(self) -> None:
     super().contents()
@@ -537,6 +550,9 @@ class BlinkyTestCase(unittest.TestCase):
   def test_design_empty(self) -> None:
     compile_board_inplace(TestBlinkyEmpty)
 
+  def test_design_battery(self) -> None:
+    compile_board_inplace(TestBlinkyBasicBattery)
+
   def test_design_incomplete(self) -> None:
     with self.assertRaises(CompilerCheckError):
       compile_board_inplace(TestBlinkyIncomplete, False)
@@ -577,15 +593,3 @@ class BlinkyTestCase(unittest.TestCase):
 
   def test_design_schematic_import_modeled(self) -> None:
     compile_board_inplace(TestBlinkyWithModeledSchematicImport)
-
-
-if __name__ == "__main__":
-  # this unit test can also be run as __main__ to test a non-unit-test environment
-  compile_board_inplace(TestBlinkyEmpty, False)
-  compile_board_inplace(TestBlinkyComplete, False)
-  compile_board_inplace(TestBlinkyWithLibrary, False)
-  compile_board_inplace(TestBlinkyWithLibraryExport, False)
-  compile_board_inplace(TestBlinkyArray, False)
-  compile_board_inplace(TestBlinkyPacked, False)
-  compile_board_inplace(TestBlinkyWithSchematicImport, False)
-  compile_board_inplace(TestBlinkyWithModeledSchematicImport, False)

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -171,7 +171,7 @@ class Multimeter(JlcBoardTop):
     VOLTAGE_RATING = (0, 250) * Volt
 
     # also support LiIon AA batteries
-    self.bat = self.Block(AABattery(voltage=(1.1, 4.2)*Volt, actual_voltage=(1.1, 4.2)*Volt))
+    self.bat = self.Block(AaBattery(voltage=(1.1, 4.2) * Volt, actual_voltage=(1.1, 4.2) * Volt))
 
     # Data-only USB port, for example to connect to a computer that can't source USB PD
     # so the PD port can be connected to a dedicated power brick.


### PR DESCRIPTION
Add an example with a Xiao RP2040 powered from a 4x stack of AA batteries.

Library changes:
- Add IoControllerVin, for microcontroller dev boards with a >=5v Vusb in / Vin pin
- Add link type to Ground port and fix up some places that were still using VoltageLink
- Make the link type covariant, so Port[GroundLink] and Port[VoltageLink] are both Port[Any]
- Add AaBatteryStack for a series stack of AA batteries that boost the voltage
- Change battery model to support offset ground for series stacks. A one-of change for now, in the future most robust / consistent support for offset ground is needed.
- Change AA battery limits to 1.0-1.6v to accommodate NiMH rechargeable cells. 1.0v lower limit is a compromise to get the Xiao to build, devices may want to support down to 0.9v to maximize runtime off rechargables.
