### PR TITLE
Compositional Passive Final

### DIFF
--- a/edg/abstract_parts/DigitalAmplifiers.py
+++ b/edg/abstract_parts/DigitalAmplifiers.py
@@ -87,7 +87,7 @@ class HighSideSwitch(PowerSwitch, KiCadSchematicBlock, GeneratorBlock):
             )
         )
 
-        conversions: Dict[str, Union[Passive, HasPassivePort]] = {
+        conversions: Dict[str, HasPassivePort] = {
             "pwr": VoltageSink(current_draw=self.output.link().current_drawn),
             "output": VoltageSource(
                 voltage_out=self.pwr.link().voltage,

--- a/edg/abstract_parts/DigitalAmplifiers.py
+++ b/edg/abstract_parts/DigitalAmplifiers.py
@@ -87,7 +87,7 @@ class HighSideSwitch(PowerSwitch, KiCadSchematicBlock, GeneratorBlock):
             )
         )
 
-        conversions: Dict[str, Union[CircuitPort, HasPassivePort]] = {
+        conversions: Dict[str, Union[Passive, HasPassivePort]] = {
             "pwr": VoltageSink(current_draw=self.output.link().current_drawn),
             "output": VoltageSource(
                 voltage_out=self.pwr.link().voltage,

--- a/edg/abstract_parts/IoController.py
+++ b/edg/abstract_parts/IoController.py
@@ -142,7 +142,7 @@ class BaseIoController(PinMappable, Block):
 
             if isinstance(allocation.pin, str):
                 assert isinstance(io_port, (CircuitPort, Passive, HasPassivePort))
-                pinmap[allocation.pin] = io_port
+                pinmap[allocation.pin] = io_port  # type: ignore
             elif allocation.pin is None:
                 assert isinstance(io_port, (CircuitPort, Passive, HasPassivePort))  # otherwise discarded
             elif isinstance(allocation.pin, dict):
@@ -151,7 +151,7 @@ class BaseIoController(PinMappable, Block):
                     assert isinstance(
                         subport, (CircuitPort, Passive, HasPassivePort)
                     ), f"bad sub-port {pin_name} {subport}"
-                    pinmap[pin_name] = subport
+                    pinmap[pin_name] = subport  # type: ignore
             else:
                 raise NotImplementedError(f"unknown allocation pin type {allocation.pin}")
 

--- a/edg/abstract_parts/IoController.py
+++ b/edg/abstract_parts/IoController.py
@@ -97,12 +97,12 @@ class BaseIoController(PinMappable, Block):
     @staticmethod
     def _instantiate_from(
         ios: List[BasePort], allocations: List[AllocatedResource]
-    ) -> Tuple[Dict[str, Union[CircuitPort, HasPassivePort]], RangeExpr]:
+    ) -> Tuple[Dict[str, Union[Passive, HasPassivePort]], RangeExpr]:
         """Given a mapping of port types to IO ports and allocated resources from PinMapUtil,
         instantiate vector elements (if a vector) or init the port model (if a port)
         for the allocated resources using their data model and return the pin mapping."""
         ios_by_type = {io.elt_type() if isinstance(io, Vector) else type(io): io for io in ios}
-        pinmap: Dict[str, Union[CircuitPort, HasPassivePort]] = {}
+        pinmap: Dict[str, Union[Passive, HasPassivePort]] = {}
 
         ports_assigned = IdentitySet[Port]()
         io_current_draw_builder = RangeExpr._to_expr_type(RangeExpr.ZERO)
@@ -141,14 +141,16 @@ class BaseIoController(PinMappable, Block):
             # TODO: recurse into bundles, really needs a more unified way of handling current draw
 
             if isinstance(allocation.pin, str):
-                assert isinstance(io_port, (CircuitPort, HasPassivePort))
+                assert isinstance(io_port, (CircuitPort, Passive, HasPassivePort))
                 pinmap[allocation.pin] = io_port
             elif allocation.pin is None:
-                assert isinstance(io_port, (CircuitPort, HasPassivePort))  # otherwise discarded
+                assert isinstance(io_port, (CircuitPort, Passive, HasPassivePort))  # otherwise discarded
             elif isinstance(allocation.pin, dict):
                 for subport_name, (pin_name, pin_resource) in allocation.pin.items():
                     subport = getattr(io_port, subport_name)
-                    assert isinstance(subport, (CircuitPort, HasPassivePort)), f"bad sub-port {pin_name} {subport}"
+                    assert isinstance(
+                        subport, (CircuitPort, Passive, HasPassivePort)
+                    ), f"bad sub-port {pin_name} {subport}"
                     pinmap[pin_name] = subport
             else:
                 raise NotImplementedError(f"unknown allocation pin type {allocation.pin}")
@@ -175,7 +177,7 @@ class BaseIoControllerPinmapGenerator(BaseIoController, GeneratorBlock):
             else:
                 raise NotImplementedError(f"unknown port type {io_port}")
 
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         """Implement me. Defines the fixed pin mappings from pin number to port."""
         raise NotImplementedError
 
@@ -183,7 +185,7 @@ class BaseIoControllerPinmapGenerator(BaseIoController, GeneratorBlock):
         """Implement me. Defines the assignable IO pinmaps."""
         raise NotImplementedError
 
-    def _make_pinning(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _make_pinning(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         allocation_list = []
         for io_port in self._io_ports:
             if isinstance(io_port, Vector):  # derive Vector connections from requested

--- a/edg/abstract_parts/OpampCircuits.py
+++ b/edg/abstract_parts/OpampCircuits.py
@@ -156,9 +156,7 @@ class Amplifier(OpampApplication, KiCadSchematicBlock, KiCadImportableBlock, Gen
         self.r2 = self.Block(Resistor(Range.from_tolerance(bottom_resistance, self.get(self.tolerance))))
 
         if self.get(self.reference.is_connected()):
-            reference_type: Union[CircuitPort, HasPassivePort] = AnalogSink(
-                impedance=self.r1.actual_resistance + self.r2.actual_resistance
-            )
+            reference_type: HasPassivePort = AnalogSink(impedance=self.r1.actual_resistance + self.r2.actual_resistance)
             reference_node: Port = self.reference
             reference_range = self.reference.link().signal
         else:

--- a/edg/abstract_parts/PassiveConnector.py
+++ b/edg/abstract_parts/PassiveConnector.py
@@ -28,15 +28,18 @@ class PassiveConnector(DiscreteComponent, Block):
 
     def connected(
         self: PassiveConnectorSelfType,
-        pins: Mapping[Union[Iterable[str], str], Union[CircuitPort, "HasPassivePort"]],
+        pins: Mapping[Union[Iterable[str], str], Union[Passive, HasPassivePort]],
     ) -> PassiveConnectorSelfType:
         """Connects the given pins to this connector, and returns self to allow chaining.
         Similar API to pinning in footprint."""
         for pin_name, pin_port in pins.items():
-            if isinstance(pin_port, HasPassivePort):
-                passive_port: CircuitPort = pin_port.net
-            else:
+            if isinstance(pin_port, Passive):
                 passive_port = pin_port
+            elif isinstance(pin_port, HasPassivePort):
+                passive_port = pin_port.net
+            elif isinstance(pin_port, CircuitPort):
+                passive_port = pin_port  # type: ignore
+
             if isinstance(pin_name, str):
                 pin_tuples: Tuple[str, ...] = (pin_name,)
             else:

--- a/edg/abstract_parts/PassiveConnector.py
+++ b/edg/abstract_parts/PassiveConnector.py
@@ -38,7 +38,7 @@ class PassiveConnector(DiscreteComponent, Block):
             elif isinstance(pin_port, HasPassivePort):
                 passive_port = pin_port.net
             elif isinstance(pin_port, CircuitPort):
-                passive_port = pin_port  # type: ignore
+                passive_port = cast(Passive, pin_port)
 
             if isinstance(pin_name, str):
                 pin_tuples: Tuple[str, ...] = (pin_name,)

--- a/edg/abstract_parts/PassiveConnector.py
+++ b/edg/abstract_parts/PassiveConnector.py
@@ -33,12 +33,9 @@ class PassiveConnector(DiscreteComponent, Block):
         """Connects the given pins to this connector, and returns self to allow chaining.
         Similar API to pinning in footprint."""
         for pin_name, pin_port in pins.items():
-            if isinstance(pin_port, Passive):
-                passive_port = pin_port
-            elif isinstance(pin_port, HasPassivePort):
-                passive_port = pin_port.net
-            elif isinstance(pin_port, CircuitPort):
-                passive_port = cast(Passive, pin_port)
+            if isinstance(pin_port, HasPassivePort):
+                passive_port: Passive = pin_port.net
+            assert isinstance(pin_port, Passive), "connected pin must be Passive or HasPassivePort"
 
             if isinstance(pin_name, str):
                 pin_tuples: Tuple[str, ...] = (pin_name,)

--- a/edg/abstract_parts/PassiveConnector.py
+++ b/edg/abstract_parts/PassiveConnector.py
@@ -35,7 +35,9 @@ class PassiveConnector(DiscreteComponent, Block):
         for pin_name, pin_port in pins.items():
             if isinstance(pin_port, HasPassivePort):
                 passive_port: Passive = pin_port.net
-            assert isinstance(pin_port, Passive), "connected pin must be Passive or HasPassivePort"
+            else:
+                assert isinstance(pin_port, Passive), "connected pin must be Passive or HasPassivePort"
+                passive_port = pin_port
 
             if isinstance(pin_name, str):
                 pin_tuples: Tuple[str, ...] = (pin_name,)

--- a/edg/abstract_parts/PinMappable.py
+++ b/edg/abstract_parts/PinMappable.py
@@ -55,7 +55,7 @@ class BaseDelegatingPinMapResource(BasePinMapResource):
 class PinResource(BaseLeafPinMapResource):
     """A resource for a single chip pin, which can be one of several port types (eg, an ADC and DIO sharing a pin)."""
 
-    def __init__(self, pin: str, name_models: Mapping[str, Union[CircuitPort, HasPassivePort]]):
+    def __init__(self, pin: str, name_models: Mapping[str, Union[Passive, HasPassivePort]]):
         self.pin = pin
         self.name_models = name_models
 

--- a/edg/abstract_parts/StandardFootprint.py
+++ b/edg/abstract_parts/StandardFootprint.py
@@ -4,7 +4,7 @@ from typing_extensions import Self
 from ..electronics_model import *
 
 StandardPinningType = TypeVar("StandardPinningType", bound=Block)
-PinningFunction = Callable[[StandardPinningType], Dict[str, CircuitPort]]
+PinningFunction = Callable[[StandardPinningType], Dict[str, Union[Passive, HasPassivePort]]]
 
 
 class StandardFootprint(Generic[StandardPinningType]):
@@ -38,7 +38,7 @@ class StandardFootprint(Generic[StandardPinningType]):
         return cls._EXPANDED_FOOTPRINT_PINNING_MAP
 
     @classmethod
-    def _make_pinning(cls, block: StandardPinningType, footprint: str) -> Dict[str, CircuitPort]:
+    def _make_pinning(cls, block: StandardPinningType, footprint: str) -> Dict[str, Union[Passive, HasPassivePort]]:
         """Returns the pinning for a footprint for a specific block's pins"""
         return cls._footprint_pinning_map()[footprint](block)
 

--- a/edg/abstract_parts/VariantPinRemapper.py
+++ b/edg/abstract_parts/VariantPinRemapper.py
@@ -4,11 +4,11 @@ from ..electronics_model import *
 
 
 class VariantPinRemapper:
-    def __init__(self, mapping: Mapping[str, Union[CircuitPort, HasPassivePort]]):
+    def __init__(self, mapping: Mapping[str, Union[Passive, HasPassivePort]]):
         self.mapping = mapping
 
-    def remap(self, remap: Dict[str, Union[str, List[str]]]) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
-        output_dict: Dict[str, Union[CircuitPort, HasPassivePort]] = {}
+    def remap(self, remap: Dict[str, Union[str, List[str]]]) -> Dict[str, Union[Passive, HasPassivePort]]:
+        output_dict: Dict[str, Union[Passive, HasPassivePort]] = {}
         remapped_names: Set[str] = set()
         for orig_name, orig_port in self.mapping.items():
             assert orig_name in remap, f"missing remap rule for {orig_name}"

--- a/edg/electronics_model/AnalogPort.py
+++ b/edg/electronics_model/AnalogPort.py
@@ -6,7 +6,7 @@ from typing_extensions import override
 
 from ..core import *
 from .PassivePort import HasPassivePort, Passive
-from .CircuitBlock import CircuitPortAdapter, KicadImportablePortAdapter
+from .CircuitBlock import KicadImportablePortAdapter
 from .GroundPort import GroundLink
 from .VoltagePorts import VoltageLink, VoltageSource
 

--- a/edg/electronics_model/CircuitBlock.py
+++ b/edg/electronics_model/CircuitBlock.py
@@ -15,28 +15,6 @@ if TYPE_CHECKING:
 CircuitLinkType = TypeVar("CircuitLinkType", bound=Link, covariant=True, default=Link)
 
 
-class CircuitPort(Port[CircuitLinkType], Generic[CircuitLinkType]):
-    """Electrical connection that represents a single port into a single copper net"""
-
-    pass
-
-
-T = TypeVar("T", bound=BasePort)
-
-
-class CircuitArrayReduction(Generic[T]):
-    def __init__(self, steps: List[Vector[Any]], port: T):
-        self.port = port
-        self.steps = steps  # reduction steps
-
-
-@non_library
-class NetBaseBlock(BaseBlock):
-    def net(self) -> None:
-        """Defines all ports on this block as copper-connected"""
-        self.nets = self.Metadata({"_": "_"})  # TODO should be empty
-
-
 @non_library
 class FootprintBlock(Block):
     """Block that represents a component that has part(s) and trace(s) on the PCB.
@@ -127,6 +105,32 @@ class WrapperFootprintBlock(FootprintBlock):
         self.fp_is_wrapper = self.Metadata("A")  # TODO replace with not metadata, eg superclass inspection
 
 
+AdapterDstType = TypeVar("AdapterDstType", covariant=True, bound=Port, default=Port)
+
+
+@non_library
+class KicadImportablePortAdapter(KiCadImportableBlock, PortAdapter[AdapterDstType], Generic[AdapterDstType]):
+    @override
+    def symbol_pinning(self, symbol_name: str) -> Dict[str, BasePort]:
+        assert symbol_name == "edg_importable:Adapter"
+        return {"1": self.src, "2": self.dst}
+
+
+@deprecated("Use compositional Passive sub-port instead")
+class CircuitPort(Port[CircuitLinkType], Generic[CircuitLinkType]):
+    """Electrical connection that represents a single port into a single copper net"""
+
+    pass
+
+
+@non_library
+@deprecated("Use compositional passive and connect nets instead of inheriting")
+class NetBaseBlock(BaseBlock):
+    def net(self) -> None:
+        """Defines all ports on this block as copper-connected"""
+        self.nets = self.Metadata({"_": "_"})  # TODO should be empty
+
+
 @abstract_block
 @deprecated("Use compositional passive and connect nets instead of inheriting")
 class NetBlock(InternalBlock, NetBaseBlock, Block):
@@ -143,17 +147,6 @@ class CircuitPortBridge(NetBaseBlock, PortBridge):
     def contents(self) -> None:
         super().contents()
         self.net()
-
-
-AdapterDstType = TypeVar("AdapterDstType", covariant=True, bound=Port, default=Port)
-
-
-@non_library
-class KicadImportablePortAdapter(KiCadImportableBlock, PortAdapter[AdapterDstType], Generic[AdapterDstType]):
-    @override
-    def symbol_pinning(self, symbol_name: str) -> Dict[str, BasePort]:
-        assert symbol_name == "edg_importable:Adapter"
-        return {"1": self.src, "2": self.dst}
 
 
 @abstract_block

--- a/edg/electronics_model/CircuitBlock.py
+++ b/edg/electronics_model/CircuitBlock.py
@@ -10,9 +10,7 @@ from ..core import *
 from ..core.HdlUserExceptions import EdgTypeError
 
 if TYPE_CHECKING:
-    from .PassivePort import HasPassivePort
-
-CircuitLinkType = TypeVar("CircuitLinkType", bound=Link, covariant=True, default=Link)
+    from .PassivePort import HasPassivePort, Passive
 
 
 @non_library
@@ -39,7 +37,7 @@ class FootprintBlock(Block):
         self,
         refdes: StringLike,
         footprint: StringLike,
-        pinning: Mapping[str, Union[CircuitPort, "HasPassivePort"]],
+        pinning: Mapping[str, Union["Passive", "HasPassivePort"]],
         mfr: Optional[StringLike] = None,
         part: Optional[StringLike] = None,
         value: Optional[StringLike] = None,
@@ -48,7 +46,7 @@ class FootprintBlock(Block):
         """Creates a footprint in this circuit block.
         Value is a one-line description of the part, eg 680R, 0.01uF, LPC1549, to be used as a aid during layout or
         assembly"""
-        from .PassivePort import HasPassivePort
+        from .PassivePort import HasPassivePort, Passive
         from ..core.Blocks import BlockElaborationState, BlockDefinitionError
 
         if self._elaboration_state not in (
@@ -68,7 +66,7 @@ class FootprintBlock(Block):
         for pin_name, pin_port in pinning.items():
             if isinstance(pin_port, HasPassivePort):
                 pin_port = pin_port.net
-            if not isinstance(pin_port, CircuitPort):
+            if not isinstance(pin_port, (CircuitPort, Passive)):
                 raise EdgTypeError(f"Footprint(...) pin", pin_port, CircuitPort)
             pinning_array.append(f"{pin_name}={pin_port._name_from(self)}")
         self.assign(self.fp_pinning, pinning_array)
@@ -114,6 +112,9 @@ class KicadImportablePortAdapter(KiCadImportableBlock, PortAdapter[AdapterDstTyp
     def symbol_pinning(self, symbol_name: str) -> Dict[str, BasePort]:
         assert symbol_name == "edg_importable:Adapter"
         return {"1": self.src, "2": self.dst}
+
+
+CircuitLinkType = TypeVar("CircuitLinkType", bound=Link, covariant=True, default=Link)
 
 
 @deprecated("Use compositional Passive sub-port instead")

--- a/edg/electronics_model/CircuitBlock.py
+++ b/edg/electronics_model/CircuitBlock.py
@@ -67,7 +67,7 @@ class FootprintBlock(Block):
             if isinstance(pin_port, HasPassivePort):
                 pin_port = pin_port.net
             if not isinstance(pin_port, (CircuitPort, Passive)):
-                raise EdgTypeError(f"Footprint(...) pin", pin_port, CircuitPort)
+                raise EdgTypeError(f"Footprint(...) pin", pin_port, Passive)
             pinning_array.append(f"{pin_name}={pin_port._name_from(self)}")
         self.assign(self.fp_pinning, pinning_array)
 

--- a/edg/electronics_model/KiCadSchematicBlock.py
+++ b/edg/electronics_model/KiCadSchematicBlock.py
@@ -202,7 +202,7 @@ class KiCadSchematicBlock(Block):
         locals: Mapping[str, Any] = {},
         *,
         nodes: Mapping[str, Optional[BasePort]] = {},
-        conversions: Mapping[str, Union[Passive, HasPassivePort]] = {},
+        conversions: Mapping[str, HasPassivePort] = {},
         auto_adapt: bool = False,
     ) -> None:
         # ideally SYMBOL_MAP would be a class variable, but this causes a import loop with Opamp,
@@ -315,16 +315,7 @@ class KiCadSchematicBlock(Block):
             for boundary_port, boundary_port_name in boundary_ports:  # generate adapters as needed, port by port
                 if boundary_port_name in conversions:
                     assert can_adapt, "conversion to boundary port only allowed for Passive ports"
-                    adapted = cast(Passive, net_ports[0]).adapt_to(conversions[boundary_port_name])
-                    self.connect(adapted, boundary_port)  # type: ignore
-                elif (
-                    auto_adapt
-                    and can_adapt
-                    and isinstance(boundary_port, CircuitPort)
-                    and not isinstance(boundary_port, Passive)
-                ):
-                    # TODO remove after full compositional passive refactor #114
-                    adapted = cast(Passive, net_ports[0]).adapt_to(boundary_port.__class__())
+                    adapted = cast(Port, cast(Passive, net_ports[0]).adapt_to(conversions[boundary_port_name]))
                     self.connect(adapted, boundary_port)
                 elif (
                     auto_adapt

--- a/edg/electronics_model/KiCadSchematicBlock.py
+++ b/edg/electronics_model/KiCadSchematicBlock.py
@@ -122,7 +122,7 @@ class KiCadSchematicBlock(Block):
 
     @staticmethod
     def _port_from_pin(
-        pin: KiCadPin, mapping: Mapping[str, BasePort], conversions: Mapping[str, Union[CircuitPort, HasPassivePort]]
+        pin: KiCadPin, mapping: Mapping[str, BasePort], conversions: Mapping[str, Union[Passive, HasPassivePort]]
     ) -> BasePort:
         """Returns the Port from a symbol's pin, using the provided mapping and applying conversions as needed."""
         from .PassivePort import Passive
@@ -152,7 +152,7 @@ class KiCadSchematicBlock(Block):
                 f"mapping defined for both number ${pin.pin_number} and name ${pin.pin_name}"
             )
         elif f"{pin.refdes}.{pin.pin_number}" in conversions:
-            conversion: Optional[Union[CircuitPort, HasPassivePort]] = conversions[f"{pin.refdes}.{pin.pin_number}"]
+            conversion: Optional[Union[Passive, HasPassivePort]] = conversions[f"{pin.refdes}.{pin.pin_number}"]
         elif f"{pin.refdes}.{pin.pin_name}" in conversions:
             conversion = conversions[f"{pin.refdes}.{pin.pin_name}"]
         else:
@@ -202,7 +202,7 @@ class KiCadSchematicBlock(Block):
         locals: Mapping[str, Any] = {},
         *,
         nodes: Mapping[str, Optional[BasePort]] = {},
-        conversions: Mapping[str, Union[CircuitPort, HasPassivePort]] = {},
+        conversions: Mapping[str, Union[Passive, HasPassivePort]] = {},
         auto_adapt: bool = False,
     ) -> None:
         # ideally SYMBOL_MAP would be a class variable, but this causes a import loop with Opamp,

--- a/edg/electronics_model/KiCadSchematicBlock.py
+++ b/edg/electronics_model/KiCadSchematicBlock.py
@@ -6,7 +6,7 @@ from typing import Type, Any, Optional, Mapping, Dict, List, Callable, Tuple, Ty
 from typing_extensions import override
 
 from ..core import *
-from .CircuitBlock import CircuitPort, FootprintBlock
+from .CircuitBlock import FootprintBlock
 from .PassivePort import Passive, HasPassivePort
 from .KiCadImportableBlock import KiCadInstantiableBlock, KiCadImportableBlock
 from .KiCadSchematicParser import (

--- a/edg/electronics_model/PassivePort.py
+++ b/edg/electronics_model/PassivePort.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TypeVar, Type, Dict, Union
+from typing import TypeVar, Type, Dict
 
 from typing_extensions import TYPE_CHECKING
 
 from ..core import *
-from .CircuitBlock import CircuitPort, CircuitLink, CircuitPortBridge, KicadImportablePortAdapter
+from .CircuitBlock import KicadImportablePortAdapter
 
 if TYPE_CHECKING:
     from .GroundPort import Ground
@@ -14,12 +14,13 @@ if TYPE_CHECKING:
     from .AnalogPort import AnalogSource, AnalogSink
 
 
-class PassiveLink(CircuitLink):
+class PassiveLink(Link):
     """Copper-only connection"""
 
     def __init__(self) -> None:
         super().__init__()
         self.passives = self.Port(Vector(Passive()))
+        self.nets = self.Metadata({"_": "_"})  # marks all ports as connected to netlister
 
 
 class PassiveAdapterGround(PortAdapter["Ground"]):
@@ -220,11 +221,12 @@ class PassiveAdapterAnalogSink(KicadImportablePortAdapter["AnalogSink"]):
         self.connect(self.src, self.dst.net)
 
 
-class PassiveBridge(CircuitPortBridge):
+class PassiveBridge(PortBridge):
     def __init__(self) -> None:
         super().__init__()
         self.outer_port = self.Port(Passive())
         self.inner_link = self.Port(Passive())
+        self.nets = self.Metadata({"_": "_"})  # marks all ports as connected to netlister
 
 
 class HasPassivePort:
@@ -236,14 +238,13 @@ class HasPassivePort:
         self.net: Passive
 
 
-# TODO this should replace CircuitPort and should be the lowest level of abstraction port, #114
-class Passive(CircuitPort[PassiveLink]):
+class Passive(Port[PassiveLink]):
     """Basic copper-only port, which can be adapted to a more strongly typed Voltage/Digital/Analog* port"""
 
     link_type = PassiveLink
     bridge_type = PassiveBridge
 
-    AdaptTargetType = TypeVar("AdaptTargetType", bound=Union[CircuitPort, HasPassivePort])
+    AdaptTargetType = TypeVar("AdaptTargetType", bound=HasPassivePort)
 
     def adapt_to(self, that: AdaptTargetType) -> AdaptTargetType:
         from .GroundPort import Ground

--- a/edg/electronics_model/PassivePort.py
+++ b/edg/electronics_model/PassivePort.py
@@ -277,4 +277,4 @@ class Passive(Port[PassiveLink]):
             assert param.initializer is not None, f"missing initializer for {param_name}"
             adapter_init_kwargs[param_name] = param.initializer
 
-        return self._convert(adapter_cls(**adapter_init_kwargs))  # type: ignore
+        return self._convert(adapter_cls(**adapter_init_kwargs))

--- a/edg/electronics_model/PinAssignmentUtil.py
+++ b/edg/electronics_model/PinAssignmentUtil.py
@@ -6,7 +6,6 @@ from typing_extensions import override
 
 from ..electronics_model import Passive
 from ..core import *
-from .CircuitBlock import CircuitPort
 
 
 def leaf_circuit_ports(prefix: str, port: Port) -> Iterable[Tuple[str, Passive]]:
@@ -147,8 +146,8 @@ class PeripheralPinAssign(AssignablePinGroup):
 
 
 class PinAssignmentUtil:
-    """Utility for pin assignment, given a list of ports and assignable pin definitions, assigns each leaf CircuitPort
-    port to a pin."""
+    """Utility for pin assignment, given a list of ports and assignable pin definitions, assigns each leaf
+    Passive(-like) to a pin."""
 
     def __init__(self, *assignables: AssignablePinGroup) -> None:
         self.assignables_by_port = IdentityDict[Port, AssignablePinGroup]()

--- a/edg/electronics_model/PinAssignmentUtil.py
+++ b/edg/electronics_model/PinAssignmentUtil.py
@@ -4,15 +4,16 @@ from itertools import chain
 
 from typing_extensions import override
 
+from ..electronics_model import Passive
 from ..core import *
 from .CircuitBlock import CircuitPort
 
 
-def leaf_circuit_ports(prefix: str, port: Port) -> Iterable[Tuple[str, CircuitPort]]:
-    if isinstance(port, CircuitPort):
+def leaf_circuit_ports(prefix: str, port: Port) -> Iterable[Tuple[str, Passive]]:
+    if isinstance(port, Passive):
         return [(prefix, port)]
     else:
-        assert port._ports, "must be CircuitPort or Port bundle with sub-Ports"
+        assert port._ports, "must be Passive or Port bundle with sub-Ports"
         return chain(*[leaf_circuit_ports(f"{prefix}.{name}", port) for (name, port) in port._ports.items()])
 
 
@@ -28,8 +29,8 @@ ConcretePinName = str
 
 
 class AssignedPins(NamedTuple):
-    assigned_pins: Dict[ConcretePinName, CircuitPort]  # map of internal pin name -> edge leaf port
-    not_connected: List[CircuitPort]  # list of edge leaf ports that are marked as NC
+    assigned_pins: Dict[ConcretePinName, Passive]  # map of internal pin name -> edge leaf port
+    not_connected: List[Passive]  # list of edge leaf ports that are marked as NC
 
 
 class AssignablePinGroup:
@@ -40,13 +41,13 @@ class AssignablePinGroup:
 
     @abstractmethod
     def assign(
-        self, port: Port, preassigns: IdentityDict[CircuitPort, PinName], assigned: Set[ConcretePinName]
+        self, port: Port, preassigns: IdentityDict[Passive, PinName], assigned: Set[ConcretePinName]
     ) -> Optional[AssignedPins]: ...  # returns an assignment of all leaf ports given a top-level port
 
 
 class AnyPinAssign(AssignablePinGroup):
     """Pin assignment where any leaf port can be connected to any pin.
-    All leaf ports must be CircuitPort.
+    All leaf ports must be Passive.
     Useful for devices with a switch matrix, or for assigning GPIOs"""
 
     def __init__(self, ports: Iterable[Port], pins: Iterable[Union[str, int]]) -> None:
@@ -59,10 +60,10 @@ class AnyPinAssign(AssignablePinGroup):
 
     @override
     def assign(
-        self, port: Port, preassigns: IdentityDict[CircuitPort, PinName], assigned: Set[ConcretePinName]
+        self, port: Port, preassigns: IdentityDict[Passive, PinName], assigned: Set[ConcretePinName]
     ) -> Optional[AssignedPins]:
-        assignments: Dict[ConcretePinName, CircuitPort] = {}
-        not_connected: List[CircuitPort] = []
+        assignments: Dict[ConcretePinName, Passive] = {}
+        not_connected: List[Passive] = []
         available_pins = self.pins.difference(assigned).difference(preassigns.values())
         for leaf_name, leaf_port in leaf_circuit_ports("", port):
             if leaf_port in preassigns:
@@ -107,15 +108,15 @@ class PeripheralPinAssign(AssignablePinGroup):
 
     @override
     def assign(
-        self, port: Port, preassigns: IdentityDict[CircuitPort, PinName], assigned: Set[ConcretePinName]
+        self, port: Port, preassigns: IdentityDict[Passive, PinName], assigned: Set[ConcretePinName]
     ) -> Optional[AssignedPins]:
         leaf_name_ports = list(leaf_circuit_ports("", port))
 
         for group_pins in self.pins:
             assert len(group_pins) == len(leaf_name_ports)
 
-            group_dict: Dict[ConcretePinName, CircuitPort] = {}
-            not_connected: List[CircuitPort] = []
+            group_dict: Dict[ConcretePinName, Passive] = {}
+            not_connected: List[Passive] = []
             group_failed = False
             for available_pins, (leaf_name, leaf_port) in zip(group_pins, leaf_name_ports):
                 if group_failed:
@@ -157,10 +158,10 @@ class PinAssignmentUtil:
                 self.assignables_by_port[port] = assignable
 
     def assign(
-        self, ports: Iterable[Port], preassigns: IdentityDict[CircuitPort, PinName] = IdentityDict()
+        self, ports: Iterable[Port], preassigns: IdentityDict[Passive, PinName] = IdentityDict()
     ) -> AssignedPins:
-        assignments: Dict[ConcretePinName, CircuitPort] = {}
-        not_connects: List[CircuitPort] = []
+        assignments: Dict[ConcretePinName, Passive] = {}
+        not_connects: List[Passive] = []
         for port in ports:
             port_assignment = self.assignables_by_port[port].assign(port, preassigns, set(assignments.keys()))
             assert port_assignment is not None  # TODO more robust and backtracking

--- a/edg/electronics_model/PinAssignmentUtil.py
+++ b/edg/electronics_model/PinAssignmentUtil.py
@@ -4,6 +4,7 @@ from itertools import chain
 
 from typing_extensions import override
 
+from ..electronics_model import CircuitPort
 from ..electronics_model import Passive
 from ..core import *
 
@@ -11,6 +12,8 @@ from ..core import *
 def leaf_circuit_ports(prefix: str, port: Port) -> Iterable[Tuple[str, Passive]]:
     if isinstance(port, Passive):
         return [(prefix, port)]
+    elif isinstance(port, CircuitPort):
+        return [(prefix, port)]  # type: ignore
     else:
         assert port._ports, "must be Passive or Port bundle with sub-Ports"
         return chain(*[leaf_circuit_ports(f"{prefix}.{name}", port) for (name, port) in port._ports.items()])

--- a/edg/electronics_model/PinAssignmentUtil.py
+++ b/edg/electronics_model/PinAssignmentUtil.py
@@ -12,7 +12,7 @@ from ..core import *
 def leaf_circuit_ports(prefix: str, port: Port) -> Iterable[Tuple[str, Passive]]:
     if isinstance(port, Passive):
         return [(prefix, port)]
-    elif isinstance(port, CircuitPort):
+    elif isinstance(port, CircuitPort):  # best-effort backwards compatibility
         return [(prefix, port)]  # type: ignore
     else:
         assert port._ports, "must be Passive or Port bundle with sub-Ports"

--- a/edg/electronics_model/TouchPort.py
+++ b/edg/electronics_model/TouchPort.py
@@ -1,5 +1,5 @@
 from ..core import *
-from .PassivePort import HasPassivePort
+from .PassivePort import HasPassivePort, Passive
 
 
 class TouchLink(Link):
@@ -24,7 +24,7 @@ class TouchDriver(HasPassivePort, Port[TouchLink]):
 
     def __init__(self) -> None:
         super().__init__()
-        self.net = self.link().net
+        self.net = self.Port(Passive())
 
 
 class TouchPadPort(HasPassivePort, Port[TouchLink]):
@@ -34,4 +34,4 @@ class TouchPadPort(HasPassivePort, Port[TouchLink]):
 
     def __init__(self) -> None:
         super().__init__()
-        self.net = self.link().net
+        self.net = self.Port(Passive())

--- a/edg/electronics_model/TouchPort.py
+++ b/edg/electronics_model/TouchPort.py
@@ -1,8 +1,8 @@
 from ..core import *
-from .CircuitBlock import CircuitPort, CircuitLink
+from .PassivePort import HasPassivePort
 
 
-class TouchLink(CircuitLink):
+class TouchLink(Link):
     """Touch sensor link, consisting of one sensor (typically a PCB copper pattern) and one driver.
     These contain no modeling."""
 
@@ -11,8 +11,10 @@ class TouchLink(CircuitLink):
         self.driver = self.Port(TouchDriver())
         self.pad = self.Port(TouchPadPort())
 
+        self.net = self.connect(self.driver.net, self.pad.net)
 
-class TouchDriver(CircuitPort[TouchLink]):
+
+class TouchDriver(HasPassivePort, Port[TouchLink]):
     """Touch sensor driver-side port, typically attached to a microcontroller pin.
     Internal to this port should be any circuitry needed to make the sensor work.
     Separately from the port, the microcontroller should generate additionally needed circuits,
@@ -20,8 +22,16 @@ class TouchDriver(CircuitPort[TouchLink]):
 
     link_type = TouchLink
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = self.link().net
 
-class TouchPadPort(CircuitPort[TouchLink]):
+
+class TouchPadPort(HasPassivePort, Port[TouchLink]):
     """Touch sensor-side port, typically attached to a copper pad."""
 
     link_type = TouchLink
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = self.link().net

--- a/edg/parts/Fpga_Ice40up.py
+++ b/edg/parts/Fpga_Ice40up.py
@@ -113,7 +113,7 @@ class Ice40up_Device(BaseIoControllerPinmapGenerator, InternalSubcircuit, Genera
     @override
     def _system_pinmap(
         self,
-    ) -> Dict[str, Union[CircuitPort, HasPassivePort]]:  # names consistent with pinout spreadsheet
+    ) -> Dict[str, Union[Passive, HasPassivePort]]:  # names consistent with pinout spreadsheet
         return VariantPinRemapper(
             {
                 "VCCPLL": self.vcc_pll,

--- a/edg/parts/IoExpander_Pca9554.py
+++ b/edg/parts/IoExpander_Pca9554.py
@@ -60,7 +60,7 @@ class Pca9554_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
             ]
         )
 
-        ic_pins: Dict[str, Union[CircuitPort, HasPassivePort]] = {
+        ic_pins: Dict[str, Union[Passive, HasPassivePort]] = {
             "1": self.vdd if addr_lsb & 1 else self.gnd,  # A0
             "2": self.vdd if addr_lsb & 2 else self.gnd,  # A1
             "3": self.vdd if addr_lsb & 4 else self.gnd,  # A2
@@ -72,7 +72,7 @@ class Pca9554_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
         }
 
         allocated = pinmaps.allocate([(DigitalBidir, self.get(self.io.requested()))], self.get(self.pin_assigns))
-        io_pins: Dict[str, CircuitPort] = {
+        io_pins: Dict[str, Union[Passive, HasPassivePort]] = {
             allocation.pin: self.io.append_elt(dout_model, allocation.name) for allocation in allocated  # type: ignore
         }
         self.generator_set_allocation(allocated)

--- a/edg/parts/IoExpander_Pcf8574.py
+++ b/edg/parts/IoExpander_Pcf8574.py
@@ -59,7 +59,7 @@ class Pcf8574_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
             ]
         )
 
-        ic_pins: Dict[str, Union[CircuitPort, HasPassivePort]] = {
+        ic_pins: Dict[str, Union[Passive, HasPassivePort]] = {
             "1": self.vdd if addr_lsb & 1 else self.gnd,  # A0
             "2": self.vdd if addr_lsb & 2 else self.gnd,  # A1
             "3": self.vdd if addr_lsb & 4 else self.gnd,  # A2
@@ -71,7 +71,7 @@ class Pcf8574_Device(PinMappable, InternalSubcircuit, FootprintBlock, JlcPart, G
         }
 
         allocated = pinmaps.allocate([(DigitalBidir, self.get(self.io.requested()))], self.get(self.pin_assigns))
-        io_pins: Dict[str, CircuitPort] = {
+        io_pins: Dict[str, Union[Passive, HasPassivePort]] = {
             allocation.pin: self.io.append_elt(dout_model, allocation.name) for allocation in allocated  # type: ignore
         }
         self.generator_set_allocation(allocated)

--- a/edg/parts/LinearRegulators.py
+++ b/edg/parts/LinearRegulators.py
@@ -577,7 +577,7 @@ class Lp5907_Device(
 
         self.assign(self.pwr_out.voltage_out, part_output_voltage)
         if footprint == "Package_TO_SOT_SMD:SOT-23-5":
-            pinning: Dict[str, Union[CircuitPort, HasPassivePort]] = {
+            pinning: Dict[str, HasPassivePort] = {
                 "1": self.pwr_in,
                 "2": self.gnd,
                 "3": self.en,

--- a/edg/parts/Microcontroller_Esp32.py
+++ b/edg/parts/Microcontroller_Esp32.py
@@ -197,7 +197,7 @@ class Esp32_Base(Esp32_Ios, GeneratorBlock):
         return self.pwr
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {
                 "Vdd": self.pwr,
@@ -373,7 +373,7 @@ class Freenove_Esp32_Wrover(
             return self.pwr_out
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         if self.get(self.pwr.is_connected()):  # board sinks power
             self.require(~self.vusb_out.is_connected(), "can't source USB power if power input connected")
             self.require(~self.pwr_out.is_connected(), "can't source 3v3 power if power input connected")

--- a/edg/parts/Microcontroller_Esp32c3.py
+++ b/edg/parts/Microcontroller_Esp32c3.py
@@ -118,7 +118,7 @@ class Esp32c3_Base(Esp32c3_Ios, BaseIoControllerPinmapGenerator):
         return self.pwr
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return {
             "Vdd": self.pwr,
             "Vss": self.gnd,
@@ -167,7 +167,7 @@ class Esp32c3_Wroom02_Device(Esp32c3_Base, InternalSubcircuit, FootprintBlock, J
     }
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(super()._system_pinmap()).remap(
             {
                 "Vdd": "1",
@@ -294,7 +294,7 @@ class Esp32c3_Device(Esp32c3_Base, InternalSubcircuit, FootprintBlock, JlcPart):
     }
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(super()._system_pinmap()).remap(
             {
                 "Vdd": ["31", "32"],  # VDDA
@@ -534,7 +534,7 @@ class Xiao_Esp32c3(IoControllerUsbOut, IoControllerPowerOut, Esp32c3_Ios, IoCont
             return self.pwr_out
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         if self.get(self.pwr.is_connected()):  # board sinks power
             self.require(~self.vusb_out.is_connected(), "can't source USB power if power input connected")
             self.require(~self.pwr_out.is_connected(), "can't source 3v3 power if power input connected")

--- a/edg/parts/Microcontroller_Esp32s3.py
+++ b/edg/parts/Microcontroller_Esp32s3.py
@@ -170,7 +170,7 @@ class Esp32s3_Base(Esp32s3_Ios, GeneratorBlock):
         return self.pwr
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {
                 "VDD": self.pwr,  # including VDD3V3, VDD3P3_RTC, VDD_SPI, VDD3P3_CPU
@@ -373,7 +373,7 @@ class Freenove_Esp32s3_Wroom(
             return self.pwr_out
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         if self.get(self.pwr.is_connected()):  # board sinks power
             self.require(~self.vusb_out.is_connected(), "can't source USB power if power input connected")
             self.require(~self.pwr_out.is_connected(), "can't source 3v3 power if power input connected")

--- a/edg/parts/Microcontroller_Lpc1549.py
+++ b/edg/parts/Microcontroller_Lpc1549.py
@@ -58,7 +58,7 @@ class Lpc1549Base_Device(
         self._io_ports.insert(0, self.swd)
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {
                 "VddA": self.pwr,

--- a/edg/parts/Microcontroller_Rp2040.py
+++ b/edg/parts/Microcontroller_Rp2040.py
@@ -280,7 +280,7 @@ class Rp2040_Device(
 
     # Pin/peripheral resource definitions (table 3)
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return {
             "51": self.qspi_sd3,
             "52": self.qspi.sck,
@@ -449,7 +449,7 @@ class Xiao_Rp2040(
             return self.pwr_out
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         if self.get(self.pwr.is_connected()):  # board sinks power
             return VariantPinRemapper(
                 {

--- a/edg/parts/Microcontroller_Stm32f103.py
+++ b/edg/parts/Microcontroller_Stm32f103.py
@@ -63,7 +63,7 @@ class Stm32f103Base_Device(
         self._io_ports.insert(0, self.swd)
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {  # Pin/peripheral resource definitions (table 3)
                 "Vbat": self.pwr,

--- a/edg/parts/Microcontroller_Stm32f303.py
+++ b/edg/parts/Microcontroller_Stm32f303.py
@@ -183,7 +183,7 @@ class Stm32f303_Device(Stm32f303_Ios, IoController, InternalSubcircuit, Generato
     SYSTEM_PIN_REMAP: Dict[str, Union[str, List[str]]]
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {
                 # 'Vbat': self.vdd,
@@ -242,7 +242,7 @@ class Nucleo_F303k8(
             return self.pwr_out, self.pwr_out
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         if self.get(self.pwr.is_connected()):  # board sinks power
             self.require(~self.vusb_out.is_connected(), "can't source USB power if power input connected")
             self.require(~self.pwr_out.is_connected(), "can't source 3v3 power if power input connected")

--- a/edg/parts/Microcontroller_Stm32g031.py
+++ b/edg/parts/Microcontroller_Stm32g031.py
@@ -44,7 +44,7 @@ class Stm32g031Base_Device(
         self.nrst = self.Port(DigitalSink.empty(), optional=True)  # internally pulled up
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {  # Pin/peripheral resource definitions (section 4)
                 "Vdd": self.pwr,

--- a/edg/parts/Microcontroller_Stm32g431.py
+++ b/edg/parts/Microcontroller_Stm32g431.py
@@ -41,7 +41,7 @@ class Stm32g431Base_Device(
         self.nrst = self.Port(DigitalSink.empty(), optional=True)  # internally pulled up
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {
                 "Vdd": self.pwr,

--- a/edg/parts/Microcontroller_Stm32l432.py
+++ b/edg/parts/Microcontroller_Stm32l432.py
@@ -46,7 +46,7 @@ class Stm32l432Base_Device(
         self.nrst = self.Port(DigitalSink.empty(), optional=True)  # internally pulled up
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {  # Pin/peripheral resource definitions (section 4)
                 "Vdd": self.pwr,

--- a/edg/parts/Microcontroller_nRF52840.py
+++ b/edg/parts/Microcontroller_nRF52840.py
@@ -288,7 +288,7 @@ class Nrf52840_Base(Nrf52840_Ios, GeneratorBlock):
         return self.pwr
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         return VariantPinRemapper(
             {
                 "Vdd": self.pwr,
@@ -602,7 +602,7 @@ class Feather_Nrf52840(
             return self.pwr_out
 
     @override
-    def _system_pinmap(self) -> Dict[str, Union[CircuitPort, HasPassivePort]]:
+    def _system_pinmap(self) -> Dict[str, Union[Passive, HasPassivePort]]:
         if self.get(self.pwr.is_connected()):  # board sinks power
             self.require(~self.vusb_out.is_connected(), "can't source USB power if power input connected")
             self.require(~self.pwr_out.is_connected(), "can't source 3v3 power if power input connected")

--- a/edg/parts/SpeakerDriver_Max98357a.py
+++ b/edg/parts/SpeakerDriver_Max98357a.py
@@ -38,7 +38,7 @@ class Max98357a_Device(InternalSubcircuit, JlcPart, SelectorFootprint, PartsTabl
             or self.get(self.footprint_spec) == "Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.45x1.45mm"
         ):
             footprint = "Package_DFN_QFN:QFN-16-1EP_3x3mm_P0.5mm_EP1.45x1.45mm"
-            pinning: Dict[str, Union[CircuitPort, HasPassivePort]] = {
+            pinning: Dict[str, Union[Passive, HasPassivePort]] = {
                 "4": self.vdd,  # hard tied to left mode only TODO selectable SD_MODE
                 "7": self.vdd,
                 "8": self.vdd,


### PR DESCRIPTION
Refactors the last leftover port (touch sense ports) to compositional passive.

Refactoring to remove references to CircuitPort, except to preserve backward compatibility (for now). Type annotations do not preserve compatibility.

Resolves #114.