### PR TITLE
Improve int handling

### DIFF
--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -262,7 +262,8 @@ object ExprEvaluate {
             RangeValue(1.0 / valMax, 1.0 / valMin)
           case RangeEmpty => RangeEmpty
           case FloatValue(opVal) => FloatValue(1.0 / opVal)
-          case IntValue(opVal) => IntValue(1 / opVal)
+          case IntValue(opVal) =>
+            FloatValue(1.0 / opVal.floatValue) // follow Python convention of division promoting to float
           case _ => throw new ExprEvaluateException(s"Unknown unary operand type in ${unary.op} ${`val`} from $unary")
         }
 

--- a/edg/parts/Batteries.py
+++ b/edg/parts/Batteries.py
@@ -103,7 +103,7 @@ class AaBatteryStack(Battery, GeneratorBlock):
           else:
             self.connect(prev_cell.pwr.as_ground(self.pwr.link().current_drawn), cell.gnd)
             prev_capacity_min = cell.actual_capacity.lower().min(prev_capacity_min)
-            prev_capacity_max=  cell.actual_capacity.upper().min(prev_capacity_max)
+            prev_capacity_max = cell.actual_capacity.upper().min(prev_capacity_max)
           prev_cell = cell
 
         assert prev_cell is not None, "must generate >=1 cell"


### PR DESCRIPTION
Ints can be 'promoted' to floats and ranges and used in their operations. Change int invert semantics to promote to float, consistent with Python behavior.