### PR TITLE
Add PowerSO8 / DFN5x6 fets

### DIFF
--- a/edg/abstract_parts/AbstractFets.py
+++ b/edg/abstract_parts/AbstractFets.py
@@ -38,7 +38,10 @@ class FetStandardFootprint(StandardFootprint['Fet']):
       '7': block.drain,
       '8': block.drain,
     },
-    'Package_SO:PowerPAK_SO-8_Single': lambda block: {
+    (
+      'Package_SO:PowerPAK_SO-8_Single',
+      'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    ): lambda block: {
       '1': block.source,
       '2': block.source,
       '3': block.source,

--- a/edg/parts/JlcFet.py
+++ b/edg/parts/JlcFet.py
@@ -26,6 +26,27 @@ class JlcBaseFet(JlcTableSelector):
     'SOIC-8_3.9x4.9x1.27P': 'Package_SO:SOIC-8_3.9x4.9mm_P1.27mm',
     'SOP-8': 'Package_SO:SOIC-8_3.9x4.9mm_P1.27mm',
     'SOP-8_3.9x4.9x1.27P': 'Package_SO:SOIC-8_3.9x4.9mm_P1.27mm',
+
+    'PowerPAK SO-8_EP_5.2x6.2x1.27P': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'POWERPAK-SO-8': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PowerPAK-SO-8': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PowerPAKSO-8L': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PowerPAKSO-8': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'DFN5X6-8': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'DFN5x6': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'DFN-8_5x6x1.27P': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'DFN-8(5x6)': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'DFN5X6-8L': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PDFN5x6': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PDFN5x6-8': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PDFN5x6-8L': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PDFN5X6-8L': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PQFN 5X6': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PQFN5x6-8': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PQFN-8(4.9x5.8)': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PQFN-8(5x6)': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PRPAK5x6': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
+    'PRPAK5x6-8L': 'Package_DFN_QFN:PQFN-8-EP_6x5mm_P1.27mm_Generic',
   }
 
   DESCRIPTION_PARSERS: List[DescriptionParser] = [


### PR DESCRIPTION
Add PowerSO8 / DFN5x6 FET pinnings using the generic footprint and add package names for JLC parts tables. The naming is a mess, but the all should be compatible packages.

Note that there are so few of these in the JLC table that they do not get picked in practice in any of the examples.