### PR TITLE
Fix OLED SPI interfaces

### DIFF
--- a/edg/parts/display/oled/Er_Oled_096_1_1.py
+++ b/edg/parts/display/oled/Er_Oled_096_1_1.py
@@ -179,6 +179,8 @@ class Er_Oled_096_1_1(Oled, Resettable, GeneratorBlock):
             self.connect(self.device.bs1, gnd_digital)
             self.connect(self.spi.sck, self.device.d0)
             self.connect(self.spi.mosi, self.device.d1)
+            self.miso_nc = self.Block(DigitalBidirNotConnected())
+            self.connect(self.spi.miso, self.miso_nc.port)
             self.connect(self.cs, self.device.cs)
             # D2 not-connected
             if self.get(self.dc.is_connected()):  # 4-line SPI

--- a/edg/parts/display/oled/Er_Oled_096_1c.py
+++ b/edg/parts/display/oled/Er_Oled_096_1c.py
@@ -176,6 +176,8 @@ class Er_Oled_096_1c(Oled, Resettable, GeneratorBlock):
             self.connect(self.device.bs1, gnd_digital)
             self.connect(self.spi.sck, self.device.d0)
             self.connect(self.spi.mosi, self.device.d1)
+            self.miso_nc = self.Block(DigitalBidirNotConnected())
+            self.connect(self.spi.miso, self.miso_nc.port)
             self.connect(self.cs, self.device.cs)
             self.connect(self.device.d2, gnd_digital)
             if self.get(self.dc.is_connected()):  # 4-line SPI

--- a/edg/parts/display/oled/test_oled_i2c_spi.py
+++ b/edg/parts/display/oled/test_oled_i2c_spi.py
@@ -1,0 +1,79 @@
+import unittest
+from typing_extensions import override
+
+from . import Er_Oled_096_1_1
+from ....vendor_parts.generic import *
+from ...connector import Fpc050Bottom, HiroseFh12sh
+from ....circuits import *
+from ....abstract_parts.IdealIoController import IdealIoController
+
+
+class OledI2cTest(DesignTop):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
+        self.gnd = self.Block(DummyGround())
+        with self.implicit_connect(
+            ImplicitConnect(self.pwr.pwr, [Power]),
+            ImplicitConnect(self.gnd.gnd, [Common]),
+        ) as imp:
+            self.dut = imp.Block(Er_Oled_096_1_1())
+
+            self.rst = self.Block(DummyDigitalSource())
+            self.connect(self.rst.io, self.dut.reset)
+
+            self.mcu = imp.Block(IdealIoController())
+            self.i2c_pull = imp.Block(I2cPullup())
+            self.connect(self.mcu.i2c.request(), self.dut.i2c, self.i2c_pull.i2c)
+
+    @override
+    def refinements(self) -> Refinements:
+        return Refinements(
+            class_refinements=[
+                (Resistor, GenericChipResistor),
+                (Capacitor, GenericMlcc),
+                (Fpc050Bottom, HiroseFh12sh),
+            ],
+            class_values=[(IdealModel, ["allow_ideal"], True)],
+        )
+
+
+class OledSpiTest(DesignTop):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
+        self.gnd = self.Block(DummyGround())
+        with self.implicit_connect(
+            ImplicitConnect(self.pwr.pwr, [Power]),
+            ImplicitConnect(self.gnd.gnd, [Common]),
+        ) as imp:
+            self.dut = imp.Block(Er_Oled_096_1_1())
+
+            self.rst = self.Block(DummyDigitalSource())
+            self.connect(self.rst.io, self.dut.reset)
+
+            self.mcu = imp.Block(IdealIoController())
+            self.connect(self.mcu.spi.request(), self.dut.spi)
+            self.cs = self.Block(DummyDigitalSource())
+            self.connect(self.cs.io, self.dut.cs)
+            self.dc = self.Block(DummyDigitalSource())
+            self.connect(self.dc.io, self.dut.dc)
+
+    @override
+    def refinements(self) -> Refinements:
+        return Refinements(
+            class_refinements=[
+                (Resistor, GenericChipResistor),
+                (Capacitor, GenericMlcc),
+                (Fpc050Bottom, HiroseFh12sh),
+            ],
+            class_values=[(IdealModel, ["allow_ideal"], True)],
+        )
+
+
+class OledInterfacesTestCase(unittest.TestCase):
+    def test_oled_i2c(self) -> None:
+        compiled = ScalaCompiler.compile(OledI2cTest)
+
+    def test_oled_spi(self) -> None:
+        compiled = ScalaCompiler.compile(OledSpiTest)


### PR DESCRIPTION
Previously, they led MISO disconnected and unmodeled. This adds a dummy connection.