### PR TITLE
Propagate errors in expr evaluation

### DIFF
--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -16,12 +16,9 @@ object ExprEvaluate {
   def evalBinary(binary: expr.BinaryExpr, lhs: ExprValue, rhs: ExprValue): ExprValue = {
     import expr.BinaryExpr.Op
 
-    (lhs, rhs) match { // errors propagation takes priority
-      case (ErrorValue(lhsMsg), ErrorValue(rhsMsg)) =>
-        return ErrorValue(Some(Seq(lhsMsg, rhsMsg).flatten.mkString("; ")))
-      case (ErrorValue(_), _) => return lhs
-      case (_, ErrorValue(_)) => return rhs
-      case _ => () // continue with normal evaluation
+    ErrorValue.aggregate(Seq(lhs, rhs)) match {
+      case Some(errorValue) => return errorValue // errors propagation takes priority
+      case None => () // continue with normal evaluation
     }
 
     binary.op match {
@@ -233,12 +230,9 @@ object ExprEvaluate {
   def evalBinarySet(binarySet: expr.BinarySetExpr, lhs: ExprValue, rhs: ExprValue): ExprValue = {
     import expr.BinarySetExpr.Op
 
-    (lhs, rhs) match { // errors propagation takes priority
-      case (ErrorValue(lhsMsg), ErrorValue(rhsMsg)) =>
-        return ErrorValue(Some(Seq(lhsMsg, rhsMsg).flatten.mkString("; ")))
-      case (ErrorValue(_), _) => return lhs
-      case (_, ErrorValue(_)) => return rhs
-      case _ => () // continue with normal evaluation
+    ErrorValue.aggregate(Seq(lhs, rhs)) match {
+      case Some(errorValue) => return errorValue // errors propagation takes priority
+      case None => () // continue with normal evaluation
     }
 
     binarySet.op match {
@@ -291,9 +285,9 @@ object ExprEvaluate {
   def evalUnary(unary: expr.UnaryExpr, `val`: ExprValue): ExprValue = {
     import expr.UnaryExpr.Op
 
-    `val` match { // errors propagation takes priority
-      case ErrorValue(_) => return `val`
-      case _ => () // continue with normal evaluation
+    ErrorValue.aggregate(Seq(`val`)) match {
+      case Some(errorValue) => return errorValue // errors propagation takes priority
+      case None => () // continue with normal evaluation
     }
 
     (unary.op, `val`) match {
@@ -332,12 +326,10 @@ object ExprEvaluate {
   def evalUnarySet(unarySet: expr.UnarySetExpr, vals: ExprValue, emptyValue: ExprValue): ExprValue = {
     import expr.UnarySetExpr.Op
 
-    (vals, emptyValue) match { // errors propagation takes priority
-      case (ErrorValue(valsMsg), ErrorValue(emptyValueMsg)) =>
-        return ErrorValue(Some(Seq(valsMsg, emptyValueMsg).flatten.mkString("; ")))
-      case (ErrorValue(_), _) => return vals
-      case (_, ErrorValue(_)) => return emptyValue
-      case _ => () // continue with normal evaluation
+    // note this does not short circuit out emptyValue if vals is not empty
+    ErrorValue.aggregate(Seq(vals, emptyValue)) match {
+      case Some(errorValue) => return errorValue // errors propagation takes priority
+      case None => () // continue with normal evaluation
     }
 
     (unarySet.op, vals) match {
@@ -435,17 +427,20 @@ object ExprEvaluate {
 
   def evalStruct(struct: expr.StructExpr, vals: Map[String, ExprValue]): ExprValue = ???
 
-  def evalRange(range: expr.RangeExpr, minimum: ExprValue, maximum: ExprValue): ExprValue = (minimum, maximum) match {
-    case (ErrorValue(minimumMsg), ErrorValue(maximumMsg)) =>
-      ErrorValue(Some(Seq(minimumMsg, maximumMsg).flatten.mkString("; ")))
-    case (ErrorValue(_), _) => minimum
-    case (_, ErrorValue(_)) => maximum
-    case (FloatPromotable(lhs), FloatPromotable(rhs)) => if (lhs <= rhs) {
-        RangeValue(lhs, rhs)
-      } else {
-        ErrorValue(Some(s"range($minimum, $maximum) is malformed, $minimum > $maximum"))
-      }
-    case _ => throw new ExprEvaluateException(s"Unknown range operands types $minimum $maximum from $range")
+  def evalRange(range: expr.RangeExpr, minimum: ExprValue, maximum: ExprValue): ExprValue = {
+    ErrorValue.aggregate(Seq(minimum, maximum)) match {
+      case Some(errorValue) => return errorValue // errors propagation takes priority
+      case None => () // continue with normal evaluation
+    }
+
+    (minimum, maximum) match {
+      case (FloatPromotable(lhs), FloatPromotable(rhs)) => if (lhs <= rhs) {
+          RangeValue(lhs, rhs)
+        } else {
+          ErrorValue(Some(s"range($minimum, $maximum) is malformed, $minimum > $maximum"))
+        }
+      case _ => throw new ExprEvaluateException(s"Unknown range operands types $minimum $maximum from $range")
+    }
   }
 
   def evalIfThenElse(ite: expr.IfThenElseExpr, cond: ExprValue, tru: ExprValue, fal: ExprValue): ExprValue =
@@ -456,17 +451,18 @@ object ExprEvaluate {
       case _ => throw new ExprEvaluateException(s"Unknown condition types if $cond then $tru else $fal from $ite")
     }
 
-  def evalExtract(extract: expr.ExtractExpr, container: ExprValue, index: ExprValue): ExprValue =
+  def evalExtract(extract: expr.ExtractExpr, container: ExprValue, index: ExprValue): ExprValue = {
+    ErrorValue.aggregate(Seq(container, index)) match {
+      case Some(errorValue) => return errorValue // errors propagation takes priority
+      case None => () // continue with normal evaluation
+    }
     (container, index) match {
-      case (ErrorValue(containerMsg), ErrorValue(indexMsg)) =>
-        ErrorValue(Some(Seq(containerMsg, indexMsg).flatten.mkString("; ")))
-      case (ErrorValue(_), _) => container
-      case (_, ErrorValue(_)) => index
       case (ArrayValue(container), IntValue(index)) => container(index.toInt)
       case _ => throw new ExprEvaluateException(
           s"Unknown operand types for extract element $index from $container from $extract"
         )
     }
+  }
 }
 
 class ExprEvaluate(refs: ConstProp, root: DesignPath) extends ValueExprMap[ExprValue] {

--- a/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprEvaluate.scala
@@ -15,6 +15,15 @@ object ExprEvaluate {
 
   def evalBinary(binary: expr.BinaryExpr, lhs: ExprValue, rhs: ExprValue): ExprValue = {
     import expr.BinaryExpr.Op
+
+    (lhs, rhs) match { // errors propagation takes priority
+      case (ErrorValue(lhsMsg), ErrorValue(rhsMsg)) =>
+        return ErrorValue(Some(Seq(lhsMsg, rhsMsg).flatten.mkString("; ")))
+      case (ErrorValue(_), _) => return lhs
+      case (_, ErrorValue(_)) => return rhs
+      case _ => () // continue with normal evaluation
+    }
+
     binary.op match {
       // Note promotion rules: range takes precedence, then float, then int
       case Op.ADD => (lhs, rhs) match {
@@ -223,6 +232,15 @@ object ExprEvaluate {
 
   def evalBinarySet(binarySet: expr.BinarySetExpr, lhs: ExprValue, rhs: ExprValue): ExprValue = {
     import expr.BinarySetExpr.Op
+
+    (lhs, rhs) match { // errors propagation takes priority
+      case (ErrorValue(lhsMsg), ErrorValue(rhsMsg)) =>
+        return ErrorValue(Some(Seq(lhsMsg, rhsMsg).flatten.mkString("; ")))
+      case (ErrorValue(_), _) => return lhs
+      case (_, ErrorValue(_)) => return rhs
+      case _ => () // continue with normal evaluation
+    }
+
     binarySet.op match {
       // Note promotion rules: range takes precedence, then float, then int
       // TODO: can we deduplicate these cases to delegate them to evalBinary?
@@ -272,6 +290,12 @@ object ExprEvaluate {
 
   def evalUnary(unary: expr.UnaryExpr, `val`: ExprValue): ExprValue = {
     import expr.UnaryExpr.Op
+
+    `val` match { // errors propagation takes priority
+      case ErrorValue(_) => return `val`
+      case _ => () // continue with normal evaluation
+    }
+
     (unary.op, `val`) match {
       case (Op.NEGATE, `val`) => `val` match {
           case RangeValue(valMin, valMax) =>
@@ -307,6 +331,15 @@ object ExprEvaluate {
 
   def evalUnarySet(unarySet: expr.UnarySetExpr, vals: ExprValue, emptyValue: ExprValue): ExprValue = {
     import expr.UnarySetExpr.Op
+
+    (vals, emptyValue) match { // errors propagation takes priority
+      case (ErrorValue(valsMsg), ErrorValue(emptyValueMsg)) =>
+        return ErrorValue(Some(Seq(valsMsg, emptyValueMsg).flatten.mkString("; ")))
+      case (ErrorValue(_), _) => return vals
+      case (_, ErrorValue(_)) => return emptyValue
+      case _ => () // continue with normal evaluation
+    }
+
     (unarySet.op, vals) match {
       case (_, ArrayValue.Empty(_)) => emptyValue
       // In this case we don't do numeric promotion
@@ -403,6 +436,10 @@ object ExprEvaluate {
   def evalStruct(struct: expr.StructExpr, vals: Map[String, ExprValue]): ExprValue = ???
 
   def evalRange(range: expr.RangeExpr, minimum: ExprValue, maximum: ExprValue): ExprValue = (minimum, maximum) match {
+    case (ErrorValue(minimumMsg), ErrorValue(maximumMsg)) =>
+      ErrorValue(Some(Seq(minimumMsg, maximumMsg).flatten.mkString("; ")))
+    case (ErrorValue(_), _) => minimum
+    case (_, ErrorValue(_)) => maximum
     case (FloatPromotable(lhs), FloatPromotable(rhs)) => if (lhs <= rhs) {
         RangeValue(lhs, rhs)
       } else {
@@ -413,6 +450,7 @@ object ExprEvaluate {
 
   def evalIfThenElse(ite: expr.IfThenElseExpr, cond: ExprValue, tru: ExprValue, fal: ExprValue): ExprValue =
     cond match {
+      case ErrorValue(_) => cond
       case BooleanValue(true) => tru
       case BooleanValue(false) => fal
       case _ => throw new ExprEvaluateException(s"Unknown condition types if $cond then $tru else $fal from $ite")
@@ -420,6 +458,10 @@ object ExprEvaluate {
 
   def evalExtract(extract: expr.ExtractExpr, container: ExprValue, index: ExprValue): ExprValue =
     (container, index) match {
+      case (ErrorValue(containerMsg), ErrorValue(indexMsg)) =>
+        ErrorValue(Some(Seq(containerMsg, indexMsg).flatten.mkString("; ")))
+      case (ErrorValue(_), _) => container
+      case (_, ErrorValue(_)) => index
       case (ArrayValue(container), IntValue(index)) => container(index.toInt)
       case _ => throw new ExprEvaluateException(
           s"Unknown operand types for extract element $index from $container from $extract"

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -51,6 +51,26 @@ object ExprValue {
   }
 }
 
+object ErrorValue {
+  def aggregate(exprs: Seq[ExprValue]): Option[ErrorValue] = {
+    val errors = exprs.collect { case error: ErrorValue => error }
+    errors match {
+        case Seq() => None
+        case Seq(single) => Some(single)
+        case multiple => Some(aggregateErrors(multiple))
+    }
+  }
+
+  private def aggregateErrors(errors: Seq[ErrorValue]): ErrorValue = {
+    val msgs = errors.flatMap(_.msg)
+    if (msgs.isEmpty) {
+      ErrorValue(None)
+    } else {
+      ErrorValue(Some(msgs.mkString("; ")))
+    }
+  }
+}
+
 case class ErrorValue(msg: Option[String]) extends ExprValue {
   def toLit: lit.ValueLit = Literal.Error(msg)
   def toStringValue: String = s"error(${msg.getOrElse("")})"

--- a/compiler/src/main/scala/edg/compiler/ExprValue.scala
+++ b/compiler/src/main/scala/edg/compiler/ExprValue.scala
@@ -55,9 +55,9 @@ object ErrorValue {
   def aggregate(exprs: Seq[ExprValue]): Option[ErrorValue] = {
     val errors = exprs.collect { case error: ErrorValue => error }
     errors match {
-        case Seq() => None
-        case Seq(single) => Some(single)
-        case multiple => Some(aggregateErrors(multiple))
+      case Seq() => None
+      case Seq(single) => Some(single)
+      case multiple => Some(aggregateErrors(multiple))
     }
   }
 

--- a/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
+++ b/compiler/src/test/scala/edg/compiler/ConstPropAssignTest.scala
@@ -188,7 +188,7 @@ class ConstPropAssignTest extends AnyFlatSpec {
     assert(constProp.getAllSolved(IndirectDesignPath() + "a").isInstanceOf[ErrorValue])
   }
 
-  it should "not propagate generated ErrorValues" in {
+  it should "not propagate ErrorValue-valued parameters" in {
     import edgir.expr.expr.BinaryExpr.Op
     val constProp = new ConstProp()
     constProp.addDeclaration(DesignPath() + "x", ValInit.Range)
@@ -207,5 +207,22 @@ class ConstPropAssignTest extends AnyFlatSpec {
     constProp.getErrors should not be empty
     assert(constProp.getValue(IndirectDesignPath() + "a").get.isInstanceOf[ErrorValue])
     constProp.getValue(IndirectDesignPath() + "b") shouldBe None
+  }
+
+  it should "propagate ErrorValues" in {
+    import edgir.expr.expr.BinaryExpr.Op
+    val constProp = new ConstProp()
+    constProp.addDeclaration(DesignPath() + "a", ValInit.Range)
+    constProp.addAssignExpr(
+      IndirectDesignPath() + "a",
+      ValueExpr.BinOp(
+        Op.ADD,
+        ValueExpr.BinOp(Op.SHRINK_MULT, ValueExpr.Literal(1, 1), ValueExpr.Literal(0, 2)),
+        ValueExpr.Literal(0, 0)
+      ),
+    )
+
+    constProp.getErrors should not be empty
+    assert(constProp.getValue(IndirectDesignPath() + "a").get.isInstanceOf[ErrorValue])
   }
 }


### PR DESCRIPTION
Previously it stopped error values at param boundaries, but it would still crash on an outer expr from type mismatch.

This adds a priority error propagation to prevent compiler crashes.