### PR TITLE
Fix: replace the crystal to 32MHz according to the ref design

### DIFF
--- a/edg/parts/Rf_Sx1262.py
+++ b/edg/parts/Rf_Sx1262.py
@@ -247,7 +247,7 @@ class Sx1262(Resettable, DiscreteRfWarning, Block):
         with self.implicit_connect(
                 ImplicitConnect(self.gnd, [Common])
         ) as imp:
-            self.xtal = imp.Block(Crystal(30*MHertz(tol=30e-6)))  # 30ppm for LoRaWAN systems
+            self.xtal = imp.Block(Crystal(32*MHertz(tol=30e-6)))  # 30ppm for LoRaWAN systems
             self.connect(self.xtal.crystal, self.ic.xtal)
 
             self.vreg_cap = imp.Block(DecouplingCapacitor(470*nFarad(tol=0.2))).connected(pwr=self.ic.vreg)


### PR DESCRIPTION
https://semtech.my.salesforce.com/sfc/p/#E0000000JelG/a/RQ000008nKCH/hp2iKwMDKWl34g1D3LBf_zC7TGBRIo2ff5LMnS8r19s

This pull request includes a single change to the `contents` method in the `Rf_Sx1262.py` file. The crystal frequency was updated to align with data sheet.

* **Crystal frequency update**:
  - Changed the crystal frequency from `30 MHz` to `32 MHz` for the `Rf_Sx1262` component to align with the ref design