### PR TITLE
Add explicit fallback to array reduction; add error value

### DIFF
--- a/compiler/src/main/scala/edg/ExprBuilder.scala
+++ b/compiler/src/main/scala/edg/ExprBuilder.scala
@@ -115,6 +115,9 @@ object ExprBuilder {
   }
 
   object Literal {
+    def Error(msg: Option[String]): lit.ValueLit =
+      lit.ValueLit(`type` = lit.ValueLit.Type.Error(lit.ErrorLit(msg.getOrElse(""))))
+
     def Floating(value: Double): lit.ValueLit = Floating(value.toFloat)
     def Floating(value: Float): lit.ValueLit = lit.ValueLit(`type` = lit.ValueLit.Type.Floating(lit.FloatLit(value)))
 

--- a/compiler/src/main/scala/edg/ExprBuilder.scala
+++ b/compiler/src/main/scala/edg/ExprBuilder.scala
@@ -49,9 +49,11 @@ object ExprBuilder {
       expr = expr.ValueExpr.Expr.Unary(expr.UnaryExpr(op = op, `val` = Some(vals)))
     )
 
-    def UnarySetOp(op: expr.UnarySetExpr.Op, vals: expr.ValueExpr): expr.ValueExpr = expr.ValueExpr(
-      expr = expr.ValueExpr.Expr.UnarySet(expr.UnarySetExpr(op = op, vals = Some(vals)))
-    )
+    def UnarySetOp(op: expr.UnarySetExpr.Op, vals: expr.ValueExpr, emptyValue: expr.ValueExpr): expr.ValueExpr =
+      expr.ValueExpr(
+        expr =
+          expr.ValueExpr.Expr.UnarySet(expr.UnarySetExpr(op = op, vals = Some(vals), emptyValue = Some(emptyValue)))
+      )
 
     def IfThenElse(cond: expr.ValueExpr, tru: expr.ValueExpr, fal: expr.ValueExpr): expr.ValueExpr = expr.ValueExpr(
       expr = expr.ValueExpr.Expr.IfThenElse(expr.IfThenElseExpr(cond = Some(cond), tru = Some(tru), fal = Some(fal)))

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -117,7 +117,7 @@ class AssignNamer() {
 }
 
 object Compiler {
-  final val kExpectedProtoVersion = 10
+  final val kExpectedProtoVersion = 11
 }
 
 /** Compiler for a particular design, with an associated library to elaborate references from.

--- a/compiler/src/main/scala/edg/compiler/Compiler.scala
+++ b/compiler/src/main/scala/edg/compiler/Compiler.scala
@@ -919,7 +919,8 @@ class Compiler private (
                     path.asIndirect ++ portPostfix + IndirectStep.Allocated,
                     ValueExpr.UnarySetOp(
                       expr.UnarySetExpr.Op.FLATTEN,
-                      ValueExpr.Array(Seq(connectTerms) ++ arrayConnectTermss)
+                      ValueExpr.Array(Seq(connectTerms) ++ arrayConnectTermss),
+                      ValueExpr.Array(Seq())
                     ),
                     path,
                     ""
@@ -1235,7 +1236,8 @@ class Compiler private (
                   path.asIndirect ++ portPostfix + IndirectStep.Allocated,
                   ValueExpr.UnarySetOp(
                     expr.UnarySetExpr.Op.FLATTEN,
-                    ValueExpr.Array(Seq(connectTerms) ++ arrayConnectTermss)
+                    ValueExpr.Array(Seq(connectTerms) ++ arrayConnectTermss),
+                    ValueExpr.Array(Seq())
                   ),
                   path,
                   ""

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -51,25 +51,25 @@ class ConstProp() {
   // Undeclared parameters cannot have values set, but can be forced (though the value is not effective until declared)
   private val paramTypes = mutable.HashMap[IndirectDesignPath, Class[_ <: ExprValue]]()
 
+  // This tracks overassign errors and their sources, which otherwise breaks the immutability of the dependency graph
+  private val overassigns = mutable.HashMap[IndirectDesignPath, mutable.HashSet[IndirectDesignPath]]()
+
   private val connectedLink = DependencyGraph[ConnectedLinkRecord, ConnectedLinkPort]() // tracks the port -> link paths
 
   // Params that have a forced/override value, so they arent over-assigned.
   private val forcedParams = mutable.Set[IndirectDesignPath]()
 
-  // Errors that were generated during the process of resolving parameters, including overassigns
-  // A value may or may not exist (and may or not have been propagated) in the param dependency graph
-  private val paramErrors = mutable.HashMap[IndirectDesignPath, mutable.ListBuffer[ErrorValue]]()
-
   def initFrom(that: ConstProp): Unit = {
-    require(paramAssign.isEmpty && paramSource.isEmpty && paramTypes.isEmpty && forcedParams.isEmpty
-      && paramErrors.isEmpty)
+    require(
+      paramAssign.isEmpty && paramSource.isEmpty && paramTypes.isEmpty && forcedParams.isEmpty && overassigns.isEmpty
+    )
     paramAssign.addAll(that.paramAssign)
     paramSource.addAll(that.paramSource)
     params.initFrom(that.params)
     paramTypes.addAll(that.paramTypes)
     connectedLink.initFrom(that.connectedLink)
     forcedParams.addAll(that.forcedParams)
-    paramErrors.addAll(that.paramErrors)
+    overassigns.addAll(that.overassigns)
   }
 
   //
@@ -116,14 +116,11 @@ class ConstProp() {
       readyList.foreach { constrTarget =>
         val assign = paramAssign(constrTarget)
         new ExprEvaluatePartial(getValue, assign.root).map(assign.value) match {
+          case ExprResult.Result(result @ ErrorValue(_)) =>
+            params.setValue(constrTarget, result, stop = true)
+            onParamSolved(constrTarget, result)
           case ExprResult.Result(result) =>
-            result match {
-              case result @ ErrorValue(_) =>
-                paramErrors.getOrElseUpdate(constrTarget, mutable.ListBuffer()).append(result)
-                params.clearReadyNode(constrTarget)
-              case result => params.setValue(constrTarget, result)
-            }
-
+            params.setValue(constrTarget, result)
             onParamSolved(constrTarget, result)
           case ExprResult.Missing(missing) => // account for CONNECTED_LINK prefix
             val missingCorrected = missing.map { path =>
@@ -211,10 +208,9 @@ class ConstProp() {
     } else {
       if (!forcedParams.contains(target)) {
         if (params.nodeDefinedAt(target)) { // TODO add propagated assign
-          val (prevRoot, prevConstr, _) = paramSource.get(target).getOrElse("?", "?", "")
-          paramErrors.getOrElseUpdate(target, mutable.ListBuffer()).append(
-            ErrorValue(s"over-assign from $root.$constrName, prev assigned from $prevRoot.$prevConstr")
-          )
+          val (prevRoot, prevConstr, _) = paramSource(target)
+          overassigns.getOrElseUpdate(target, mutable.HashSet()).add(root.asIndirect + constrName)
+          overassigns.getOrElseUpdate(target, mutable.HashSet()).add(prevRoot.asIndirect + prevConstr)
           return // first set "wins"
         }
         params.addNode(target, paramTypesDep)
@@ -291,7 +287,7 @@ class ConstProp() {
     * references.
     */
   def getUnsolved: Set[IndirectDesignPath] = {
-    paramTypes.keySet.toSet -- params.knownValueKeys -- paramErrors.keys
+    paramTypes.keySet.toSet -- params.knownValueKeys
   }
 
   def getAllSolved: Map[IndirectDesignPath, ExprValue] = params.toMap
@@ -303,8 +299,8 @@ class ConstProp() {
   }
 
   def getErrors: Seq[ExprError] = {
-    paramErrors.flatMap { case (target, errors) =>
-      errors.map(error => ExprError(target, error.msg))
-    }.toSeq
+    (params.toMap.collect { case (target, ErrorValue(Some(msg))) => ExprError(target, msg) } ++ overassigns.map {
+      case (target, sources) => ExprError(target, s"overassign from " + sources.map(_.toString).mkString(", "))
+    }).toSeq
   }
 }

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -260,7 +260,8 @@ class ConstProp() {
   }
 
   /** Returns the value of a parameter, or None if it does not have a value (yet?). Can be used to check if parameters
-    * are resolved yet by testing against None. Cannot return an ErrorValue
+    * are resolved yet by testing against None.
+    * Overassigns return their first value for consistency.
     */
   def getValue(param: IndirectDesignPath): Option[ExprValue] = {
     resolveConnectedLink(param) match {
@@ -290,7 +291,13 @@ class ConstProp() {
     paramTypes.keySet.toSet -- params.knownValueKeys
   }
 
-  def getAllSolved: Map[IndirectDesignPath, ExprValue] = params.toMap
+  private def getOverassignValues: Map[IndirectDesignPath, ErrorValue] = {
+    overassigns.map { case (target, sources) =>
+      target -> ErrorValue(Some(s"overassign from " + sources.map(_.toString).mkString(", ")))
+    }.toMap
+  }
+
+  def getAllSolved: Map[IndirectDesignPath, ExprValue] = params.toMap ++ getOverassignValues
 
   def getAllConnections: Map[DesignPath, DesignPath] = connectedLink.toMap.collect {
     case (ConnectedLinkRecord.ConnectedLink(towardsBlockPort), ConnectedLinkPort(linkPath, linkPortSuffix))
@@ -299,8 +306,10 @@ class ConstProp() {
   }
 
   def getErrors: Seq[ExprError] = {
-    (params.toMap.collect { case (target, ErrorValue(Some(msg))) => ExprError(target, msg) } ++ overassigns.map {
-      case (target, sources) => ExprError(target, s"overassign from " + sources.map(_.toString).mkString(", "))
+    (params.toMap.collect { case (target, ErrorValue(Some(msg))) =>
+      ExprError(target, msg)
+    } ++ getOverassignValues.map {
+      case (target, error) => ExprError(target, error.msg.get)
     }).toSeq
   }
 }

--- a/compiler/src/main/scala/edg/compiler/ConstProp.scala
+++ b/compiler/src/main/scala/edg/compiler/ConstProp.scala
@@ -260,8 +260,7 @@ class ConstProp() {
   }
 
   /** Returns the value of a parameter, or None if it does not have a value (yet?). Can be used to check if parameters
-    * are resolved yet by testing against None.
-    * Overassigns return their first value for consistency.
+    * are resolved yet by testing against None. Overassigns return their first value for consistency.
     */
   def getValue(param: IndirectDesignPath): Option[ExprValue] = {
     resolveConnectedLink(param) match {

--- a/compiler/src/main/scala/edg/compiler/DesignRefsValidate.scala
+++ b/compiler/src/main/scala/edg/compiler/DesignRefsValidate.scala
@@ -34,8 +34,12 @@ object CollectExprRefs extends ValueExprMap[Seq[ref.LocalPath]] {
   override def mapUnary(unary: expr.UnaryExpr, `val`: Seq[ref.LocalPath]): Seq[ref.LocalPath] = {
     `val`
   }
-  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: Seq[ref.LocalPath]): Seq[ref.LocalPath] = {
-    vals
+  override def mapUnarySet(
+      unarySet: expr.UnarySetExpr,
+      vals: Seq[ref.LocalPath],
+      emptyValue: Seq[ref.LocalPath]
+  ): Seq[ref.LocalPath] = {
+    vals ++ emptyValue
   }
   override def mapArray(array: expr.ArrayExpr, vals: Seq[Seq[ref.LocalPath]]): Seq[ref.LocalPath] = {
     vals.flatten

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -317,7 +317,7 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.sum, valMaxs.sum)
           case ArrayValue.UnpackRange.RangeWithEmpty(_, _) => RangeEmpty
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case ArrayValue.UnpackRange.EmptyArray() =>
+          case ArrayValue.UnpackRange.EmptyArray() =>  // empty array case handled above
             throw new AssertionError("compiler internal error, shouldn't happen")
         }
 
@@ -360,7 +360,7 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.RangeWithEmpty(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case ArrayValue.UnpackRange.EmptyArray() =>
+          case ArrayValue.UnpackRange.EmptyArray() =>  // empty array case handled above
             throw new AssertionError("compiler internal error, shouldn't happen")
         }
       case (Op.HULL, ArrayValue.ExtractFloat(vals)) => RangeValue(vals.min, vals.max)

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -59,7 +59,9 @@ object ExprEvaluate {
             val lower = contribMax * targetMin
             val upper = contribMin * targetMax
             if (lower > upper) {
-              ErrorValue(s"shrink_mult($lhs, $rhs) produces empty range, target $lhs tighter tol than contrib $rhs")
+              ErrorValue(
+                Some(s"shrink_mult($lhs, $rhs) produces empty range, target $lhs tighter tol than contrib $rhs")
+              )
             } else {
               RangeValue(lower, upper)
             }
@@ -293,8 +295,8 @@ object ExprEvaluate {
       case (Op.MIN, RangeValue(valMin, _)) => FloatValue(valMin)
       case (Op.MAX, RangeValue(_, valMax)) => FloatValue(valMax)
 
-      case (Op.MAX, RangeEmpty) => ErrorValue("max(RangeEmpty) is undefined")
-      case (Op.MIN, RangeEmpty) => ErrorValue("min(RangeEmpty) is undefined")
+      case (Op.MAX, RangeEmpty) => ErrorValue(Some("max(RangeEmpty) is undefined"))
+      case (Op.MIN, RangeEmpty) => ErrorValue(Some("min(RangeEmpty) is undefined"))
 
       case (Op.CENTER, RangeValue(valMin, valMax)) => FloatValue((valMin + valMax) / 2)
       case (Op.WIDTH, RangeValue(valMin, valMax)) => FloatValue(math.abs(valMax - valMin))
@@ -336,7 +338,7 @@ object ExprEvaluate {
       case (Op.SET_EXTRACT, ArrayValue(vals)) => if (vals.forall(_ == vals.head)) {
           vals.head
         } else {
-          ErrorValue(f"set_extract($vals) with non-equal values")
+          ErrorValue(Some(f"set_extract($vals) with non-equal values"))
         }
 
       // Any empty value means the expression result is empty
@@ -346,11 +348,11 @@ object ExprEvaluate {
             if (maxMin <= minMax) {
               RangeValue(maxMin, minMax)
             } else { // does not intersect, null set
-              ErrorValue(f"intersection($extracted) produces empty set")
+              ErrorValue(Some(f"intersection($extracted) produces empty set"))
             }
           case ArrayValue.UnpackRange.RangeWithEmpty(_, _) => RangeEmpty
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case _ => ErrorValue(f"intersection($vals) is undefined")
+          case _ => ErrorValue(Some(f"intersection($vals) is undefined"))
         }
 
       // Any value is used (empty effectively discarded)
@@ -404,7 +406,7 @@ object ExprEvaluate {
     case (FloatPromotable(lhs), FloatPromotable(rhs)) => if (lhs <= rhs) {
         RangeValue(lhs, rhs)
       } else {
-        ErrorValue(s"range($minimum, $maximum) is malformed, $minimum > $maximum")
+        ErrorValue(Some(s"range($minimum, $maximum) is malformed, $minimum > $maximum"))
       }
     case _ => throw new ExprEvaluateException(s"Unknown range operands types $minimum $maximum from $range")
   }

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -317,7 +317,7 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.sum, valMaxs.sum)
           case ArrayValue.UnpackRange.RangeWithEmpty(_, _) => RangeEmpty
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case ArrayValue.UnpackRange.EmptyArray() =>  // empty array case handled above
+          case ArrayValue.UnpackRange.EmptyArray() => // empty array case handled above
             throw new AssertionError("compiler internal error, shouldn't happen")
         }
 
@@ -360,7 +360,7 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.RangeWithEmpty(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case ArrayValue.UnpackRange.EmptyArray() =>  // empty array case handled above
+          case ArrayValue.UnpackRange.EmptyArray() => // empty array case handled above
             throw new AssertionError("compiler internal error, shouldn't happen")
         }
       case (Op.HULL, ArrayValue.ExtractFloat(vals)) => RangeValue(vals.min, vals.max)

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -315,6 +315,8 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.sum, valMaxs.sum)
           case ArrayValue.UnpackRange.RangeWithEmpty(_, _) => RangeEmpty
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
+          case ArrayValue.UnpackRange.EmptyArray() =>
+            throw new AssertionError("compiler internal error, shouldn't happen")
         }
 
       case (Op.ALL_TRUE, ArrayValue.ExtractBoolean(vals)) => BooleanValue(vals.forall(_ == true))
@@ -356,6 +358,8 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.RangeWithEmpty(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
+          case ArrayValue.UnpackRange.EmptyArray() =>
+            throw new AssertionError("compiler internal error, shouldn't happen")
         }
       case (Op.HULL, ArrayValue.ExtractFloat(vals)) => RangeValue(vals.min, vals.max)
 

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -303,11 +303,11 @@ object ExprEvaluate {
     }
   }
 
-  def evalUnarySet(unarySet: expr.UnarySetExpr, vals: ExprValue): ExprValue = {
+  def evalUnarySet(unarySet: expr.UnarySetExpr, vals: ExprValue, emptyValue: ExprValue): ExprValue = {
     import expr.UnarySetExpr.Op
     (unarySet.op, vals) match {
+      case (_, ArrayValue.Empty(_)) => emptyValue
       // In this case we don't do numeric promotion
-      case (Op.SUM, ArrayValue.Empty(_)) => FloatValue(0) // TODO type needs to be dynamic
       case (Op.SUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.sum)
       case (Op.SUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.sum)
       case (Op.SUM, ArrayValue.ExtractBoolean(vals)) => IntValue(vals.count(_ == true))
@@ -315,13 +315,9 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.sum, valMaxs.sum)
           case ArrayValue.UnpackRange.RangeWithEmpty(_, _) => RangeEmpty
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case ArrayValue.UnpackRange.EmptyArray() =>
-            RangeValue(0, 0) // unreachable in practice, superseded by float 0 case
         }
 
-      case (Op.ALL_TRUE, ArrayValue.Empty(_)) => BooleanValue(true)
       case (Op.ALL_TRUE, ArrayValue.ExtractBoolean(vals)) => BooleanValue(vals.forall(_ == true))
-      case (Op.ANY_TRUE, ArrayValue.Empty(_)) => BooleanValue(false)
       case (Op.ANY_TRUE, ArrayValue.ExtractBoolean(vals)) => BooleanValue(vals.contains(true))
 
       // TODO better support for empty arrays?
@@ -335,7 +331,6 @@ object ExprEvaluate {
       case (Op.MINIMUM, ArrayValue.ExtractFloat(vals)) => FloatValue(vals.min)
       case (Op.MINIMUM, ArrayValue.ExtractInt(vals)) => IntValue(vals.min)
 
-      case (Op.SET_EXTRACT, ArrayValue.Empty(_)) => ErrorValue("set_extract(empty) is undefined")
       case (Op.SET_EXTRACT, ArrayValue(vals)) => if (vals.forall(_ == vals.head)) {
           vals.head
         } else {
@@ -353,8 +348,6 @@ object ExprEvaluate {
             }
           case ArrayValue.UnpackRange.RangeWithEmpty(_, _) => RangeEmpty
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          // The implicit initial value of intersect is the full range
-          case ArrayValue.UnpackRange.EmptyArray() => RangeValue(Float.NegativeInfinity, Float.PositiveInfinity)
           case _ => ErrorValue(f"intersection($vals) is undefined")
         }
 
@@ -363,7 +356,6 @@ object ExprEvaluate {
           case ArrayValue.UnpackRange.FullRange(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.RangeWithEmpty(valMins, valMaxs) => RangeValue(valMins.min, valMaxs.max)
           case ArrayValue.UnpackRange.EmptyRange() => RangeEmpty
-          case ArrayValue.UnpackRange.EmptyArray() => RangeEmpty // TODO: should this be an error?
         }
       case (Op.HULL, ArrayValue.ExtractFloat(vals)) => RangeValue(vals.min, vals.max)
 
@@ -442,8 +434,8 @@ class ExprEvaluate(refs: ConstProp, root: DesignPath) extends ValueExprMap[ExprV
   override def mapUnary(unary: expr.UnaryExpr, `val`: ExprValue): ExprValue =
     ExprEvaluate.evalUnary(unary, `val`)
 
-  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: ExprValue): ExprValue =
-    ExprEvaluate.evalUnarySet(unarySet, vals)
+  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: ExprValue, emptyValue: ExprValue): ExprValue =
+    ExprEvaluate.evalUnarySet(unarySet, vals, emptyValue)
 
   override def mapArray(array: expr.ArrayExpr, vals: Seq[ExprValue]): ExprValue =
     ExprEvaluate.evalArray(array, vals)

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluatePartial.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluatePartial.scala
@@ -70,10 +70,14 @@ class ExprEvaluatePartial(refResolver: IndirectDesignPath => Option[ExprValue], 
     case ExprResult.Result(resVal) => ExprResult.Result(ExprEvaluate.evalUnary(unary, resVal))
   }
 
-  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: ExprResult): ExprResult = vals match {
-    case vals @ ExprResult.Missing(_) => vals
-    case ExprResult.Result(vals) => ExprResult.Result(ExprEvaluate.evalUnarySet(unarySet, vals))
-  }
+  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: ExprResult, emptyValue: ExprResult): ExprResult =
+    (vals, emptyValue) match {
+      case (ExprResult.Missing(vals), ExprResult.Missing(emptyValue)) => ExprResult.Missing(vals ++ emptyValue)
+      case (vals @ ExprResult.Missing(_), _) => vals
+      case (_, emptyValue @ ExprResult.Missing(_)) => emptyValue
+      case (ExprResult.Result(vals), ExprResult.Result(emptyValue)) =>
+        ExprResult.Result(ExprEvaluate.evalUnarySet(unarySet, vals, emptyValue))
+    }
 
   override def mapArray(array: expr.ArrayExpr, vals: Seq[ExprResult]): ExprResult = {
     val missing = vals.collect {

--- a/compiler/src/main/scala/edg/compiler/ExprToString.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprToString.scala
@@ -143,7 +143,7 @@ class ExprToString() extends ValueExprMap[String] {
     }
   }
 
-  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: String): String = unarySet.op match {
+  override def mapUnarySet(unarySet: expr.UnarySetExpr, vals: String, emptyValue: String): String = unarySet.op match {
     case UnarySetExprOp(op) => s"$op(${vals})"
     case op => s"unknown[$op](${vals})"
   }

--- a/compiler/src/main/scala/edg/compiler/ExprToString.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprToString.scala
@@ -30,6 +30,7 @@ class ExprToString() extends ValueExprMap[String] {
       val arrayElts = array.elts.map(mapLiteral)
       s"[${arrayElts.mkString(", ")}]"
     case lit.ValueLit.Type.Struct(_) => "unsupported struct"
+    case lit.ValueLit.Type.Error(literal) => s"error(${literal.message})"
     case lit.ValueLit.Type.Empty => "(empty)"
   }
 

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -25,6 +25,10 @@ object ExprValue {
   }
 
   def fromValueLit(literal: lit.ValueLit): ExprValue = literal.`type` match {
+    case lit.ValueLit.Type.Error(literal) => ErrorValue(literal.message match {
+        case "" => None
+        case msg => Some(msg)
+      })
     case lit.ValueLit.Type.Floating(literal) => FloatValue(literal.`val`.toFloat)
     case lit.ValueLit.Type.Integer(literal) => IntValue(literal.`val`)
     case lit.ValueLit.Type.Boolean(literal) => BooleanValue(literal.`val`)
@@ -45,6 +49,11 @@ object ExprValue {
     case lit.ValueLit.Type.Empty | lit.ValueLit.Type.Struct(_) =>
       throw new IllegalArgumentException(s"unsupported literal $literal")
   }
+}
+
+case class ErrorValue(msg: Option[String]) extends ExprValue {
+  def toLit: lit.ValueLit = Literal.Error(msg)
+  def toStringValue: String = s"error(${msg.getOrElse("")})"
 }
 
 // These should be consistent with what is in init.proto
@@ -206,10 +215,4 @@ case class ArrayValue[T <: ExprValue](values: Seq[T]) extends ExprValue {
     val valuesString = values.map { _.toStringValue }.mkString(", ")
     s"[$valuesString]"
   }
-}
-
-// a special value not in the IR that indicates and error
-case class ErrorValue(msg: String) extends ExprValue {
-  override def toLit: lit.ValueLit = throw new IllegalArgumentException("cannot convert error value to literal")
-  override def toStringValue: String = msg
 }

--- a/compiler/src/main/scala/edg/compiler/ValueExprMap.scala
+++ b/compiler/src/main/scala/edg/compiler/ValueExprMap.scala
@@ -43,7 +43,7 @@ trait ValueExprMap[OutputType] {
     throw new NotImplementedError(s"Undefined mapBinarySet for $binarySet")
   def mapUnary(unary: expr.UnaryExpr, `val`: OutputType): OutputType =
     throw new NotImplementedError(s"Undefined mapUnary for $unary")
-  def mapUnarySet(unarySet: expr.UnarySetExpr, vals: OutputType): OutputType =
+  def mapUnarySet(unarySet: expr.UnarySetExpr, vals: OutputType, emptyValue: OutputType): OutputType =
     throw new NotImplementedError(s"Undefined mapBinarySet for $unarySet")
   def mapArray(array: expr.ArrayExpr, vals: Seq[OutputType]): OutputType =
     throw new NotImplementedError(s"Undefined mapArray for $array")
@@ -117,7 +117,7 @@ trait ValueExprMap[OutputType] {
     mapUnary(unary, map(unary.`val`.get))
   }
   def wrapUnarySet(unarySet: expr.UnarySetExpr): OutputType = {
-    mapUnarySet(unarySet, map(unarySet.vals.get))
+    mapUnarySet(unarySet, map(unarySet.vals.get), map(unarySet.emptyValue.get))
   }
   def wrapArray(array: expr.ArrayExpr): OutputType = {
     mapArray(array, array.vals.map(value => map(value)))

--- a/compiler/src/main/scala/edg/compiler/ValueExprMap.scala
+++ b/compiler/src/main/scala/edg/compiler/ValueExprMap.scala
@@ -44,7 +44,7 @@ trait ValueExprMap[OutputType] {
   def mapUnary(unary: expr.UnaryExpr, `val`: OutputType): OutputType =
     throw new NotImplementedError(s"Undefined mapUnary for $unary")
   def mapUnarySet(unarySet: expr.UnarySetExpr, vals: OutputType, emptyValue: OutputType): OutputType =
-    throw new NotImplementedError(s"Undefined mapBinarySet for $unarySet")
+    throw new NotImplementedError(s"Undefined mapUnarySet for $unarySet")
   def mapArray(array: expr.ArrayExpr, vals: Seq[OutputType]): OutputType =
     throw new NotImplementedError(s"Undefined mapArray for $array")
   def mapStruct(struct: expr.StructExpr, vals: Map[String, OutputType]): OutputType =

--- a/compiler/src/main/scala/edg/util/DependencyGraph.scala
+++ b/compiler/src/main/scala/edg/util/DependencyGraph.scala
@@ -63,24 +63,18 @@ class DependencyGraph[KeyType, ValueType] {
   // Node must exist, or this will exception out
   def nodeMissing(node: KeyType): Iterable[KeyType] = deps(node)
 
-  // Clears a node from ready without setting a value in the graph.
-  // Useful to stop propagation at some point, but without crashing.
-  // The node may be marked ready again by other sources.
-  def clearReadyNode(node: KeyType): Unit = {
-    require(ready.contains(node), s"attempt to clear ready node $node that is not ready")
-    ready -= node
-  }
-
   // Sets the value of a node. May not overwrite values.
-  // If stop is true, propagation will not continue:
-  // while the node will have a value, dependents will not be marked as ready
-  def setValue(node: KeyType, value: ValueType): Unit = {
+  // Optionally stops propagation if stop=true.
+  def setValue(node: KeyType, value: ValueType, stop: Boolean = false): Unit = {
     require(!values.isDefinedAt(node), s"redefinition of $node (prior value ${values(node)}, new value $value)")
     deps.put(node, mutable.Set())
     values.put(node, value)
     ready -= node
 
     // See if the update caused anything else to be ready
+    if (stop) {
+      return
+    }
     for (inverseDep <- inverseDeps.getOrElse(node, mutable.ArrayBuffer())) {
       val remainingDeps = deps(inverseDep)
       remainingDeps -= node

--- a/compiler/src/test/scala/edg/compiler/CompilerEvaluationTest.scala
+++ b/compiler/src/test/scala/edg/compiler/CompilerEvaluationTest.scala
@@ -91,11 +91,15 @@ class CompilerEvaluationTest extends AnyFlatSpec with CompilerTestUtil {
           "calcSourceFloat" -> ValueExpr.Assign(Ref("sourceFloat"), ValueExpr.Ref("source", "floatVal")),
           "calcSinkSum" -> ValueExpr.Assign(
             Ref("sinkSum"),
-            ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("sinks"), Ref("sumVal")))
+            ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("sinks"), Ref("sumVal")), ValueExpr.Literal(0.0))
           ),
           "calcSinkIntersect" -> ValueExpr.Assign(
             Ref("sinkIntersect"),
-            ValueExpr.UnarySetOp(Op.INTERSECTION, ValueExpr.MapExtract(Ref("sinks"), Ref("intersectVal")))
+            ValueExpr.UnarySetOp(
+              Op.INTERSECTION,
+              ValueExpr.MapExtract(Ref("sinks"), Ref("intersectVal")),
+              ValueExpr.Literal(Float.NegativeInfinity, Float.PositiveInfinity)
+            )
           ),
         )
       ),

--- a/compiler/src/test/scala/edg/compiler/ConstPropArrayTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropArrayTest.scala
@@ -77,7 +77,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     val constProp = new ConstProp()
     addArray(constProp, Seq(), 4, { i => ValueExpr.Literal(i.toFloat, (i + 4).toFloat) }, Seq("ports"), Seq("param"))
 
-    constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
+    constProp.addDeclaration(DesignPath() + "reduce", ValInit.Range)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
       ValueExpr.UnarySetOp(

--- a/compiler/src/test/scala/edg/compiler/ConstPropArrayTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropArrayTest.scala
@@ -54,7 +54,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("ports"), "param"))
+      ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Literal(0))
     )
     constProp.getValue(IndirectDesignPath() + "reduce") should equal(Some(IntValue(1 + 2 + 3 + 4 + 5)))
   }
@@ -67,7 +67,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.MAXIMUM, ValueExpr.MapExtract(Ref("ports"), "param"))
+      ValueExpr.UnarySetOp(Op.MAXIMUM, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Literal(0))
     )
     constProp.getValue(IndirectDesignPath() + "reduce") should equal(Some(IntValue(5)))
   }
@@ -80,7 +80,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.INTERSECTION, ValueExpr.MapExtract(Ref("ports"), "param"))
+      ValueExpr.UnarySetOp(Op.INTERSECTION, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Literal(Float.NegativeInfinity, Float.PositiveInfinity))
     )
     constProp.getValue(IndirectDesignPath() + "reduce") should equal(Some(RangeValue(3.0, 4.0)))
   }
@@ -92,7 +92,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.SET_EXTRACT, ValueExpr.MapExtract(Ref("ports"), "param"))
+      ValueExpr.UnarySetOp(Op.SET_EXTRACT, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Array(Seq()))
     )
     constProp.getValue(IndirectDesignPath() + "reduce") should equal(None)
     constProp.getErrors should not be empty
@@ -106,7 +106,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.SET_EXTRACT, ValueExpr.MapExtract(Ref("ports"), "param"))
+      ValueExpr.UnarySetOp(Op.SET_EXTRACT, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Literal(Seq()))
     )
     constProp.getValue(IndirectDesignPath() + "reduce") should equal(Some(IntValue(2)))
   }
@@ -119,7 +119,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("ports"), "param"))
+      ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Literal(0))
     )
 
     addArray(constProp, Seq(), 5, { i => ValueExpr.Literal(i + 1) }, Seq("ports"), Seq("param"))

--- a/compiler/src/test/scala/edg/compiler/ConstPropArrayTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropArrayTest.scala
@@ -80,7 +80,11 @@ class ConstPropArrayTest extends AnyFlatSpec {
     constProp.addDeclaration(DesignPath() + "reduce", ValInit.Integer)
     constProp.addAssignExpr(
       IndirectDesignPath() + "reduce",
-      ValueExpr.UnarySetOp(Op.INTERSECTION, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Literal(Float.NegativeInfinity, Float.PositiveInfinity))
+      ValueExpr.UnarySetOp(
+        Op.INTERSECTION,
+        ValueExpr.MapExtract(Ref("ports"), "param"),
+        ValueExpr.Literal(Float.NegativeInfinity, Float.PositiveInfinity)
+      )
     )
     constProp.getValue(IndirectDesignPath() + "reduce") should equal(Some(RangeValue(3.0, 4.0)))
   }
@@ -94,7 +98,7 @@ class ConstPropArrayTest extends AnyFlatSpec {
       IndirectDesignPath() + "reduce",
       ValueExpr.UnarySetOp(Op.SET_EXTRACT, ValueExpr.MapExtract(Ref("ports"), "param"), ValueExpr.Array(Seq()))
     )
-    constProp.getValue(IndirectDesignPath() + "reduce") should equal(None)
+    assert(constProp.getValue(IndirectDesignPath() + "reduce").get.isInstanceOf[ErrorValue])
     constProp.getErrors should not be empty
   }
 

--- a/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
@@ -193,8 +193,8 @@ class ConstPropAssignTest extends AnyFlatSpec {
       ValueExpr.BinOp(Op.SHRINK_MULT, ValueExpr.Literal(1, 1), ValueExpr.Ref("x")),
     )
     constProp.addAssignValue(IndirectDesignPath() + "x", RangeValue(0, 2))
-    constProp.getValue(IndirectDesignPath() + "a") should equal(None)
-    constProp.getValue(IndirectDesignPath() + "b") should equal(None)
+    assert(constProp.getValue(IndirectDesignPath() + "a").get.isInstanceOf[ErrorValue])
+    assert(constProp.getValue(IndirectDesignPath() + "b").get.isInstanceOf[ErrorValue])
     constProp.getErrors should not be empty
   }
 }

--- a/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
@@ -185,7 +185,7 @@ class ConstPropAssignTest extends AnyFlatSpec {
     constProp.addAssignValue(IndirectDesignPath() + "a", IntValue(3))
 
     constProp.getErrors should not be empty
-    constProp.getValue(IndirectDesignPath() + "a") should equal(None)
+    assert(constProp.getAllSolved(IndirectDesignPath() + "a").isInstanceOf[ErrorValue])
   }
 
   it should "not propagate generated ErrorValues" in {

--- a/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
@@ -178,6 +178,16 @@ class ConstPropAssignTest extends AnyFlatSpec {
     constProp2.getValue(IndirectDesignPath() + "a") should equal(Some(IntValue(3)))
   }
 
+  it should "error on overassign" in {
+    val constProp = new ConstProp()
+    constProp.addDeclaration(DesignPath() + "a", ValInit.Integer)
+    constProp.addAssignValue(IndirectDesignPath() + "a", IntValue(2))
+    constProp.addAssignValue(IndirectDesignPath() + "a", IntValue(3))
+
+    constProp.getErrors should not be empty
+    constProp.getValue(IndirectDesignPath() + "a") should equal(None)
+  }
+
   it should "not propagate generated ErrorValues" in {
     import edgir.expr.expr.BinaryExpr.Op
     val constProp = new ConstProp()
@@ -193,8 +203,9 @@ class ConstPropAssignTest extends AnyFlatSpec {
       ValueExpr.BinOp(Op.SHRINK_MULT, ValueExpr.Literal(1, 1), ValueExpr.Ref("x")),
     )
     constProp.addAssignValue(IndirectDesignPath() + "x", RangeValue(0, 2))
-    assert(constProp.getValue(IndirectDesignPath() + "a").get.isInstanceOf[ErrorValue])
-    assert(constProp.getValue(IndirectDesignPath() + "b").get.isInstanceOf[ErrorValue])
+
     constProp.getErrors should not be empty
+    assert(constProp.getValue(IndirectDesignPath() + "a").get.isInstanceOf[ErrorValue])
+    constProp.getValue(IndirectDesignPath() + "b") shouldBe None
   }
 }

--- a/compiler/src/test/scala/edg/compiler/ExprEvaluatePartialTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ExprEvaluatePartialTest.scala
@@ -155,7 +155,7 @@ class ExprEvaluatePartialTest extends AnyFlatSpec {
     val evalTest = new ExprEvaluatePartial(refs.get, DesignPath())
 
     evalTest.map(
-      ValueExpr.UnarySetOp(expr.UnarySetExpr.Op.SUM, ValueExpr.MapExtract(Ref("container"), "inner"))
+      ValueExpr.UnarySetOp(expr.UnarySetExpr.Op.SUM, ValueExpr.MapExtract(Ref("container"), "inner"), ValueExpr.Literal(0, 0))
     ) should equal(ExprResult.Result(IntValue(6)))
   }
 }

--- a/compiler/src/test/scala/edg/compiler/ExprEvaluatePartialTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ExprEvaluatePartialTest.scala
@@ -158,7 +158,7 @@ class ExprEvaluatePartialTest extends AnyFlatSpec {
       ValueExpr.UnarySetOp(
         expr.UnarySetExpr.Op.SUM,
         ValueExpr.MapExtract(Ref("container"), "inner"),
-        ValueExpr.Literal(0, 0)
+        ValueExpr.Literal(0)
       )
     ) should equal(ExprResult.Result(IntValue(6)))
   }

--- a/compiler/src/test/scala/edg/compiler/ExprEvaluatePartialTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ExprEvaluatePartialTest.scala
@@ -155,7 +155,11 @@ class ExprEvaluatePartialTest extends AnyFlatSpec {
     val evalTest = new ExprEvaluatePartial(refs.get, DesignPath())
 
     evalTest.map(
-      ValueExpr.UnarySetOp(expr.UnarySetExpr.Op.SUM, ValueExpr.MapExtract(Ref("container"), "inner"), ValueExpr.Literal(0, 0))
+      ValueExpr.UnarySetOp(
+        expr.UnarySetExpr.Op.SUM,
+        ValueExpr.MapExtract(Ref("container"), "inner"),
+        ValueExpr.Literal(0, 0)
+      )
     ) should equal(ExprResult.Result(IntValue(6)))
   }
 }

--- a/compiler/src/test/scala/edg/compiler/ExprEvaluateTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ExprEvaluateTest.scala
@@ -307,7 +307,8 @@ class ExprEvaluateTest extends AnyFlatSpec {
           Literal.Boolean(false),
           Literal.Boolean(true),
           Literal.Boolean(false),
-        ))
+        )),
+        ValueExpr.Array(Seq())
       )
     ) should equal(ArrayValue(Seq(BooleanValue(true), BooleanValue(false), BooleanValue(true))))
 
@@ -318,7 +319,8 @@ class ExprEvaluateTest extends AnyFlatSpec {
           Literal.Array(Seq(Literal.Integer(0), Literal.Integer(1))),
           Literal.Array(Seq(Literal.Integer(2))),
           Literal.Array(Seq(Literal.Integer(3), Literal.Integer(4), Literal.Integer(5))),
-        ))
+        )),
+        ValueExpr.Array(Seq())
       )
     ) should equal(ArrayValue(Seq(IntValue(0), IntValue(1), IntValue(2), IntValue(3), IntValue(4), IntValue(5))))
 
@@ -329,7 +331,8 @@ class ExprEvaluateTest extends AnyFlatSpec {
           ValueExpr.Literal(Seq(
             Literal.Array(Seq(Literal.Integer(0), Literal.Integer(1))),
             Literal.Array(Seq(Literal.Boolean(true))),
-          ))
+          )),
+          ValueExpr.Array(Seq())
         )
       )
     }

--- a/compiler/src/test/scala/edg/compiler/TunnelExportTest.scala
+++ b/compiler/src/test/scala/edg/compiler/TunnelExportTest.scala
@@ -97,11 +97,11 @@ class TunnelExportTest extends AnyFlatSpec with CompilerTestUtil {
         constraints = SeqMap(
           "calcSum" -> ValueExpr.Assign(
             Ref("sum"),
-            ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("ports"), Ref("floatVal")))
+            ValueExpr.UnarySetOp(Op.SUM, ValueExpr.MapExtract(Ref("ports"), Ref("floatVal")), ValueExpr.Literal(0.0))
           ),
           "calcHull" -> ValueExpr.Assign(
             Ref("hull"),
-            ValueExpr.UnarySetOp(Op.HULL, ValueExpr.MapExtract(Ref("ports"), Ref("floatVal")))
+            ValueExpr.UnarySetOp(Op.HULL, ValueExpr.MapExtract(Ref("ports"), Ref("floatVal")), ValueExpr.Literal(0.0))
           ),
         )
       ),

--- a/compiler/src/test/scala/edg/compiler/TunnelExportTest.scala
+++ b/compiler/src/test/scala/edg/compiler/TunnelExportTest.scala
@@ -101,7 +101,11 @@ class TunnelExportTest extends AnyFlatSpec with CompilerTestUtil {
           ),
           "calcHull" -> ValueExpr.Assign(
             Ref("hull"),
-            ValueExpr.UnarySetOp(Op.HULL, ValueExpr.MapExtract(Ref("ports"), Ref("floatVal")), ValueExpr.Literal(0.0))
+            ValueExpr.UnarySetOp(
+              Op.HULL,
+              ValueExpr.MapExtract(Ref("ports"), Ref("floatVal")),
+              ValueExpr.Literal(0.0, 0.0)
+            )
           ),
         )
       ),

--- a/edg/core/Array.py
+++ b/edg/core/Array.py
@@ -61,6 +61,7 @@ class FlattenBinding(Binding):
     def populate_expr_proto(self, pb: edgir.ValueExpr, expr: ConstraintExpr, ref_map: Refable.RefMapType) -> None:
         pb.unary_set.op = edgir.UnarySetExpr.Op.FLATTEN
         self.elts._populate_expr_proto(pb.unary_set.vals, ref_map)
+        pb.unary_set.empty_value.literal.array.SetInParent()  # mark as empty array
 
 
 @non_library

--- a/edg/core/ArrayExpr.py
+++ b/edg/core/ArrayExpr.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import Generic, Any, Type, Optional, Union, Iterable, Sequence, List
 
 from typing_extensions import TypeVar, override

--- a/edg/core/ArrayExpr.py
+++ b/edg/core/ArrayExpr.py
@@ -106,10 +106,10 @@ class ArrayExpr(
         self._elt_sample: ArrayEltType = self._elt_type()._new_bind(SampleElementBinding())
 
     def all_unique(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_unique, BoolExpr(True)))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_unique, BoolExpr._to_expr_type(True)))
 
     def all_equal(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_equal, BoolExpr(True)))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_equal, BoolExpr._to_expr_type(True)))
 
 
 ArrayBoolLike = Union["ArrayBoolExpr", Sequence[BoolLike]]
@@ -119,16 +119,16 @@ class ArrayBoolExpr(ArrayExpr[BoolExpr, List[bool], ArrayBoolLike]):
     _elt_type = BoolExpr
 
     def __invert__(self) -> ArrayBoolExpr:
-        return self._new_bind(UnarySetOpBinding(self, BoolOp.op_not, ArrayBoolExpr([])))
+        return self._new_bind(UnarySetOpBinding(self, BoolOp.op_not, ArrayBoolExpr._to_expr_type([])))
 
     def any(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_or, BoolExpr(False)))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_or, BoolExpr._to_expr_type(False)))
 
     def all(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_and, BoolExpr(True)))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_and, BoolExpr._to_expr_type(True)))
 
     def count(self) -> IntExpr:
-        return IntExpr()._new_bind(UnarySetOpBinding(self, NumericOp.sum, IntExpr(0)))
+        return IntExpr()._new_bind(UnarySetOpBinding(self, NumericOp.sum, IntExpr._to_expr_type(0)))
 
 
 ArrayIntLike = Union["ArrayIntExpr", Sequence[IntLike]]
@@ -138,7 +138,7 @@ class ArrayIntExpr(ArrayExpr[IntExpr, List[int], ArrayIntLike]):
     _elt_type = IntExpr
 
     def sum(self) -> IntExpr:
-        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, IntExpr(0)))
+        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, IntExpr._to_expr_type(0)))
 
 
 ArrayFloatLike = Union["ArrayFloatExpr", Sequence[FloatLike]]
@@ -148,13 +148,13 @@ class ArrayFloatExpr(ArrayExpr[FloatExpr, List[float], ArrayFloatLike]):
     _elt_type = FloatExpr
 
     def sum(self) -> FloatExpr:
-        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, FloatExpr(0)))
+        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, FloatExpr._to_expr_type(0)))
 
     def min(self) -> FloatExpr:
-        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.min, FloatExpr(float("inf"))))
+        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.min, FloatExpr._to_expr_type(float("inf"))))
 
     def max(self) -> FloatExpr:
-        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.max, FloatExpr(float("-inf"))))
+        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.max, FloatExpr._to_expr_type(float("-inf"))))
 
 
 ArrayRangeLike = Union["ArrayRangeExpr", Sequence[RangeLike]]
@@ -174,7 +174,7 @@ class ArrayRangeExpr(ArrayExpr[RangeExpr, List[Range], ArrayRangeLike]):
     def __rtruediv__(self, other: Union[FloatLike, RangeLike]) -> ArrayRangeExpr:
         """Broadcast-pointwise invert-and-multiply (division with array as rhs)"""
         return self._create_binary_set_op(
-            self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.invert, ArrayRangeExpr([]))),
+            self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.invert, ArrayRangeExpr._to_expr_type([]))),
             RangeExpr._to_expr_type(other),
             NumericOp.mul,
         )
@@ -185,10 +185,17 @@ class ArrayRangeExpr(ArrayExpr[RangeExpr, List[Range], ArrayRangeLike]):
         return ArrayBoolExpr()._new_bind(BinarySetOpBinding(self, RangeExpr._to_expr_type(other), EqOp.all_equal))
 
     def intersection(self) -> RangeExpr:
-        return self._elt_type._new_bind(UnarySetOpBinding(self, RangeSetOp.intersection, RangeExpr(RangeExpr.ALL)))
+        return self._elt_type._new_bind(
+            UnarySetOpBinding(self, RangeSetOp.intersection, RangeExpr._to_expr_type(RangeExpr.ALL))
+        )
 
     def hull(self) -> RangeExpr:
-        return self._elt_type._new_bind(UnarySetOpBinding(self, RangeSetOp.hull, RangeExpr(RangeExpr.EMPTY)))
+        return self._elt_type._new_bind(
+            UnarySetOpBinding(self, RangeSetOp.hull, RangeExpr._to_expr_type(RangeExpr.EMPTY))
+        )
+
+    def sum(self) -> RangeExpr:
+        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, RangeExpr._to_expr_type((0, 0))))
 
 
 ArrayStringLike = Union["ArrayStringExpr", Sequence[StringLike]]

--- a/edg/core/ArrayExpr.py
+++ b/edg/core/ArrayExpr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import Generic, Any, Type, Optional, Union, Iterable, Sequence, List
 
 from typing_extensions import TypeVar, override
@@ -104,29 +105,11 @@ class ArrayExpr(
         super().__init__(initializer)
         self._elt_sample: ArrayEltType = self._elt_type()._new_bind(SampleElementBinding())
 
-    def _create_unary_set_op(self, op: Union[NumericOp, BoolOp, RangeSetOp, EqOp]) -> ArrayEltType:
-        return self._elt_type._new_bind(UnarySetOpBinding(self, op))
-
     def all_unique(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_unique))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_unique, BoolExpr(True)))
 
     def all_equal(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_equal))
-
-    def sum(self) -> ArrayEltType:
-        return self._create_unary_set_op(NumericOp.sum)
-
-    def min(self) -> FloatExpr:
-        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.min))
-
-    def max(self) -> FloatExpr:
-        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.max))
-
-    def intersection(self) -> ArrayEltType:
-        return self._create_unary_set_op(RangeSetOp.intersection)
-
-    def hull(self) -> ArrayEltType:
-        return self._create_unary_set_op(RangeSetOp.hull)
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, EqOp.all_equal, BoolExpr(True)))
 
 
 ArrayBoolLike = Union["ArrayBoolExpr", Sequence[BoolLike]]
@@ -136,16 +119,16 @@ class ArrayBoolExpr(ArrayExpr[BoolExpr, List[bool], ArrayBoolLike]):
     _elt_type = BoolExpr
 
     def __invert__(self) -> ArrayBoolExpr:
-        return self._new_bind(UnarySetOpBinding(self, BoolOp.op_not))
+        return self._new_bind(UnarySetOpBinding(self, BoolOp.op_not, ArrayBoolExpr([])))
 
     def any(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_or))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_or, BoolExpr(False)))
 
     def all(self) -> BoolExpr:
-        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_and))
+        return BoolExpr()._new_bind(UnarySetOpBinding(self, BoolOp.op_and, BoolExpr(True)))
 
     def count(self) -> IntExpr:
-        return IntExpr()._new_bind(UnarySetOpBinding(self, NumericOp.sum))
+        return IntExpr()._new_bind(UnarySetOpBinding(self, NumericOp.sum, IntExpr(0)))
 
 
 ArrayIntLike = Union["ArrayIntExpr", Sequence[IntLike]]
@@ -154,12 +137,24 @@ ArrayIntLike = Union["ArrayIntExpr", Sequence[IntLike]]
 class ArrayIntExpr(ArrayExpr[IntExpr, List[int], ArrayIntLike]):
     _elt_type = IntExpr
 
+    def sum(self) -> IntExpr:
+        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, IntExpr(0)))
+
 
 ArrayFloatLike = Union["ArrayFloatExpr", Sequence[FloatLike]]
 
 
 class ArrayFloatExpr(ArrayExpr[FloatExpr, List[float], ArrayFloatLike]):
     _elt_type = FloatExpr
+
+    def sum(self) -> FloatExpr:
+        return self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.sum, FloatExpr(0)))
+
+    def min(self) -> FloatExpr:
+        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.min, FloatExpr(float("inf"))))
+
+    def max(self) -> FloatExpr:
+        return FloatExpr()._new_bind(UnarySetOpBinding(self, RangeSetOp.max, FloatExpr(float("-inf"))))
 
 
 ArrayRangeLike = Union["ArrayRangeExpr", Sequence[RangeLike]]
@@ -179,13 +174,21 @@ class ArrayRangeExpr(ArrayExpr[RangeExpr, List[Range], ArrayRangeLike]):
     def __rtruediv__(self, other: Union[FloatLike, RangeLike]) -> ArrayRangeExpr:
         """Broadcast-pointwise invert-and-multiply (division with array as rhs)"""
         return self._create_binary_set_op(
-            self._create_unary_set_op(NumericOp.invert), RangeExpr._to_expr_type(other), NumericOp.mul
+            self._elt_type._new_bind(UnarySetOpBinding(self, NumericOp.invert, ArrayRangeExpr([]))),
+            RangeExpr._to_expr_type(other),
+            NumericOp.mul,
         )
 
     def elts_equals(self, other: RangeLike) -> ArrayBoolExpr:
         """Returns an ArrayBoolExpr of equality between each element of this and single-element other.
         TODO: generalize to equality for other array types, needs some generic version of _to_expr_type"""
         return ArrayBoolExpr()._new_bind(BinarySetOpBinding(self, RangeExpr._to_expr_type(other), EqOp.all_equal))
+
+    def intersection(self) -> RangeExpr:
+        return self._elt_type._new_bind(UnarySetOpBinding(self, RangeSetOp.intersection, RangeExpr(RangeExpr.ALL)))
+
+    def hull(self) -> RangeExpr:
+        return self._elt_type._new_bind(UnarySetOpBinding(self, RangeSetOp.hull, RangeExpr(RangeExpr.EMPTY)))
 
 
 ArrayStringLike = Union["ArrayStringExpr", Sequence[StringLike]]

--- a/edg/core/Binding.py
+++ b/edg/core/Binding.py
@@ -307,7 +307,9 @@ class UnarySetOpBinding(Binding):
     def __repr__(self) -> str:
         return f"UnarySetOp({self.op}, ...)"
 
-    def __init__(self, src: ConstraintExpr, op: Union[NumericOp, BoolOp, EqOp, RangeSetOp]):
+    def __init__(
+        self, src: ConstraintExpr, op: Union[NumericOp, BoolOp, EqOp, RangeSetOp], empty_value: ConstraintExpr
+    ):
         self.op_map = {
             NumericOp.negate: edgir.UnarySetExpr.NEGATE,
             NumericOp.invert: edgir.UnarySetExpr.INVERT,
@@ -327,6 +329,7 @@ class UnarySetOpBinding(Binding):
         super().__init__()
         self.src = src
         self.op = op
+        self.empty_value = empty_value
 
     @override
     def get_subexprs(self) -> Iterable[Union[ConstraintExpr, BasePort]]:
@@ -336,6 +339,7 @@ class UnarySetOpBinding(Binding):
     def populate_expr_proto(self, pb: edgir.ValueExpr, expr: ConstraintExpr, ref_map: Refable.RefMapType) -> None:
         pb.unary_set.op = self.op_map[self.op]
         self.src._populate_expr_proto(pb.unary_set.vals, ref_map)
+        self.empty_value._populate_expr_proto(pb.unary_set.empty_value, ref_map)
 
 
 class BinaryOpBinding(Binding):

--- a/edg/core/CompiledDesignExport.py
+++ b/edg/core/CompiledDesignExport.py
@@ -2,7 +2,7 @@ from typing import Optional, Dict, List, Any, Union, Mapping
 from typing_extensions import override
 import re
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel
 
 from .. import edgir
 from .ConstraintExpr import RangeExpr
@@ -19,6 +19,7 @@ class CompiledParam(BaseModel):
     # this is minimalistic so the output json is more compact
     type: str
     value: Optional[Any] = None  # solved value, if available
+    error: Optional[str] = None  # if value is an error, the error message, otherwise None
     value_excluded: Optional[bool] = None  # true if value excluded, None otherwise to skip the field
     doc: Optional[str] = None  # doc specified by its parent block, if available
 
@@ -112,11 +113,13 @@ class CompiledDesignExportTransform(
             return value
 
     def _param_to_compiled(self, path: Path, elt: edgir.ValInit) -> CompiledParam:
-        if path.params[-1] in self._EXCLUDED_PARAM_VALUES:
+        value = self._design.get_value(path.to_local_path())
+        if isinstance(value, edgir.ErrorValue):
+            return CompiledParam(type=self._param_to_type(elt), error=value.msg)
+        elif path.params[-1] in self._EXCLUDED_PARAM_VALUES:
             return CompiledParam(type=self._param_to_type(elt), value_excluded=True)
         else:
-            value = self._param_value_to_json(self._design.get_value(path.to_local_path()))
-            return CompiledParam(type=self._param_to_type(elt), value=value)
+            return CompiledParam(type=self._param_to_type(elt), value=self._param_value_to_json(value))
 
     @override
     def transform_block(

--- a/edg/core/test_block_portvector.py
+++ b/edg/core/test_block_portvector.py
@@ -234,4 +234,5 @@ class VectorConstraintProtoTestCase(unittest.TestCase):
         expected_constr.assign.src.unary_set.op = edgir.UnarySetExpr.SUM
         expected_constr.assign.src.unary_set.vals.map_extract.container.ref.steps.add().name = "vector"
         expected_constr.assign.src.unary_set.vals.map_extract.path.steps.add().name = "float_param"
+        expected_constr.assign.src.unary_set.empty_value.literal.floating.val = 0
         self.assertIn(expected_constr, constraints)

--- a/edg/core/test_compiled_design_export.py
+++ b/edg/core/test_compiled_design_export.py
@@ -32,3 +32,11 @@ class CompiledDesignExportTestCase(unittest.TestCase):
         result = CompiledDesignExportTransform(compiled).transform()
         self.assertEqual(result.links["link"].params["range_sum"].value, (6.0, 130.0))
         self.assertEqual(result.links["link"].params["range_intersection"].value, (5.0, 10.0))
+
+    def test_param_error(self) -> None:
+        from .test_simple_expr_eval import TestEvalExprErrorBlock
+
+        compiled = ScalaCompiler.compile(TestEvalExprErrorBlock, ignore_errors=True)
+        result = CompiledDesignExportTransform(compiled).transform()
+        self.assertIn("overassign", result.params["overassign_float"].error)
+        self.assertEqual(result.params["overassign_float"].value, None)

--- a/edg/core/test_compiled_design_export.py
+++ b/edg/core/test_compiled_design_export.py
@@ -38,5 +38,5 @@ class CompiledDesignExportTestCase(unittest.TestCase):
 
         compiled = ScalaCompiler.compile(TestEvalExprErrorBlock, ignore_errors=True)
         result = CompiledDesignExportTransform(compiled).transform()
-        self.assertIn("overassign", result.params["overassign_float"].error)
+        self.assertIn("overassign", cast(str, result.params["overassign_float"].error))
         self.assertEqual(result.params["overassign_float"].value, None)

--- a/edg/core/test_link.py
+++ b/edg/core/test_link.py
@@ -50,10 +50,12 @@ class LinkTestCase(unittest.TestCase):
         expected_constr.assign.src.binary.lhs.unary_set.op = edgir.UnarySetExpr.MINIMUM
         expected_constr.assign.src.binary.lhs.unary_set.vals.map_extract.container.ref.steps.add().name = "sinks"
         expected_constr.assign.src.binary.lhs.unary_set.vals.map_extract.path.steps.add().name = "float_param"
+        expected_constr.assign.src.binary.lhs.unary_set.empty_value.literal.floating.val = float("inf")
 
         expected_constr.assign.src.binary.rhs.unary_set.op = edgir.UnarySetExpr.MAXIMUM
         expected_constr.assign.src.binary.rhs.unary_set.vals.map_extract.container.ref.steps.add().name = "sinks"
         expected_constr.assign.src.binary.rhs.unary_set.vals.map_extract.path.steps.add().name = "float_param"
+        expected_constr.assign.src.binary.rhs.unary_set.empty_value.literal.floating.val = float("-inf")
         self.assertIn(expected_constr, constraints)
 
         expected_constr = edgir.ValueExpr()
@@ -69,6 +71,8 @@ class LinkTestCase(unittest.TestCase):
         expected_constr.assign.src.unary_set.op = edgir.UnarySetExpr.INTERSECTION
         expected_constr.assign.src.unary_set.vals.map_extract.container.ref.steps.add().name = "sinks"
         expected_constr.assign.src.unary_set.vals.map_extract.path.steps.add().name = "range_limit"
+        expected_constr.assign.src.unary_set.empty_value.literal.range.minimum.floating.val = float("-inf")
+        expected_constr.assign.src.unary_set.empty_value.literal.range.maximum.floating.val = float("inf")
         self.assertIn(expected_constr, constraints)
 
         expected_constr = edgir.ValueExpr()

--- a/edg/core/test_simple_expr_eval.py
+++ b/edg/core/test_simple_expr_eval.py
@@ -28,6 +28,27 @@ class EvalExprTestCase(unittest.TestCase):
         self.assertEqual(self.compiled.get_value(["sum_range"]), Range(9.0, 14.0))
 
 
+class TestEvalExprErrorBlock(Block):
+    def __init__(self) -> None:
+        super().__init__()
+        self.overassign_float = self.Parameter(FloatExpr())
+
+    @override
+    def contents(self) -> None:
+        self.assign(self.overassign_float, 1.0)
+        self.assign(self.overassign_float, 2.0)
+
+
+class EvalExprErrorTestCase(unittest.TestCase):
+    @override
+    def setUp(self) -> None:
+        self.compiled = ScalaCompiler.compile(TestEvalExprErrorBlock, ignore_errors=True)
+
+    def test_sum(self) -> None:
+        self.assertEqual(len(self.compiled.errors), 1)
+        self.assertIsInstance(self.compiled.get_value(["overassign_float"]), edgir.ErrorValue)
+
+
 class TestReductionLink(Link):
     def __init__(self) -> None:
         super().__init__()

--- a/edg/edgir/__init__.py
+++ b/edg/edgir/__init__.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, Iterable, TYPE_CHECKING, List, cast, overload
+from typing import Union, Optional, Iterable, TYPE_CHECKING, List, cast, overload, NamedTuple
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 
@@ -74,7 +74,11 @@ def resolve_portlike(port: PortLike) -> PortTypes:
         raise ValueError(f"bad portlike {port}")
 
 
-LitLeafTypes = Union[bool, float, "Range", str]  # TODO for Range: fix me, this prevents a circular import
+class ErrorValue(NamedTuple):
+    msg: str
+
+
+LitLeafTypes = Union[bool, float, "Range", str, ErrorValue]  # TODO for Range: fix me, this prevents a circular import
 LitTypes = Union[LitLeafTypes, List[LitLeafTypes]]
 
 
@@ -97,6 +101,8 @@ def valuelit_to_lit(expr: ValueLit) -> LitTypes:
             raise ValueError(f"bad valuelit array {expr}")
         else:
             return cast(List[LitLeafTypes], elts)
+    elif expr.HasField("error"):
+        return ErrorValue(expr.error.message)
     else:
         raise ValueError(f"bad valuelit {expr}")
 

--- a/edg/edgir/__init__.py
+++ b/edg/edgir/__init__.py
@@ -126,6 +126,8 @@ def lit_to_valuelit(value: LitTypes) -> ValueLit:
         pb.array.SetInParent()
         for elt in value:
             pb.array.elts.add().CopyFrom(lit_to_valuelit(elt))
+    elif isinstance(value, ErrorValue):
+        pb.error.message = value.msg
     else:
         raise ValueError(f"unknown lit {value}")
     return pb

--- a/edg/edgir/expr_pb2.py
+++ b/edg/edgir/expr_pb2.py
@@ -11,7 +11,7 @@ from ..edgir import common_pb2 as edgir_dot_common__pb2
 from ..edgir import lit_pb2 as edgir_dot_lit__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x10edgir/expr.proto\x12\nedgir.expr\x1a\x0fedgir/ref.proto\x1a\x12edgir/common.proto\x1a\x0fedgir/lit.proto"\xb4\x01\n\tUnaryExpr\x12$\n\x02op\x18\x01 \x01(\x0e2\x18.edgir.expr.UnaryExpr.Op\x12"\n\x03val\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"]\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\n\n\x06NEGATE\x10\x01\x12\x07\n\x03NOT\x10\x02\x12\n\n\x06INVERT\x10\x03\x12\x07\n\x03MIN\x10\x04\x12\x07\n\x03MAX\x10\x05\x12\n\n\x06CENTER\x10\x06\x12\t\n\x05WIDTH\x10\x07"\x9f\x02\n\x0cUnarySetExpr\x12\'\n\x02op\x18\x01 \x01(\x0e2\x1b.edgir.expr.UnarySetExpr.Op\x12#\n\x04vals\x18\x04 \x01(\x0b2\x15.edgir.expr.ValueExpr"\xc0\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03SUM\x10\x01\x12\x0c\n\x08ALL_TRUE\x10\x02\x12\x0c\n\x08ANY_TRUE\x10\x03\x12\n\n\x06ALL_EQ\x10\x04\x12\x0e\n\nALL_UNIQUE\x10\x05\x12\x0b\n\x07MAXIMUM\x10\n\x12\x0b\n\x07MINIMUM\x10\x0b\x12\x0f\n\x0bSET_EXTRACT\x10\x0c\x12\x10\n\x0cINTERSECTION\x10\r\x12\x08\n\x04HULL\x10\x0e\x12\n\n\x06NEGATE\x10\x14\x12\n\n\x06INVERT\x10\x15\x12\x0b\n\x07FLATTEN\x10\x1e"\xd4\x02\n\nBinaryExpr\x12%\n\x02op\x18\x01 \x01(\x0e2\x19.edgir.expr.BinaryExpr.Op\x12"\n\x03lhs\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03rhs\x18\x03 \x01(\x0b2\x15.edgir.expr.ValueExpr"\xd6\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03ADD\x10\n\x12\x08\n\x04MULT\x10\x0c\x12\x0f\n\x0bSHRINK_MULT\x107\x12\x07\n\x03AND\x10\x14\x12\x06\n\x02OR\x10\x15\x12\x07\n\x03XOR\x10\x16\x12\x0b\n\x07IMPLIES\x10\x17\x12\x06\n\x02EQ\x10\x1e\x12\x07\n\x03NEQ\x10\x1f\x12\x06\n\x02GT\x10(\x12\x07\n\x03GTE\x10)\x12\x06\n\x02LT\x10*\x12\x07\n\x03LTE\x10,\x12\x07\n\x03MAX\x10-\x12\x07\n\x03MIN\x10.\x12\x10\n\x0cINTERSECTION\x103\x12\x08\n\x04HULL\x106\x12\n\n\x06WITHIN\x105\x12\t\n\x05RANGE\x10\x01"\xbf\x01\n\rBinarySetExpr\x12(\n\x02op\x18\x01 \x01(\x0e2\x1c.edgir.expr.BinarySetExpr.Op\x12$\n\x05lhset\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03rhs\x18\x03 \x01(\x0b2\x15.edgir.expr.ValueExpr":\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03ADD\x10\n\x12\x08\n\x04MULT\x10\x0c\x12\n\n\x06CONCAT\x10\x14\x12\x06\n\x02EQ\x10\x1e"0\n\tArrayExpr\x12#\n\x04vals\x18\x01 \x03(\x0b2\x15.edgir.expr.ValueExpr"[\n\tRangeExpr\x12&\n\x07minimum\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12&\n\x07maximum\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"\x80\x01\n\nStructExpr\x12.\n\x04vals\x18\x01 \x03(\x0b2 .edgir.expr.StructExpr.ValsEntry\x1aB\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr:\x028\x01"\xa3\x01\n\x0eIfThenElseExpr\x12#\n\x04cond\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03tru\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03fal\x18\x03 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12$\n\x04meta\x18\x7f \x01(\x0b2\x16.edgir.common.Metadata"]\n\x0bExtractExpr\x12(\n\tcontainer\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12$\n\x05index\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"^\n\x0eMapExtractExpr\x12(\n\tcontainer\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x04path\x18\x02 \x01(\x0b2\x14.edgir.ref.LocalPath"\x91\x01\n\rConnectedExpr\x12)\n\nblock_port\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12(\n\tlink_port\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12+\n\x08expanded\x18\x03 \x03(\x0b2\x19.edgir.expr.ConnectedExpr"\x9c\x01\n\x0cExportedExpr\x12,\n\rexterior_port\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x122\n\x13internal_block_port\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12*\n\x08expanded\x18\x03 \x03(\x0b2\x18.edgir.expr.ExportedExpr"S\n\nAssignExpr\x12!\n\x03dst\x18\x01 \x01(\x0b2\x14.edgir.ref.LocalPath\x12"\n\x03src\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"\x97\x07\n\tValueExpr\x12&\n\x07literal\x18\x01 \x01(\x0b2\x13.edgir.lit.ValueLitH\x00\x12(\n\x06binary\x18\x02 \x01(\x0b2\x16.edgir.expr.BinaryExprH\x00\x12/\n\nbinary_set\x18\x12 \x01(\x0b2\x19.edgir.expr.BinarySetExprH\x00\x12&\n\x05unary\x18\x03 \x01(\x0b2\x15.edgir.expr.UnaryExprH\x00\x12-\n\tunary_set\x18\x04 \x01(\x0b2\x18.edgir.expr.UnarySetExprH\x00\x12&\n\x05array\x18\x06 \x01(\x0b2\x15.edgir.expr.ArrayExprH\x00\x12(\n\x06struct\x18\x07 \x01(\x0b2\x16.edgir.expr.StructExprH\x00\x12&\n\x05range\x18\x08 \x01(\x0b2\x15.edgir.expr.RangeExprH\x00\x120\n\nifThenElse\x18\n \x01(\x0b2\x1a.edgir.expr.IfThenElseExprH\x00\x12*\n\x07extract\x18\x0c \x01(\x0b2\x17.edgir.expr.ExtractExprH\x00\x121\n\x0bmap_extract\x18\x0e \x01(\x0b2\x1a.edgir.expr.MapExtractExprH\x00\x12.\n\tconnected\x18\x0f \x01(\x0b2\x19.edgir.expr.ConnectedExprH\x00\x12,\n\x08exported\x18\x10 \x01(\x0b2\x18.edgir.expr.ExportedExprH\x00\x123\n\x0econnectedArray\x18\x13 \x01(\x0b2\x19.edgir.expr.ConnectedExprH\x00\x121\n\rexportedArray\x18\x14 \x01(\x0b2\x18.edgir.expr.ExportedExprH\x00\x12(\n\x06assign\x18\x11 \x01(\x0b2\x16.edgir.expr.AssignExprH\x00\x122\n\x0eexportedTunnel\x18\x15 \x01(\x0b2\x18.edgir.expr.ExportedExprH\x00\x12.\n\x0cassignTunnel\x18\x16 \x01(\x0b2\x16.edgir.expr.AssignExprH\x00\x12#\n\x03ref\x18c \x01(\x0b2\x14.edgir.ref.LocalPathH\x00\x12$\n\x04meta\x18\x7f \x01(\x0b2\x16.edgir.common.MetadataB\x06\n\x04exprb\x06proto3'
+    b'\n\x10edgir/expr.proto\x12\nedgir.expr\x1a\x0fedgir/ref.proto\x1a\x12edgir/common.proto\x1a\x0fedgir/lit.proto"\xb4\x01\n\tUnaryExpr\x12$\n\x02op\x18\x01 \x01(\x0e2\x18.edgir.expr.UnaryExpr.Op\x12"\n\x03val\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"]\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\n\n\x06NEGATE\x10\x01\x12\x07\n\x03NOT\x10\x02\x12\n\n\x06INVERT\x10\x03\x12\x07\n\x03MIN\x10\x04\x12\x07\n\x03MAX\x10\x05\x12\n\n\x06CENTER\x10\x06\x12\t\n\x05WIDTH\x10\x07"\xcb\x02\n\x0cUnarySetExpr\x12\'\n\x02op\x18\x01 \x01(\x0e2\x1b.edgir.expr.UnarySetExpr.Op\x12#\n\x04vals\x18\x04 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12*\n\x0bempty_value\x18\x05 \x01(\x0b2\x15.edgir.expr.ValueExpr"\xc0\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03SUM\x10\x01\x12\x0c\n\x08ALL_TRUE\x10\x02\x12\x0c\n\x08ANY_TRUE\x10\x03\x12\n\n\x06ALL_EQ\x10\x04\x12\x0e\n\nALL_UNIQUE\x10\x05\x12\x0b\n\x07MAXIMUM\x10\n\x12\x0b\n\x07MINIMUM\x10\x0b\x12\x0f\n\x0bSET_EXTRACT\x10\x0c\x12\x10\n\x0cINTERSECTION\x10\r\x12\x08\n\x04HULL\x10\x0e\x12\n\n\x06NEGATE\x10\x14\x12\n\n\x06INVERT\x10\x15\x12\x0b\n\x07FLATTEN\x10\x1e"\xd4\x02\n\nBinaryExpr\x12%\n\x02op\x18\x01 \x01(\x0e2\x19.edgir.expr.BinaryExpr.Op\x12"\n\x03lhs\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03rhs\x18\x03 \x01(\x0b2\x15.edgir.expr.ValueExpr"\xd6\x01\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03ADD\x10\n\x12\x08\n\x04MULT\x10\x0c\x12\x0f\n\x0bSHRINK_MULT\x107\x12\x07\n\x03AND\x10\x14\x12\x06\n\x02OR\x10\x15\x12\x07\n\x03XOR\x10\x16\x12\x0b\n\x07IMPLIES\x10\x17\x12\x06\n\x02EQ\x10\x1e\x12\x07\n\x03NEQ\x10\x1f\x12\x06\n\x02GT\x10(\x12\x07\n\x03GTE\x10)\x12\x06\n\x02LT\x10*\x12\x07\n\x03LTE\x10,\x12\x07\n\x03MAX\x10-\x12\x07\n\x03MIN\x10.\x12\x10\n\x0cINTERSECTION\x103\x12\x08\n\x04HULL\x106\x12\n\n\x06WITHIN\x105\x12\t\n\x05RANGE\x10\x01"\xbf\x01\n\rBinarySetExpr\x12(\n\x02op\x18\x01 \x01(\x0e2\x1c.edgir.expr.BinarySetExpr.Op\x12$\n\x05lhset\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03rhs\x18\x03 \x01(\x0b2\x15.edgir.expr.ValueExpr":\n\x02Op\x12\r\n\tUNDEFINED\x10\x00\x12\x07\n\x03ADD\x10\n\x12\x08\n\x04MULT\x10\x0c\x12\n\n\x06CONCAT\x10\x14\x12\x06\n\x02EQ\x10\x1e"0\n\tArrayExpr\x12#\n\x04vals\x18\x01 \x03(\x0b2\x15.edgir.expr.ValueExpr"[\n\tRangeExpr\x12&\n\x07minimum\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12&\n\x07maximum\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"\x80\x01\n\nStructExpr\x12.\n\x04vals\x18\x01 \x03(\x0b2 .edgir.expr.StructExpr.ValsEntry\x1aB\n\tValsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05value\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr:\x028\x01"\xa3\x01\n\x0eIfThenElseExpr\x12#\n\x04cond\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03tru\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x03fal\x18\x03 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12$\n\x04meta\x18\x7f \x01(\x0b2\x16.edgir.common.Metadata"]\n\x0bExtractExpr\x12(\n\tcontainer\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12$\n\x05index\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"^\n\x0eMapExtractExpr\x12(\n\tcontainer\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12"\n\x04path\x18\x02 \x01(\x0b2\x14.edgir.ref.LocalPath"\x91\x01\n\rConnectedExpr\x12)\n\nblock_port\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12(\n\tlink_port\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12+\n\x08expanded\x18\x03 \x03(\x0b2\x19.edgir.expr.ConnectedExpr"\x9c\x01\n\x0cExportedExpr\x12,\n\rexterior_port\x18\x01 \x01(\x0b2\x15.edgir.expr.ValueExpr\x122\n\x13internal_block_port\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr\x12*\n\x08expanded\x18\x03 \x03(\x0b2\x18.edgir.expr.ExportedExpr"S\n\nAssignExpr\x12!\n\x03dst\x18\x01 \x01(\x0b2\x14.edgir.ref.LocalPath\x12"\n\x03src\x18\x02 \x01(\x0b2\x15.edgir.expr.ValueExpr"\x97\x07\n\tValueExpr\x12&\n\x07literal\x18\x01 \x01(\x0b2\x13.edgir.lit.ValueLitH\x00\x12(\n\x06binary\x18\x02 \x01(\x0b2\x16.edgir.expr.BinaryExprH\x00\x12/\n\nbinary_set\x18\x12 \x01(\x0b2\x19.edgir.expr.BinarySetExprH\x00\x12&\n\x05unary\x18\x03 \x01(\x0b2\x15.edgir.expr.UnaryExprH\x00\x12-\n\tunary_set\x18\x04 \x01(\x0b2\x18.edgir.expr.UnarySetExprH\x00\x12&\n\x05array\x18\x06 \x01(\x0b2\x15.edgir.expr.ArrayExprH\x00\x12(\n\x06struct\x18\x07 \x01(\x0b2\x16.edgir.expr.StructExprH\x00\x12&\n\x05range\x18\x08 \x01(\x0b2\x15.edgir.expr.RangeExprH\x00\x120\n\nifThenElse\x18\n \x01(\x0b2\x1a.edgir.expr.IfThenElseExprH\x00\x12*\n\x07extract\x18\x0c \x01(\x0b2\x17.edgir.expr.ExtractExprH\x00\x121\n\x0bmap_extract\x18\x0e \x01(\x0b2\x1a.edgir.expr.MapExtractExprH\x00\x12.\n\tconnected\x18\x0f \x01(\x0b2\x19.edgir.expr.ConnectedExprH\x00\x12,\n\x08exported\x18\x10 \x01(\x0b2\x18.edgir.expr.ExportedExprH\x00\x123\n\x0econnectedArray\x18\x13 \x01(\x0b2\x19.edgir.expr.ConnectedExprH\x00\x121\n\rexportedArray\x18\x14 \x01(\x0b2\x18.edgir.expr.ExportedExprH\x00\x12(\n\x06assign\x18\x11 \x01(\x0b2\x16.edgir.expr.AssignExprH\x00\x122\n\x0eexportedTunnel\x18\x15 \x01(\x0b2\x18.edgir.expr.ExportedExprH\x00\x12.\n\x0cassignTunnel\x18\x16 \x01(\x0b2\x16.edgir.expr.AssignExprH\x00\x12#\n\x03ref\x18c \x01(\x0b2\x14.edgir.ref.LocalPathH\x00\x12$\n\x04meta\x18\x7f \x01(\x0b2\x16.edgir.common.MetadataB\x06\n\x04exprb\x06proto3'
 )
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "edgir.expr_pb2", globals())
@@ -24,36 +24,36 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _UNARYEXPR_OP._serialized_start = 174
     _UNARYEXPR_OP._serialized_end = 267
     _UNARYSETEXPR._serialized_start = 270
-    _UNARYSETEXPR._serialized_end = 557
-    _UNARYSETEXPR_OP._serialized_start = 365
-    _UNARYSETEXPR_OP._serialized_end = 557
-    _BINARYEXPR._serialized_start = 560
-    _BINARYEXPR._serialized_end = 900
-    _BINARYEXPR_OP._serialized_start = 686
-    _BINARYEXPR_OP._serialized_end = 900
-    _BINARYSETEXPR._serialized_start = 903
-    _BINARYSETEXPR._serialized_end = 1094
-    _BINARYSETEXPR_OP._serialized_start = 1036
-    _BINARYSETEXPR_OP._serialized_end = 1094
-    _ARRAYEXPR._serialized_start = 1096
-    _ARRAYEXPR._serialized_end = 1144
-    _RANGEEXPR._serialized_start = 1146
-    _RANGEEXPR._serialized_end = 1237
-    _STRUCTEXPR._serialized_start = 1240
-    _STRUCTEXPR._serialized_end = 1368
-    _STRUCTEXPR_VALSENTRY._serialized_start = 1302
-    _STRUCTEXPR_VALSENTRY._serialized_end = 1368
-    _IFTHENELSEEXPR._serialized_start = 1371
-    _IFTHENELSEEXPR._serialized_end = 1534
-    _EXTRACTEXPR._serialized_start = 1536
-    _EXTRACTEXPR._serialized_end = 1629
-    _MAPEXTRACTEXPR._serialized_start = 1631
-    _MAPEXTRACTEXPR._serialized_end = 1725
-    _CONNECTEDEXPR._serialized_start = 1728
-    _CONNECTEDEXPR._serialized_end = 1873
-    _EXPORTEDEXPR._serialized_start = 1876
-    _EXPORTEDEXPR._serialized_end = 2032
-    _ASSIGNEXPR._serialized_start = 2034
-    _ASSIGNEXPR._serialized_end = 2117
-    _VALUEEXPR._serialized_start = 2120
-    _VALUEEXPR._serialized_end = 3039
+    _UNARYSETEXPR._serialized_end = 601
+    _UNARYSETEXPR_OP._serialized_start = 409
+    _UNARYSETEXPR_OP._serialized_end = 601
+    _BINARYEXPR._serialized_start = 604
+    _BINARYEXPR._serialized_end = 944
+    _BINARYEXPR_OP._serialized_start = 730
+    _BINARYEXPR_OP._serialized_end = 944
+    _BINARYSETEXPR._serialized_start = 947
+    _BINARYSETEXPR._serialized_end = 1138
+    _BINARYSETEXPR_OP._serialized_start = 1080
+    _BINARYSETEXPR_OP._serialized_end = 1138
+    _ARRAYEXPR._serialized_start = 1140
+    _ARRAYEXPR._serialized_end = 1188
+    _RANGEEXPR._serialized_start = 1190
+    _RANGEEXPR._serialized_end = 1281
+    _STRUCTEXPR._serialized_start = 1284
+    _STRUCTEXPR._serialized_end = 1412
+    _STRUCTEXPR_VALSENTRY._serialized_start = 1346
+    _STRUCTEXPR_VALSENTRY._serialized_end = 1412
+    _IFTHENELSEEXPR._serialized_start = 1415
+    _IFTHENELSEEXPR._serialized_end = 1578
+    _EXTRACTEXPR._serialized_start = 1580
+    _EXTRACTEXPR._serialized_end = 1673
+    _MAPEXTRACTEXPR._serialized_start = 1675
+    _MAPEXTRACTEXPR._serialized_end = 1769
+    _CONNECTEDEXPR._serialized_start = 1772
+    _CONNECTEDEXPR._serialized_end = 1917
+    _EXPORTEDEXPR._serialized_start = 1920
+    _EXPORTEDEXPR._serialized_end = 2076
+    _ASSIGNEXPR._serialized_start = 2078
+    _ASSIGNEXPR._serialized_end = 2161
+    _VALUEEXPR._serialized_start = 2164
+    _VALUEEXPR._serialized_end = 3083

--- a/edg/edgir/expr_pb2.pyi
+++ b/edg/edgir/expr_pb2.pyi
@@ -170,17 +170,26 @@ class UnarySetExpr(_message.Message):
     "Flatten[A] : Set[Set[A]] -> Set[A]\n    Given an array of array of elements, flattens the inner array.\n    Alternatively stated, concatenates all of the elements of the outer arrary\n    "
     OP_FIELD_NUMBER: _builtins.int
     VALS_FIELD_NUMBER: _builtins.int
+    EMPTY_VALUE_FIELD_NUMBER: _builtins.int
     op: Global___UnarySetExpr.Op.ValueType
 
     @_builtins.property
     def vals(self) -> Global___ValueExpr: ...
+    @_builtins.property
+    def empty_value(self) -> Global___ValueExpr:
+        """value returned on an empty set, especially for reductions"""
+
     def __init__(
-        self, *, op: Global___UnarySetExpr.Op.ValueType = ..., vals: Global___ValueExpr | None = ...
+        self,
+        *,
+        op: Global___UnarySetExpr.Op.ValueType = ...,
+        vals: Global___ValueExpr | None = ...,
+        empty_value: Global___ValueExpr | None = ...,
     ) -> None: ...
-    _HasFieldArgType: _TypeAlias = _typing.Literal["vals", b"vals"]
+    _HasFieldArgType: _TypeAlias = _typing.Literal["empty_value", b"empty_value", "vals", b"vals"]
 
     def HasField(self, field_name: _HasFieldArgType) -> _builtins.bool: ...
-    _ClearFieldArgType: _TypeAlias = _typing.Literal["op", b"op", "vals", b"vals"]
+    _ClearFieldArgType: _TypeAlias = _typing.Literal["empty_value", b"empty_value", "op", b"op", "vals", b"vals"]
 
     def ClearField(self, field_name: _ClearFieldArgType) -> None: ...
 

--- a/edg/edgir/lit_pb2.py
+++ b/edg/edgir/lit_pb2.py
@@ -9,7 +9,7 @@ _sym_db = _symbol_database.Default()
 from ..edgir import common_pb2 as edgir_dot_common__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0fedgir/lit.proto\x12\tedgir.lit\x1a\x12edgir/common.proto"\x17\n\x08FloatLit\x12\x0b\n\x03val\x18\x01 \x01(\x01"\x15\n\x06IntLit\x12\x0b\n\x03val\x18\x01 \x01(\x12"\x16\n\x07BoolLit\x12\x0b\n\x03val\x18\x01 \x01(\x08"\x16\n\x07TextLit\x12\x0b\n\x03val\x18\x01 \x01(\t"V\n\x08RangeLit\x12$\n\x07minimum\x18\x01 \x01(\x0b2\x13.edgir.lit.ValueLit\x12$\n\x07maximum\x18\x02 \x01(\x0b2\x13.edgir.lit.ValueLit"\x84\x01\n\tStructLit\x122\n\x07members\x18\x01 \x03(\x0b2!.edgir.lit.StructLit.MembersEntry\x1aC\n\x0cMembersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12"\n\x05value\x18\x02 \x01(\x0b2\x13.edgir.lit.ValueLit:\x028\x01"-\n\x08ArrayLit\x12!\n\x04elts\x18\x01 \x03(\x0b2\x13.edgir.lit.ValueLit"\xc6\x02\n\x08ValueLit\x12\'\n\x08floating\x18\x01 \x01(\x0b2\x13.edgir.lit.FloatLitH\x00\x12$\n\x07integer\x18\x02 \x01(\x0b2\x11.edgir.lit.IntLitH\x00\x12%\n\x07boolean\x18\x03 \x01(\x0b2\x12.edgir.lit.BoolLitH\x00\x12"\n\x04text\x18\x04 \x01(\x0b2\x12.edgir.lit.TextLitH\x00\x12&\n\x06struct\x18\t \x01(\x0b2\x14.edgir.lit.StructLitH\x00\x12$\n\x05range\x18\n \x01(\x0b2\x13.edgir.lit.RangeLitH\x00\x12$\n\x05array\x18\x0b \x01(\x0b2\x13.edgir.lit.ArrayLitH\x00\x12$\n\x04meta\x18\x7f \x01(\x0b2\x16.edgir.common.MetadataB\x06\n\x04typeb\x06proto3'
+    b'\n\x0fedgir/lit.proto\x12\tedgir.lit\x1a\x12edgir/common.proto"\x17\n\x08FloatLit\x12\x0b\n\x03val\x18\x01 \x01(\x01"\x15\n\x06IntLit\x12\x0b\n\x03val\x18\x01 \x01(\x12"\x16\n\x07BoolLit\x12\x0b\n\x03val\x18\x01 \x01(\x08"\x16\n\x07TextLit\x12\x0b\n\x03val\x18\x01 \x01(\t"V\n\x08RangeLit\x12$\n\x07minimum\x18\x01 \x01(\x0b2\x13.edgir.lit.ValueLit\x12$\n\x07maximum\x18\x02 \x01(\x0b2\x13.edgir.lit.ValueLit"\x84\x01\n\tStructLit\x122\n\x07members\x18\x01 \x03(\x0b2!.edgir.lit.StructLit.MembersEntry\x1aC\n\x0cMembersEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12"\n\x05value\x18\x02 \x01(\x0b2\x13.edgir.lit.ValueLit:\x028\x01"-\n\x08ArrayLit\x12!\n\x04elts\x18\x01 \x03(\x0b2\x13.edgir.lit.ValueLit"\x1b\n\x08ErrorLit\x12\x0f\n\x07message\x18\x01 \x01(\t"\xec\x02\n\x08ValueLit\x12\'\n\x08floating\x18\x01 \x01(\x0b2\x13.edgir.lit.FloatLitH\x00\x12$\n\x07integer\x18\x02 \x01(\x0b2\x11.edgir.lit.IntLitH\x00\x12%\n\x07boolean\x18\x03 \x01(\x0b2\x12.edgir.lit.BoolLitH\x00\x12"\n\x04text\x18\x04 \x01(\x0b2\x12.edgir.lit.TextLitH\x00\x12&\n\x06struct\x18\t \x01(\x0b2\x14.edgir.lit.StructLitH\x00\x12$\n\x05range\x18\n \x01(\x0b2\x13.edgir.lit.RangeLitH\x00\x12$\n\x05array\x18\x0b \x01(\x0b2\x13.edgir.lit.ArrayLitH\x00\x12$\n\x05error\x18c \x01(\x0b2\x13.edgir.lit.ErrorLitH\x00\x12$\n\x04meta\x18\x7f \x01(\x0b2\x16.edgir.common.MetadataB\x06\n\x04typeb\x06proto3'
 )
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "edgir.lit_pb2", globals())
@@ -33,5 +33,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _STRUCTLIT_MEMBERSENTRY._serialized_end = 367
     _ARRAYLIT._serialized_start = 369
     _ARRAYLIT._serialized_end = 414
-    _VALUELIT._serialized_start = 417
-    _VALUELIT._serialized_end = 743
+    _ERRORLIT._serialized_start = 416
+    _ERRORLIT._serialized_end = 443
+    _VALUELIT._serialized_start = 446
+    _VALUELIT._serialized_end = 810

--- a/edg/edgir/lit_pb2.pyi
+++ b/edg/edgir/lit_pb2.pyi
@@ -146,6 +146,19 @@ class ArrayLit(_message.Message):
 Global___ArrayLit: _TypeAlias = ArrayLit
 
 @_typing.final
+class ErrorLit(_message.Message):
+    DESCRIPTOR: _descriptor.Descriptor
+    MESSAGE_FIELD_NUMBER: _builtins.int
+    message: _builtins.str
+
+    def __init__(self, *, message: _builtins.str = ...) -> None: ...
+    _ClearFieldArgType: _TypeAlias = _typing.Literal["message", b"message"]
+
+    def ClearField(self, field_name: _ClearFieldArgType) -> None: ...
+
+Global___ErrorLit: _TypeAlias = ErrorLit
+
+@_typing.final
 class ValueLit(_message.Message):
     DESCRIPTOR: _descriptor.Descriptor
     FLOATING_FIELD_NUMBER: _builtins.int
@@ -155,6 +168,7 @@ class ValueLit(_message.Message):
     STRUCT_FIELD_NUMBER: _builtins.int
     RANGE_FIELD_NUMBER: _builtins.int
     ARRAY_FIELD_NUMBER: _builtins.int
+    ERROR_FIELD_NUMBER: _builtins.int
     META_FIELD_NUMBER: _builtins.int
 
     @_builtins.property
@@ -172,6 +186,10 @@ class ValueLit(_message.Message):
     @_builtins.property
     def array(self) -> Global___ArrayLit: ...
     @_builtins.property
+    def error(self) -> Global___ErrorLit:
+        """propagating error, either created by the user or the compiler"""
+
+    @_builtins.property
     def meta(self) -> _common_pb2.Metadata: ...
     def __init__(
         self,
@@ -183,6 +201,7 @@ class ValueLit(_message.Message):
         struct: Global___StructLit | None = ...,
         range: Global___RangeLit | None = ...,
         array: Global___ArrayLit | None = ...,
+        error: Global___ErrorLit | None = ...,
         meta: _common_pb2.Metadata | None = ...,
     ) -> None: ...
     _HasFieldArgType: _TypeAlias = _typing.Literal[
@@ -190,6 +209,8 @@ class ValueLit(_message.Message):
         b"array",
         "boolean",
         b"boolean",
+        "error",
+        b"error",
         "floating",
         b"floating",
         "integer",
@@ -212,6 +233,8 @@ class ValueLit(_message.Message):
         b"array",
         "boolean",
         b"boolean",
+        "error",
+        b"error",
         "floating",
         b"floating",
         "integer",
@@ -230,7 +253,7 @@ class ValueLit(_message.Message):
 
     def ClearField(self, field_name: _ClearFieldArgType) -> None: ...
     _WhichOneofReturnType_type: _TypeAlias = _typing.Literal[
-        "floating", "integer", "boolean", "text", "struct", "range", "array"
+        "floating", "integer", "boolean", "text", "struct", "range", "array", "error"
     ]
     _WhichOneofArgType_type: _TypeAlias = _typing.Literal["type", b"type"]
 

--- a/edg/edgir/lit_pb2.pyi
+++ b/edg/edgir/lit_pb2.pyi
@@ -150,6 +150,7 @@ class ErrorLit(_message.Message):
     DESCRIPTOR: _descriptor.Descriptor
     MESSAGE_FIELD_NUMBER: _builtins.int
     message: _builtins.str
+    "considered propagated if empty"
 
     def __init__(self, *, message: _builtins.str = ...) -> None: ...
     _ClearFieldArgType: _TypeAlias = _typing.Literal["message", b"message"]

--- a/edg/edgir/lit_pb2.pyi
+++ b/edg/edgir/lit_pb2.pyi
@@ -150,7 +150,7 @@ class ErrorLit(_message.Message):
     DESCRIPTOR: _descriptor.Descriptor
     MESSAGE_FIELD_NUMBER: _builtins.int
     message: _builtins.str
-    "considered propagated if empty"
+    "if errors propagate, empty means this was propagated to avoid error spam"
 
     def __init__(self, *, message: _builtins.str = ...) -> None: ...
     _ClearFieldArgType: _TypeAlias = _typing.Literal["message", b"message"]
@@ -188,7 +188,7 @@ class ValueLit(_message.Message):
     def array(self) -> Global___ArrayLit: ...
     @_builtins.property
     def error(self) -> Global___ErrorLit:
-        """propagating error, either created by the user or the compiler"""
+        """may either propagate or be treated as unsolved"""
 
     @_builtins.property
     def meta(self) -> _common_pb2.Metadata: ...

--- a/edg/hdl_server/__main__.py
+++ b/edg/hdl_server/__main__.py
@@ -9,7 +9,7 @@ from .. import edgrpc
 from ..core import *
 from ..core.Core import NonLibraryProperty
 
-EDG_PROTO_VERSION = 10
+EDG_PROTO_VERSION = 11
 
 
 class LibraryElementIndexer:

--- a/proto/edgir/expr.proto
+++ b/proto/edgir/expr.proto
@@ -148,6 +148,7 @@ message UnarySetExpr {
   }
   Op op = 1;
   ValueExpr vals = 4;
+  ValueExpr empty_value = 5;  // value returned on an empty set, especially for reductions
 }
 
 message BinaryExpr {

--- a/proto/edgir/lit.proto
+++ b/proto/edgir/lit.proto
@@ -42,7 +42,7 @@ message ArrayLit {
 }
 
 message ErrorLit {
-  string message = 1;  // considered propagated if empty
+  string message = 1;  // if errors propagate, empty means this was propagated to avoid error spam
 }
 
 message ValueLit {
@@ -56,7 +56,7 @@ message ValueLit {
     RangeLit  range    = 10;
     ArrayLit  array    = 11;
 
-    ErrorLit  error    = 99;  // propagating error, either created by the user or the compiler
+    ErrorLit  error    = 99;  // may either propagate or be treated as unsolved
   }
 
   edgir.common.Metadata meta = 127;

--- a/proto/edgir/lit.proto
+++ b/proto/edgir/lit.proto
@@ -42,7 +42,7 @@ message ArrayLit {
 }
 
 message ErrorLit {
-  string message = 1;
+  string message = 1;  // considered propagated if empty
 }
 
 message ValueLit {

--- a/proto/edgir/lit.proto
+++ b/proto/edgir/lit.proto
@@ -41,6 +41,10 @@ message ArrayLit {
   repeated ValueLit elts = 1;
 }
 
+message ErrorLit {
+  string message = 1;
+}
+
 message ValueLit {
 
   oneof type {
@@ -51,6 +55,8 @@ message ValueLit {
     StructLit struct   = 9;
     RangeLit  range    = 10;
     ArrayLit  array    = 11;
+
+    ErrorLit  error    = 99;  // propagating error, either created by the user or the compiler
   }
 
   edgir.common.Metadata meta = 127;


### PR DESCRIPTION
Changes the IR and compiler to define the empty array output of array reduction operations in the frontend, allowing better type propagation (especially disambiguating float 0 and range 0 for sums).

Changes the error handling to generate an error value instead of crashing the compiler, allowing a partial compile instead of a unhelpful stack trace.

In the compiler, moves the param errors into the param value, while tracking overassigns separately because of the immutability of the param value system.

Also tightens up what reduction operations are allowed in the array subtypes.

Resolves #223 