### PR TITLE
Unify .connected(...) with DummyBlocks and TestPoints

### DIFF
--- a/edg/abstract_parts/TestPoint.py
+++ b/edg/abstract_parts/TestPoint.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, TypeVar, Generic
 from typing_extensions import override
 
 from ..electronics_interfaces import *
@@ -15,77 +15,69 @@ class TestPoint(InternalSubcircuit, Block):
         self.tp_name = self.ArgParameter(tp_name)
 
 
+TestPointLinkType = TypeVar("TestPointLinkType", bound=Link)
+SelfType = TypeVar("SelfType", bound="BaseTypedTestPoint[Link]")
+
+
 @non_library
-class BaseTypedTestPoint(TypedTestPoint, Block):
+class BaseTypedTestPoint(TypedTestPoint, Block, Generic[TestPointLinkType]):
     """Base class with utility infrastructure for typed test points"""
 
     def __init__(self, tp_name: StringLike = "") -> None:
         super().__init__()
-        self.io: Port
+        self.io: Port[TestPointLinkType]
         self.tp_name = self.ArgParameter(tp_name)
-        self.tp = self.Block(TestPoint(tp_name=StringExpr()))
 
-    @override
-    def contents(self) -> None:
-        super().contents()
-        self.assign(self.tp.tp_name, (self.tp_name == "").then_else(self.io.link().name(), self.tp_name))
+    def connected(self: SelfType, io: Port[TestPointLinkType]) -> SelfType:
+        builder.block().connect(io, self.io)
+        return self
 
 
 @non_library
-class BaseRfTestPoint(TypedTestPoint, Block):
+class BaseSingleTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[TestPointLinkType]):
+    """Base class that provides naming infrastructure for single-wire test points"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.tp = self.Block(TestPoint((self.tp_name == "").then_else(self.io.link().name(), self.tp_name)))
+
+
+@non_library
+class BaseRfTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[TestPointLinkType]):
     """Base class with utility infrastructure for typed RF test points."""
 
-    def __init__(self, tp_name: StringLike = "") -> None:
-        super().__init__()
-        self.tp_name = self.ArgParameter(tp_name)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.conn = self.Block(RfConnector())
         self.gnd = self.Export(self.conn.gnd, [Common])
-        self.io: Port
-
-    @override
-    def contents(self) -> None:
-        super().contents()
-        conn_tp = self.conn.with_mixin(RfConnectorTestPoint(StringExpr()))
-        self.assign(conn_tp.tp_name, (self.tp_name == "").then_else(self.io.link().name(), self.tp_name))
+        self.conn.with_mixin(RfConnectorTestPoint((self.tp_name == "").then_else(self.io.link().name(), self.tp_name)))
 
 
-class GroundTestPoint(BaseTypedTestPoint, Block):
+class GroundTestPoint(BaseSingleTestPoint[GroundLink], Block):
     """Test point with a VoltageSink port."""
 
-    def __init__(self, *args: Any) -> None:
-        super().__init__(*args)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.io: Ground = self.Port(Ground(), [InOut])
         self.connect(self.io.net, self.tp.io)
 
-    def connected(self, io: Port[GroundLink]) -> "GroundTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class VoltageTestPoint(BaseTypedTestPoint, Block):
+class VoltageTestPoint(BaseSingleTestPoint[VoltageLink], Block):
     """Test point with a VoltageSink port."""
 
-    def __init__(self, *args: Any) -> None:
-        super().__init__(*args)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.io: VoltageSink = self.Port(VoltageSink(), [InOut])
         self.connect(self.io.net, self.tp.io)
 
-    def connected(self, io: Port[VoltageLink]) -> "VoltageTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class DigitalTestPoint(BaseTypedTestPoint, Block):
+class DigitalTestPoint(BaseSingleTestPoint[DigitalLink], Block):
     """Test point with a DigitalSink port."""
 
-    def __init__(self, *args: Any) -> None:
-        super().__init__(*args)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.io: DigitalSink = self.Port(DigitalSink(), [InOut])
         self.connect(self.io.net, self.tp.io)
-
-    def connected(self, io: Port[DigitalLink]) -> "DigitalTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
 
 class DigitalArrayTestPoint(TypedTestPoint, GeneratorBlock):
@@ -110,20 +102,16 @@ class DigitalArrayTestPoint(TypedTestPoint, GeneratorBlock):
             self.connect(self.io.append_elt(DigitalSink.empty(), requested), tp.io)
 
 
-class AnalogTestPoint(BaseTypedTestPoint, Block):
+class AnalogTestPoint(BaseSingleTestPoint[AnalogLink], Block):
     """Test point with a AnalogSink port"""
 
-    def __init__(self, *args: Any) -> None:
-        super().__init__(*args)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.io: AnalogSink = self.Port(AnalogSink(), [InOut])
         self.connect(self.io.net, self.tp.io)
 
-    def connected(self, io: Port[AnalogLink]) -> "AnalogTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class AnalogCoaxTestPoint(BaseRfTestPoint, Block):
+class AnalogCoaxTestPoint(BaseRfTestPoint[AnalogLink], Block):
     """Test point with a AnalogSink port and using a coax connector with shielding connected to gnd.
     No impedance matching, this is intended for lower frequency signals where the wavelength would be
     much longer than the test lead length"""
@@ -133,18 +121,13 @@ class AnalogCoaxTestPoint(BaseRfTestPoint, Block):
         self.io: AnalogSink = self.Port(AnalogSink(), [InOut])
         self.connect(self.io.net, self.conn.sig)
 
-    def connected(self, io: Port[AnalogLink]) -> "AnalogCoaxTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class I2cTestPoint(TypedTestPoint, Block):
+class I2cTestPoint(BaseTypedTestPoint[I2cLink], Block):
     """Two test points for I2C SDA and SCL"""
 
-    def __init__(self, tp_name: StringLike = "") -> None:
-        super().__init__()
-        self.io = self.Port(I2cTarget(DigitalBidir.empty()), [InOut])
-        self.tp_name = self.ArgParameter(tp_name)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.io: I2cTarget = self.Port(I2cTarget(DigitalBidir.empty()), [InOut])
 
     @override
     def contents(self) -> None:
@@ -155,18 +138,13 @@ class I2cTestPoint(TypedTestPoint, Block):
         self.connect(self.tp_scl.io, self.io.scl)
         self.connect(self.tp_sda.io, self.io.sda)
 
-    def connected(self, io: Port[I2cLink]) -> "I2cTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class SpiTestPoint(TypedTestPoint, Block):
+class SpiTestPoint(BaseTypedTestPoint[SpiLink], Block):
     """Test points for SPI"""
 
-    def __init__(self, tp_name: StringLike = "") -> None:
-        super().__init__()
-        self.io = self.Port(SpiPeripheral(DigitalBidir.empty()), [InOut])
-        self.tp_name = self.ArgParameter(tp_name)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.io: SpiPeripheral = self.Port(SpiPeripheral(DigitalBidir.empty()), [InOut])
 
     @override
     def contents(self) -> None:
@@ -179,18 +157,13 @@ class SpiTestPoint(TypedTestPoint, Block):
         self.connect(self.tp_mosi.io, self.io.mosi)
         self.connect(self.tp_miso.io, self.io.miso)
 
-    def connected(self, io: Port[SpiLink]) -> "SpiTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class CanControllerTestPoint(TypedTestPoint, Block):
+class CanControllerTestPoint(BaseTypedTestPoint[CanLogicLink], Block):
     """Two test points for CAN controller-side TXD and RXD"""
 
-    def __init__(self, tp_name: StringLike = "") -> None:
-        super().__init__()
-        self.io = self.Port(CanPassivePort(DigitalBidir.empty()), [InOut])
-        self.tp_name = self.ArgParameter(tp_name)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.io: CanPassivePort = self.Port(CanPassivePort(DigitalBidir.empty()), [InOut])
 
     @override
     def contents(self) -> None:
@@ -201,18 +174,13 @@ class CanControllerTestPoint(TypedTestPoint, Block):
         self.connect(self.tp_txd.io, self.io.txd)
         self.connect(self.tp_rxd.io, self.io.rxd)
 
-    def connected(self, io: Port[CanLogicLink]) -> "CanControllerTestPoint":
-        builder.block().connect(io, self.io)
-        return self
 
-
-class CanDiffTestPoint(TypedTestPoint, Block):
+class CanDiffTestPoint(BaseTypedTestPoint[CanDiffLink], Block):
     """Two test points for CAN differential-side canh and canl"""
 
-    def __init__(self, tp_name: StringLike = "") -> None:
-        super().__init__()
-        self.io = self.Port(CanDiffPort(DigitalBidir.empty()), [InOut])
-        self.tp_name = self.ArgParameter(tp_name)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.io: CanDiffPort = self.Port(CanDiffPort(DigitalBidir.empty()), [InOut])
 
     @override
     def contents(self) -> None:
@@ -222,7 +190,3 @@ class CanDiffTestPoint(TypedTestPoint, Block):
         self.tp_canl = self.Block(DigitalTestPoint(name_prefix + ".canl"))
         self.connect(self.tp_canh.io, self.io.canh)
         self.connect(self.tp_canl.io, self.io.canl)
-
-    def connected(self, io: Port[CanLogicLink]) -> "CanDiffTestPoint":
-        builder.block().connect(io, self.io)
-        return self

--- a/edg/abstract_parts/TestPoint.py
+++ b/edg/abstract_parts/TestPoint.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Generic
+from typing import Any, TypeVar, Generic, Self
 from typing_extensions import override
 
 from ..electronics_interfaces import *
@@ -16,7 +16,6 @@ class TestPoint(InternalSubcircuit, Block):
 
 
 TestPointLinkType = TypeVar("TestPointLinkType", bound=Link)
-SelfType = TypeVar("SelfType", bound="BaseTypedTestPoint[Link]")
 
 
 @non_library
@@ -28,7 +27,7 @@ class BaseTypedTestPoint(TypedTestPoint, Block, Generic[TestPointLinkType]):
         self.io: Port[TestPointLinkType]
         self.tp_name = self.ArgParameter(tp_name)
 
-    def connected(self: SelfType, io: Port[TestPointLinkType]) -> SelfType:
+    def connected(self, io: Port[TestPointLinkType]) -> Self:
         builder.block().connect(io, self.io)
         return self
 

--- a/edg/abstract_parts/TestPoint.py
+++ b/edg/abstract_parts/TestPoint.py
@@ -1,5 +1,5 @@
-from typing import Any, TypeVar, Generic, Self
-from typing_extensions import override
+from typing import Any, TypeVar, Generic
+from typing_extensions import override, Self
 
 from ..electronics_interfaces import *
 from .Connectors import RfConnector, RfConnectorTestPoint

--- a/edg/abstract_parts/TestPoint.py
+++ b/edg/abstract_parts/TestPoint.py
@@ -39,7 +39,12 @@ class BaseSingleTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.tp = self.Block(TestPoint((self.tp_name == "").then_else(self.io.link().name(), self.tp_name)))
+        self.tp = self.Block(TestPoint(StringExpr()))
+
+    @override
+    def contents(self) -> None:
+        super().contents()
+        self.assign(self.tp.tp_name, (self.tp_name == "").then_else(self.io.link().name(), self.tp_name))
 
 
 @non_library
@@ -50,6 +55,10 @@ class BaseRfTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[Test
         super().__init__(*args, **kwargs)
         self.conn = self.Block(RfConnector())
         self.gnd = self.Export(self.conn.gnd, [Common])
+
+    @override
+    def contents(self) -> None:
+        super().contents()
         self.conn.with_mixin(RfConnectorTestPoint((self.tp_name == "").then_else(self.io.link().name(), self.tp_name)))
 
 

--- a/edg/abstract_parts/TestPoint.py
+++ b/edg/abstract_parts/TestPoint.py
@@ -33,7 +33,7 @@ class BaseTypedTestPoint(TypedTestPoint, Block, Generic[TestPointLinkType]):
 
 
 @non_library
-class BaseSingleTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[TestPointLinkType]):
+class BaseSingleTestPoint(BaseTypedTestPoint[TestPointLinkType], Generic[TestPointLinkType]):
     """Base class that provides naming infrastructure for single-wire test points"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -47,7 +47,7 @@ class BaseSingleTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[
 
 
 @non_library
-class BaseRfTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[TestPointLinkType]):
+class BaseRfTestPoint(BaseTypedTestPoint[TestPointLinkType], Generic[TestPointLinkType]):
     """Base class with utility infrastructure for typed RF test points."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -61,8 +61,8 @@ class BaseRfTestPoint(BaseTypedTestPoint[TestPointLinkType], Block, Generic[Test
         self.conn.with_mixin(RfConnectorTestPoint((self.tp_name == "").then_else(self.io.link().name(), self.tp_name)))
 
 
-class GroundTestPoint(BaseSingleTestPoint[GroundLink], Block):
-    """Test point with a VoltageSink port."""
+class GroundTestPoint(BaseSingleTestPoint[GroundLink]):
+    """Test point with a Ground port."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -70,7 +70,7 @@ class GroundTestPoint(BaseSingleTestPoint[GroundLink], Block):
         self.connect(self.io.net, self.tp.io)
 
 
-class VoltageTestPoint(BaseSingleTestPoint[VoltageLink], Block):
+class VoltageTestPoint(BaseSingleTestPoint[VoltageLink]):
     """Test point with a VoltageSink port."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -79,7 +79,7 @@ class VoltageTestPoint(BaseSingleTestPoint[VoltageLink], Block):
         self.connect(self.io.net, self.tp.io)
 
 
-class DigitalTestPoint(BaseSingleTestPoint[DigitalLink], Block):
+class DigitalTestPoint(BaseSingleTestPoint[DigitalLink]):
     """Test point with a DigitalSink port."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -110,7 +110,7 @@ class DigitalArrayTestPoint(TypedTestPoint, GeneratorBlock):
             self.connect(self.io.append_elt(DigitalSink.empty(), requested), tp.io)
 
 
-class AnalogTestPoint(BaseSingleTestPoint[AnalogLink], Block):
+class AnalogTestPoint(BaseSingleTestPoint[AnalogLink]):
     """Test point with a AnalogSink port"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -119,7 +119,7 @@ class AnalogTestPoint(BaseSingleTestPoint[AnalogLink], Block):
         self.connect(self.io.net, self.tp.io)
 
 
-class AnalogCoaxTestPoint(BaseRfTestPoint[AnalogLink], Block):
+class AnalogCoaxTestPoint(BaseRfTestPoint[AnalogLink]):
     """Test point with a AnalogSink port and using a coax connector with shielding connected to gnd.
     No impedance matching, this is intended for lower frequency signals where the wavelength would be
     much longer than the test lead length"""
@@ -130,7 +130,7 @@ class AnalogCoaxTestPoint(BaseRfTestPoint[AnalogLink], Block):
         self.connect(self.io.net, self.conn.sig)
 
 
-class I2cTestPoint(BaseTypedTestPoint[I2cLink], Block):
+class I2cTestPoint(BaseTypedTestPoint[I2cLink]):
     """Two test points for I2C SDA and SCL"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -147,7 +147,7 @@ class I2cTestPoint(BaseTypedTestPoint[I2cLink], Block):
         self.connect(self.tp_sda.io, self.io.sda)
 
 
-class SpiTestPoint(BaseTypedTestPoint[SpiLink], Block):
+class SpiTestPoint(BaseTypedTestPoint[SpiLink]):
     """Test points for SPI"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -166,7 +166,7 @@ class SpiTestPoint(BaseTypedTestPoint[SpiLink], Block):
         self.connect(self.tp_miso.io, self.io.miso)
 
 
-class CanControllerTestPoint(BaseTypedTestPoint[CanLogicLink], Block):
+class CanControllerTestPoint(BaseTypedTestPoint[CanLogicLink]):
     """Two test points for CAN controller-side TXD and RXD"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -183,7 +183,7 @@ class CanControllerTestPoint(BaseTypedTestPoint[CanLogicLink], Block):
         self.connect(self.tp_rxd.io, self.io.rxd)
 
 
-class CanDiffTestPoint(BaseTypedTestPoint[CanDiffLink], Block):
+class CanDiffTestPoint(BaseTypedTestPoint[CanDiffLink]):
     """Two test points for CAN differential-side canh and canl"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/edg/abstract_parts/test_ideal_circuit.py
+++ b/edg/abstract_parts/test_ideal_circuit.py
@@ -10,24 +10,20 @@ class IdealCircuitTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.gnd = self.Block(DummyGround())
-        self.pwr = self.Block(DummyVoltageSource(5 * Volt(tol=0)))
         with self.implicit_connect(
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.reg = imp.Block(LinearRegulator(2 * Volt(tol=0)))
-            self.connect(self.reg.pwr_in, self.pwr.pwr)
-            self.reg_draw = self.Block(DummyVoltageSink(current_draw=1 * Amp(tol=0)))
-            self.connect(self.reg_draw.pwr, self.reg.pwr_out)
+            self.pwr = self.Block(DummyVoltageSource(5 * Volt(tol=0))).connected(self.reg.pwr_in)
+            self.reg_draw = self.Block(DummyVoltageSink(current_draw=1 * Amp(tol=0))).connected(self.reg.pwr_out)
 
             self.boost = imp.Block(BoostConverter(4 * Volt(tol=0)))
             self.connect(self.boost.pwr_in, self.reg.pwr_out)
-            self.boost_draw = self.Block(DummyVoltageSink(current_draw=1 * Amp(tol=0)))
-            self.connect(self.boost_draw.pwr, self.boost.pwr_out)  # draws 2A from reg
+            self.boost_draw = self.Block(DummyVoltageSink(current_draw=1 * Amp(tol=0))).connected(self.boost.pwr_out)
 
             self.mcu = imp.Block(IoController())
             self.connect(self.mcu.pwr, self.reg.pwr_out)
-            self.mcu_io = self.Block(DummyDigitalSink())
-            self.connect(self.mcu_io.io, self.mcu.gpio.request("test"))
+            self.mcu_io = self.Block(DummyDigitalSink()).connected(self.mcu.gpio.request("test"))
 
         self.require(self.pwr.current_drawn == 3 * Amp(tol=0))
         self.require(self.reg_draw.voltage == 2 * Volt(tol=0))

--- a/edg/circuits/LevelShifter.py
+++ b/edg/circuits/LevelShifter.py
@@ -86,4 +86,5 @@ class BidirectionalLevelShifter(Interface, GeneratorBlock):
         if self.get(self.hv_res) != RangeExpr.INF:
             self.hv_pu = self.Block(PullupResistor(self.hv_res)).connected(self.hv_pwr, self.hv_io)
         else:
-            self.dummy_hv = self.Block(DummyVoltageSink()).connected(self.hv_pwr)  # must be connected
+            # TODO debug this type check failure
+            self.dummy_hv = self.Block(DummyVoltageSink()).connected(self.hv_pwr)  # type: ignore

--- a/edg/circuits/LevelShifter.py
+++ b/edg/circuits/LevelShifter.py
@@ -86,5 +86,4 @@ class BidirectionalLevelShifter(Interface, GeneratorBlock):
         if self.get(self.hv_res) != RangeExpr.INF:
             self.hv_pu = self.Block(PullupResistor(self.hv_res)).connected(self.hv_pwr, self.hv_io)
         else:
-            # TODO debug this type check failure
-            self.dummy_hv = self.Block(DummyVoltageSink()).connected(self.hv_pwr)  # type: ignore
+            self.dummy_hv = self.Block(DummyVoltageSink()).connected(self.hv_pwr)  # mark as connected

--- a/edg/circuits/LevelShifter.py
+++ b/edg/circuits/LevelShifter.py
@@ -86,5 +86,4 @@ class BidirectionalLevelShifter(Interface, GeneratorBlock):
         if self.get(self.hv_res) != RangeExpr.INF:
             self.hv_pu = self.Block(PullupResistor(self.hv_res)).connected(self.hv_pwr, self.hv_io)
         else:
-            self.dummy_hv = self.Block(DummyVoltageSink())  # must be connected
-            self.connect(self.dummy_hv.pwr, self.hv_pwr)
+            self.dummy_hv = self.Block(DummyVoltageSink()).connected(self.hv_pwr)  # must be connected

--- a/edg/circuits/test_diodemerge.py
+++ b/edg/circuits/test_diodemerge.py
@@ -10,13 +10,9 @@ class DiodeMergeTestTop(DesignTop):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(DiodePowerMerge(voltage_drop=(0, 1) * Volt))
-        (self.srca,), _ = self.chain(
-            self.dut.pwr_ins.request(), self.Block(DummyVoltageSource(voltage_out=(12, 14) * Volt))
-        )
-        (self.srcb,), _ = self.chain(
-            self.dut.pwr_ins.request(), self.Block(DummyVoltageSource(voltage_out=(4, 5) * Volt))
-        )
-        (self.sink,), _ = self.chain(self.dut.pwr_out, self.Block(DummyVoltageSink(current_draw=(0.5, 1.5) * Amp)))
+        self.srca = self.Block(DummyVoltageSource(voltage_out=(12, 14) * Volt)).connected(self.dut.pwr_ins.request())
+        self.srcb = self.Block(DummyVoltageSource(voltage_out=(4, 5) * Volt)).connected(self.dut.pwr_ins.request())
+        self.sink = self.Block(DummyVoltageSink(current_draw=(0.5, 1.5) * Amp)).connected(self.dut.pwr_out)
 
     @override
     def refinements(self) -> Refinements:

--- a/edg/circuits/test_opamp.py
+++ b/edg/circuits/test_opamp.py
@@ -6,12 +6,6 @@ from ..abstract_parts import *
 from .OpampCircuits import Amplifier
 
 
-class AnalogSourceDummy(Block):
-    def __init__(self) -> None:
-        super().__init__()
-        self.port = self.Port(AnalogSource(), [InOut])
-
-
 class TestOpamp(Opamp):
     @override
     def contents(self) -> None:
@@ -34,11 +28,11 @@ class AmplifierTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(Amplifier(amplification=Range.from_tolerance(2, 0.05)))
-        (self.dummyin,), _ = self.chain(self.dut.input, self.Block(AnalogSourceDummy()))
-        (self.dummyref,), _ = self.chain(self.dut.reference, self.Block(AnalogSourceDummy()))
-        (self.dummyout,), _ = self.chain(self.dut.output, self.Block(DummyAnalogSink()))
-        (self.dummypwr,), _ = self.chain(self.dut.pwr, self.Block(DummyVoltageSource()))
-        (self.dummygnd,), _ = self.chain(self.dut.gnd, self.Block(DummyGround()))
+        self.dummygnd = self.Block(DummyGround()).connected(self.dut.gnd)
+        self.dummypwr = self.Block(DummyVoltageSource()).connected(self.dut.pwr)
+        self.dummyin = self.Block(DummyAnalogSource()).connected(self.dut.input)
+        self.dummyref = self.Block(DummyAnalogSource()).connected(self.dut.reference)
+        self.dummyout = self.Block(DummyAnalogSink()).connected(self.dut.output)
 
 
 class OpampCircuitTest(unittest.TestCase):

--- a/edg/circuits/test_power_circuits.py
+++ b/edg/circuits/test_power_circuits.py
@@ -12,12 +12,10 @@ class RampLimiterTestTop(DesignTop):
         super().__init__()
         self.dut = self.Block(RampLimiter())
 
-        (self.dummyin,), _ = self.chain(self.dut.pwr_in, self.Block(DummyVoltageSource(voltage_out=12 * Volt(tol=0))))
-        (self.dummyout,), _ = self.chain(self.dut.pwr_out, self.Block(DummyVoltageSink(current_draw=1 * Amp(tol=0))))
-        (self.dummyctl,), _ = self.chain(
-            self.dut.control, self.Block(DummyDigitalSource(voltage_out=3.3 * Volt(tol=0)))
-        )
-        (self.dummygnd,), _ = self.chain(self.dut.gnd, self.Block(DummyGround()))
+        self.dummygnd = self.Block(DummyGround()).connected(self.dut.gnd)
+        self.dummyin = self.Block(DummyVoltageSource(voltage_out=12 * Volt(tol=0))).connected(self.dut.pwr_in)
+        self.dummyout = self.Block(DummyVoltageSink(current_draw=1 * Amp(tol=0))).connected(self.dut.pwr_out)
+        self.dummyctl = self.Block(DummyDigitalSource(voltage_out=3.3 * Volt(tol=0))).connected(self.dut.control)
 
     @override
     def refinements(self) -> Refinements:

--- a/edg/circuits/test_switching_converters.py
+++ b/edg/circuits/test_switching_converters.py
@@ -171,10 +171,10 @@ class BuckPowerPathTestTop(DesignTop):
                 output_voltage_ripple=25 * mVolt,
             )
         )
-        (self.pwr_in,), _ = self.chain(self.Block(DummyVoltageSource()), self.dut.pwr_in)
-        (self.switch,), _ = self.chain(self.Block(DummyVoltageSource()), self.dut.switch)
-        (self.pwr_out,), _ = self.chain(self.Block(DummyVoltageSink()), self.dut.pwr_out)
-        (self.gnd,), _ = self.chain(self.Block(DummyGround()), self.dut.gnd)
+        self.gnd = self.Block(DummyGround()).connected(self.dut.gnd)
+        self.pwr_in = self.Block(DummyVoltageSource()).connected(self.dut.pwr_in)
+        self.switch = self.Block(DummyVoltageSource()).connected(self.dut.switch)
+        self.pwr_out = self.Block(DummyVoltageSink()).connected(self.dut.pwr_out)
 
         self.require(self.dut.actual_dutycycle.contains(Range(0.334, 0.832)))
         self.require(self.dut.actual_inductor_current_ripple.contains(Range(0.433, 0.478)))
@@ -206,10 +206,10 @@ class BoostPowerPathTestTop(DesignTop):
                 output_voltage_ripple=25 * mVolt,
             )
         )
-        (self.pwr_in,), _ = self.chain(self.Block(DummyVoltageSource()), self.dut.pwr_in)
-        (self.pwr_out,), _ = self.chain(self.Block(DummyVoltageSource()), self.dut.pwr_out)
-        (self.switch,), _ = self.chain(self.Block(DummyVoltageSink()), self.dut.switch)
-        (self.gnd,), _ = self.chain(self.Block(DummyGround()), self.dut.gnd)
+        self.gnd = self.Block(DummyGround()).connected(self.dut.gnd)
+        self.pwr_in = self.Block(DummyVoltageSource()).connected(self.dut.pwr_in)
+        self.pwr_out = self.Block(DummyVoltageSource()).connected(self.dut.pwr_out)
+        self.switch = self.Block(DummyVoltageSink()).connected(self.dut.switch)
 
         self.require(self.dut.actual_dutycycle.contains(Range(0.4, 0.771)))
         self.require(self.dut.actual_inductor_current_ripple.contains(Range(0.495, 0.546)))

--- a/edg/electronics_interfaces/DummyDevices.py
+++ b/edg/electronics_interfaces/DummyDevices.py
@@ -1,5 +1,5 @@
-from typing import Dict, TypeVar, Generic, Self
-from typing_extensions import override
+from typing import Dict, TypeVar, Generic
+from typing_extensions import override, Self
 
 from ..electronics_model import *
 from .VoltagePorts import VoltageSink, VoltageSource

--- a/edg/electronics_interfaces/DummyDevices.py
+++ b/edg/electronics_interfaces/DummyDevices.py
@@ -1,4 +1,4 @@
-from typing import Dict, TypeVar, Generic
+from typing import Dict, TypeVar, Generic, Self
 from typing_extensions import override
 
 from ..electronics_model import *
@@ -7,7 +7,6 @@ from .DigitalPorts import DigitalSink, DigitalSource, DigitalLink
 from .AnalogPort import AnalogSink, AnalogSource, AnalogLink
 
 DummyLinkType = TypeVar("DummyLinkType", bound=Link)
-SelfType = TypeVar("SelfType", bound="BaseDummyBlock[Link]")
 
 
 @non_library
@@ -18,7 +17,7 @@ class BaseDummyBlock(DummyDevice, Block, Generic[DummyLinkType]):
         super().__init__()
         self.io: Port[DummyLinkType]
 
-    def connected(self: SelfType, io: Port[DummyLinkType]) -> SelfType:
+    def connected(self, io: Port[DummyLinkType]) -> Self:
         builder.block().connect(io, self.io)
         return self
 

--- a/edg/electronics_interfaces/DummyDevices.py
+++ b/edg/electronics_interfaces/DummyDevices.py
@@ -1,33 +1,47 @@
-from typing import Dict
+from typing import Dict, TypeVar, Generic
 from typing_extensions import override
 
 from ..electronics_model import *
 from .VoltagePorts import VoltageSink, VoltageSource
-from .DigitalPorts import DigitalSink, DigitalSource
-from .AnalogPort import AnalogSink, AnalogSource
+from .DigitalPorts import DigitalSink, DigitalSource, DigitalLink
+from .AnalogPort import AnalogSink, AnalogSource, AnalogLink
+
+DummyLinkType = TypeVar("DummyLinkType", bound=Link)
+SelfType = TypeVar("SelfType", bound="BaseDummyBlock[Link]")
 
 
-class DummyPassive(DummyDevice):
+@non_library
+class BaseDummyBlock(DummyDevice, Block, Generic[DummyLinkType]):
+    """Base class with utility infrastructure for typed dummy blocks, a non-physical device that provides a magic IO"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.io: Port[DummyLinkType]
+
+    def connected(self: SelfType, io: Port[DummyLinkType]) -> SelfType:
+        builder.block().connect(io, self.io)
+        return self
+
+
+class DummyPassive(BaseDummyBlock[PassiveLink]):
     def __init__(self) -> None:
         super().__init__()
         self.io = self.Port(Passive(), [InOut])
 
 
-class DummyDigitalSource(DummyDevice):
+class DummyDigitalSource(BaseDummyBlock[DigitalLink]):
     def __init__(self, voltage_out: RangeLike = RangeExpr.ZERO, current_limits: RangeLike = RangeExpr.ALL) -> None:
         super().__init__()
-
         self.io = self.Port(DigitalSource(voltage_out=voltage_out, current_limits=current_limits), [InOut])
 
 
-class DummyDigitalSink(DummyDevice):
+class DummyDigitalSink(BaseDummyBlock[DigitalLink]):
     def __init__(self, voltage_limit: RangeLike = RangeExpr.ALL, current_draw: RangeLike = RangeExpr.ZERO) -> None:
         super().__init__()
-
         self.io = self.Port(DigitalSink(voltage_limits=voltage_limit, current_draw=current_draw), [InOut])
 
 
-class DummyAnalogSource(DummyDevice):
+class DummyAnalogSource(BaseDummyBlock[AnalogLink]):
     def __init__(
         self,
         voltage_out: RangeLike = RangeExpr.ZERO,
@@ -36,7 +50,6 @@ class DummyAnalogSource(DummyDevice):
         impedance: RangeLike = RangeExpr.ZERO,
     ) -> None:
         super().__init__()
-
         self.io = self.Port(
             AnalogSource(
                 voltage_out=voltage_out, signal_out=signal_out, current_limits=current_limits, impedance=impedance
@@ -45,7 +58,7 @@ class DummyAnalogSource(DummyDevice):
         )
 
 
-class DummyAnalogSink(DummyDevice):
+class DummyAnalogSink(BaseDummyBlock[AnalogLink]):
     def __init__(
         self,
         voltage_limit: RangeLike = RangeExpr.ALL,
@@ -54,7 +67,6 @@ class DummyAnalogSink(DummyDevice):
         impedance: RangeLike = RangeExpr.INF,
     ) -> None:
         super().__init__()
-
         self.io = self.Port(
             AnalogSink(
                 voltage_limits=voltage_limit, signal_limits=signal_limit, current_draw=current_draw, impedance=impedance

--- a/edg/electronics_interfaces/GroundDummy.py
+++ b/edg/electronics_interfaces/GroundDummy.py
@@ -14,7 +14,7 @@ class DummyGround(BaseDummyBlock[GroundLink]):
     def __getattr__(self, item: str) -> Any:
         if item == "gnd":
             warnings.warn(
-                f"Use .io instead.",
+                f"DummyGround.gnd is deprecated, use .io instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/edg/electronics_interfaces/GroundDummy.py
+++ b/edg/electronics_interfaces/GroundDummy.py
@@ -1,3 +1,6 @@
+import warnings
+from typing import Any
+
 from ..electronics_model import *
 from .DummyDevices import BaseDummyBlock
 from .GroundPort import Ground, Common, GroundLink
@@ -7,3 +10,16 @@ class DummyGround(BaseDummyBlock[GroundLink]):
     def __init__(self) -> None:
         super().__init__()
         self.io = self.Port(Ground(), [Common, InOut])
+
+    def __getattr__(self, item: str) -> Any:
+        if item == "gnd":
+            warnings.warn(
+                f"Use .io instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.io
+        else:
+            raise AttributeError(
+                item
+            )  # ideally we'd use super().__getattr__(...), but that's not defined in base classes

--- a/edg/electronics_interfaces/GroundDummy.py
+++ b/edg/electronics_interfaces/GroundDummy.py
@@ -1,8 +1,9 @@
 from ..electronics_model import *
-from .GroundPort import Ground, Common
+from .DummyDevices import BaseDummyBlock
+from .GroundPort import Ground, Common, GroundLink
 
 
-class DummyGround(DummyDevice):
+class DummyGround(BaseDummyBlock[GroundLink]):
     def __init__(self) -> None:
         super().__init__()
-        self.gnd = self.Port(Ground(), [Common, InOut])
+        self.io = self.Port(Ground(), [Common, InOut])

--- a/edg/electronics_interfaces/VoltageDummy.py
+++ b/edg/electronics_interfaces/VoltageDummy.py
@@ -33,7 +33,7 @@ class DummyVoltageSource(BaseDummyBlock[VoltageLink]):
     def __getattr__(self, item: str) -> Any:
         if item == "pwr":
             warnings.warn(
-                f"Use .io instead.",
+                f"DummyVoltageSource.pwr is deprecated, use .io instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -71,7 +71,7 @@ class DummyVoltageSink(BaseDummyBlock[VoltageLink]):
     def __getattr__(self, item: str) -> Any:
         if item == "pwr":
             warnings.warn(
-                f"Use .io instead.",
+                f"DummyVoltageSink.pwr is deprecated, use .io instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/edg/electronics_interfaces/VoltageDummy.py
+++ b/edg/electronics_interfaces/VoltageDummy.py
@@ -1,3 +1,6 @@
+import warnings
+from typing import Any
+
 from ..electronics_model import *
 from .DummyDevices import BaseDummyBlock
 from .VoltagePorts import VoltageSource, VoltageSink, Power, VoltageLink
@@ -27,6 +30,19 @@ class DummyVoltageSource(BaseDummyBlock[VoltageLink]):
         self.voltage_limits = self.Parameter(RangeExpr(self.io.link().voltage_limits))
         self.reverse_voltage = self.Parameter(RangeExpr(self.io.link().reverse_voltage))
 
+    def __getattr__(self, item: str) -> Any:
+        if item == "pwr":
+            warnings.warn(
+                f"Use .io instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.io
+        else:
+            raise AttributeError(
+                item
+            )  # ideally we'd use super().__getattr__(...), but that's not defined in base classes
+
 
 class DummyVoltageSink(BaseDummyBlock[VoltageLink]):
 
@@ -51,3 +67,16 @@ class DummyVoltageSink(BaseDummyBlock[VoltageLink]):
 
         self.voltage = self.Parameter(RangeExpr(self.io.link().voltage))
         self.current_limits = self.Parameter(RangeExpr(self.io.link().current_limits))
+
+    def __getattr__(self, item: str) -> Any:
+        if item == "pwr":
+            warnings.warn(
+                f"Use .io instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.io
+        else:
+            raise AttributeError(
+                item
+            )  # ideally we'd use super().__getattr__(...), but that's not defined in base classes

--- a/edg/electronics_interfaces/VoltageDummy.py
+++ b/edg/electronics_interfaces/VoltageDummy.py
@@ -1,8 +1,9 @@
 from ..electronics_model import *
-from .VoltagePorts import VoltageSource, VoltageSink, Power
+from .DummyDevices import BaseDummyBlock
+from .VoltagePorts import VoltageSource, VoltageSink, Power, VoltageLink
 
 
-class DummyVoltageSource(DummyDevice):
+class DummyVoltageSource(BaseDummyBlock[VoltageLink]):
     def __init__(
         self,
         voltage_out: RangeLike = RangeExpr.ZERO,
@@ -12,7 +13,7 @@ class DummyVoltageSource(DummyDevice):
     ) -> None:
         super().__init__()
 
-        self.pwr = self.Port(
+        self.io = self.Port(
             VoltageSource(
                 voltage_out=voltage_out,
                 current_limits=current_limits,
@@ -22,12 +23,12 @@ class DummyVoltageSource(DummyDevice):
             [Power, InOut],
         )
 
-        self.current_drawn = self.Parameter(RangeExpr(self.pwr.link().current_drawn))
-        self.voltage_limits = self.Parameter(RangeExpr(self.pwr.link().voltage_limits))
-        self.reverse_voltage = self.Parameter(RangeExpr(self.pwr.link().reverse_voltage))
+        self.current_drawn = self.Parameter(RangeExpr(self.io.link().current_drawn))
+        self.voltage_limits = self.Parameter(RangeExpr(self.io.link().voltage_limits))
+        self.reverse_voltage = self.Parameter(RangeExpr(self.io.link().reverse_voltage))
 
 
-class DummyVoltageSink(DummyDevice):
+class DummyVoltageSink(BaseDummyBlock[VoltageLink]):
 
     def __init__(
         self,
@@ -38,7 +39,7 @@ class DummyVoltageSink(DummyDevice):
     ) -> None:
         super().__init__()
 
-        self.pwr = self.Port(
+        self.io = self.Port(
             VoltageSink(
                 voltage_limits=voltage_limit,
                 current_draw=current_draw,
@@ -48,5 +49,5 @@ class DummyVoltageSink(DummyDevice):
             [Power, InOut],
         )
 
-        self.voltage = self.Parameter(RangeExpr(self.pwr.link().voltage))
-        self.current_limits = self.Parameter(RangeExpr(self.pwr.link().current_limits))
+        self.voltage = self.Parameter(RangeExpr(self.io.link().voltage))
+        self.current_limits = self.Parameter(RangeExpr(self.io.link().current_limits))

--- a/edg/electronics_interfaces/test_voltage_link.py
+++ b/edg/electronics_interfaces/test_voltage_link.py
@@ -11,7 +11,7 @@ class VoltageTestTop(DesignTop):
         super().__init__()
         self.src = self.Block(DummyVoltageSource(voltage_out=5 * Volt(tol=0), current_limits=(0, 1) * Amp))
         self.sink = self.Block(DummyVoltageSink(voltage_limit=5 * Volt(tol=0.1), current_draw=1 * Amp(tol=0)))
-        self.connect(self.src.pwr, self.sink.pwr)
+        self.connect(self.src.io, self.sink.io)
 
 
 class NoSourceVoltageTest(DesignTop):
@@ -29,7 +29,7 @@ class OvervoltageTestTop(DesignTop):
         super().__init__()
         self.src = self.Block(DummyVoltageSource(voltage_out=5 * Volt(tol=0), current_limits=(0, 1) * Amp))
         self.sink = self.Block(DummyVoltageSink(voltage_limit=3.3 * Volt(tol=0.1), current_draw=1 * Amp(tol=0)))
-        self.connect(self.src.pwr, self.sink.pwr)
+        self.connect(self.src.io, self.sink.io)
 
 
 class OvercurrentTestTop(DesignTop):
@@ -40,7 +40,7 @@ class OvercurrentTestTop(DesignTop):
         self.src = self.Block(DummyVoltageSource(voltage_out=5 * Volt(tol=0), current_limits=(0, 1) * Amp))
         self.sink1 = self.Block(DummyVoltageSink(voltage_limit=5 * Volt(tol=0.1), current_draw=1 * Amp(tol=0)))
         self.sink2 = self.Block(DummyVoltageSink(voltage_limit=5 * Volt(tol=0.1), current_draw=1 * Amp(tol=0)))
-        self.connect(self.src.pwr, self.sink1.pwr, self.sink2.pwr)
+        self.connect(self.src.io, self.sink1.io, self.sink2.io)
 
 
 class ReverseVoltageTestTop(DesignTop):
@@ -70,7 +70,7 @@ class ReverseVoltageTestTop(DesignTop):
                 current_draw=0 * Amp(tol=0),
             )
         )
-        self.connect(self.src.pwr, self.sink.pwr, self.sink2.pwr)
+        self.connect(self.src.io, self.sink.io, self.sink2.io)
         self.require(self.src.reverse_voltage == 5 * Volt(tol=0))
 
 
@@ -103,7 +103,7 @@ class ReverseMultiSourceTestTop(DesignTop):
                 reverse_current_limits=(0, 1) * Amp,
             )
         )
-        self.connect(self.src.pwr, self.sink1.pwr, self.sink2.pwr)
+        self.connect(self.src.io, self.sink1.io, self.sink2.io)
 
 
 class ReverseNoSinkTest(DesignTop):
@@ -120,7 +120,7 @@ class ReverseNoSinkTest(DesignTop):
                 reverse_current_limits=(0, 1) * Amp,
             )
         )
-        self.connect(self.src.pwr, self.sink.pwr)
+        self.connect(self.src.io, self.sink.io)
 
 
 class ReverseOvervoltageTestTop(DesignTop):
@@ -144,7 +144,7 @@ class ReverseOvervoltageTestTop(DesignTop):
                 reverse_current_limits=(0, 1) * Amp,
             )
         )
-        self.connect(self.src.pwr, self.sink.pwr)
+        self.connect(self.src.io, self.sink.io)
         self.require(self.src.reverse_voltage != RangeExpr.EMPTY)
 
 
@@ -169,7 +169,7 @@ class ReverseForwardOvervoltageTestTop(DesignTop):
                 reverse_current_limits=(0, 1) * Amp,
             )
         )
-        self.connect(self.src.pwr, self.sink.pwr)
+        self.connect(self.src.io, self.sink.io)
         self.require(self.src.reverse_voltage != RangeExpr.EMPTY)
 
 

--- a/edg/parts/display/oled/test_oled_i2c_spi.py
+++ b/edg/parts/display/oled/test_oled_i2c_spi.py
@@ -14,8 +14,8 @@ class OledI2cTest(DesignTop):
         self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
         self.gnd = self.Block(DummyGround())
         with self.implicit_connect(
-            ImplicitConnect(self.pwr.pwr, [Power]),
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.pwr.io, [Power]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.dut = imp.Block(Er_Oled_096_1_1())
 
@@ -43,8 +43,8 @@ class OledSpiTest(DesignTop):
         self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
         self.gnd = self.Block(DummyGround())
         with self.implicit_connect(
-            ImplicitConnect(self.pwr.pwr, [Power]),
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.pwr.io, [Power]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.dut = imp.Block(Er_Oled_096_1_1())
 

--- a/edg/parts/display/oled/test_oled_i2c_spi.py
+++ b/edg/parts/display/oled/test_oled_i2c_spi.py
@@ -19,8 +19,7 @@ class OledI2cTest(DesignTop):
         ) as imp:
             self.dut = imp.Block(Er_Oled_096_1_1())
 
-            self.rst = self.Block(DummyDigitalSource())
-            self.connect(self.rst.io, self.dut.reset)
+            self.rst = self.Block(DummyDigitalSource()).connected(self.dut.reset)
 
             self.mcu = imp.Block(IdealIoController())
             self.i2c_pull = imp.Block(I2cPullup())
@@ -49,15 +48,12 @@ class OledSpiTest(DesignTop):
         ) as imp:
             self.dut = imp.Block(Er_Oled_096_1_1())
 
-            self.rst = self.Block(DummyDigitalSource())
-            self.connect(self.rst.io, self.dut.reset)
+            self.rst = self.Block(DummyDigitalSource()).connected(self.dut.reset)
 
             self.mcu = imp.Block(IdealIoController())
             self.connect(self.mcu.spi.request(), self.dut.spi)
-            self.cs = self.Block(DummyDigitalSource())
-            self.connect(self.cs.io, self.dut.cs)
-            self.dc = self.Block(DummyDigitalSource())
-            self.connect(self.dc.io, self.dut.dc)
+            self.cs = self.Block(DummyDigitalSource()).connected(self.dut.cs)
+            self.dc = self.Block(DummyDigitalSource()).connected(self.dut.dc)
 
     @override
     def refinements(self) -> Refinements:

--- a/edg/parts/microcontroller/Esp32.py
+++ b/edg/parts/microcontroller/Esp32.py
@@ -425,9 +425,9 @@ class Freenove_Esp32_Wrover(
                     current_limits=UsbConnector.USB2_CURRENT_LIMITS,
                 )
             )
-            self.connect(self.pwr_out_model.pwr, self.model.pwr)
+            self.connect(self.pwr_out_model.io, self.model.pwr)
             if self.get(self.pwr_out.is_connected()):
-                self.connect(self.pwr_out, self.pwr_out_model.pwr)
+                self.connect(self.pwr_out, self.pwr_out_model.io)
             self.export_tap(self.pwr_out.net, self.device.v3v3)
 
         if self.get(self.vusb_out.is_connected()):

--- a/edg/parts/microcontroller/Esp32.py
+++ b/edg/parts/microcontroller/Esp32.py
@@ -413,8 +413,7 @@ class Freenove_Esp32_Wrover(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround())
-            self.connect(self.gnd_model.gnd, self.model.gnd)
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/Esp32.py
+++ b/edg/parts/microcontroller/Esp32.py
@@ -413,8 +413,7 @@ class Freenove_Esp32_Wrover(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            # TODO debug this type failure
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/Esp32.py
+++ b/edg/parts/microcontroller/Esp32.py
@@ -413,7 +413,8 @@ class Freenove_Esp32_Wrover(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
+            # TODO debug this type failure
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/Esp32c3.py
+++ b/edg/parts/microcontroller/Esp32c3.py
@@ -596,9 +596,9 @@ class Xiao_Esp32c3(
                     current_limits=UsbConnector.USB2_CURRENT_LIMITS,
                 )
             )
-            self.connect(self.pwr_out_model.pwr, self.model.vdd3p3)
+            self.connect(self.pwr_out_model.io, self.model.vdd3p3)
             if self.get(self.pwr_out.is_connected()):
-                self.connect(self.pwr_out, self.pwr_out_model.pwr)
+                self.connect(self.pwr_out, self.pwr_out_model.io)
             self.export_tap(self.pwr_out.net, self.device.v3v3)
 
         if self.get(self.vusb_out.is_connected()):

--- a/edg/parts/microcontroller/Esp32c3.py
+++ b/edg/parts/microcontroller/Esp32c3.py
@@ -581,8 +581,7 @@ class Xiao_Esp32c3(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround())
-            self.connect(self.gnd_model.gnd, self.model.gnd)
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         self.connect(
             self.model.vdda, self.model.vdd3p3, self.model.vdd3p3_rtc, self.model.vdd3p3_cpu, self.model.vdd_spi

--- a/edg/parts/microcontroller/Esp32c3.py
+++ b/edg/parts/microcontroller/Esp32c3.py
@@ -581,7 +581,8 @@ class Xiao_Esp32c3(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
+            # TODO debug this type failure
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
 
         self.connect(
             self.model.vdda, self.model.vdd3p3, self.model.vdd3p3_rtc, self.model.vdd3p3_cpu, self.model.vdd_spi

--- a/edg/parts/microcontroller/Esp32c3.py
+++ b/edg/parts/microcontroller/Esp32c3.py
@@ -581,8 +581,7 @@ class Xiao_Esp32c3(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            # TODO debug this type failure
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         self.connect(
             self.model.vdda, self.model.vdd3p3, self.model.vdd3p3_rtc, self.model.vdd3p3_cpu, self.model.vdd_spi

--- a/edg/parts/microcontroller/Esp32s3.py
+++ b/edg/parts/microcontroller/Esp32s3.py
@@ -393,7 +393,8 @@ class Freenove_Esp32s3_Wroom(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
+            # TODO debug this type failure
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/Esp32s3.py
+++ b/edg/parts/microcontroller/Esp32s3.py
@@ -393,8 +393,7 @@ class Freenove_Esp32s3_Wroom(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            # TODO debug this type failure
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/Esp32s3.py
+++ b/edg/parts/microcontroller/Esp32s3.py
@@ -405,9 +405,9 @@ class Freenove_Esp32s3_Wroom(
                     current_limits=UsbConnector.USB2_CURRENT_LIMITS,
                 )
             )
-            self.connect(self.pwr_out_model.pwr, self.model.pwr)
+            self.connect(self.pwr_out_model.io, self.model.pwr)
             if self.get(self.pwr_out.is_connected()):
-                self.connect(self.pwr_out, self.pwr_out_model.pwr)
+                self.connect(self.pwr_out, self.pwr_out_model.io)
             self.export_tap(self.pwr_out.net, self.device.v3v3)
 
         if self.get(self.vusb_out.is_connected()):

--- a/edg/parts/microcontroller/Esp32s3.py
+++ b/edg/parts/microcontroller/Esp32s3.py
@@ -393,8 +393,7 @@ class Freenove_Esp32s3_Wroom(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround())
-            self.connect(self.gnd_model.gnd, self.model.gnd)
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/Rp2040.py
+++ b/edg/parts/microcontroller/Rp2040.py
@@ -500,8 +500,7 @@ class Xiao_Rp2040(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround())
-            self.connect(self.gnd_model.gnd, self.model.gnd)
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         self.connect(self.model.vreg_vout, self.model.dvdd)
         model_pwr = self.connect(self.model.iovdd, self.model.vreg_vin, self.model.adc_avdd, self.model.usb_vdd)

--- a/edg/parts/microcontroller/Rp2040.py
+++ b/edg/parts/microcontroller/Rp2040.py
@@ -500,8 +500,7 @@ class Xiao_Rp2040(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            # TODO debug this type failure
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         self.connect(self.model.vreg_vout, self.model.dvdd)
         model_pwr = self.connect(self.model.iovdd, self.model.vreg_vin, self.model.adc_avdd, self.model.usb_vdd)

--- a/edg/parts/microcontroller/Rp2040.py
+++ b/edg/parts/microcontroller/Rp2040.py
@@ -514,9 +514,9 @@ class Xiao_Rp2040(
                     current_limits=UsbConnector.USB2_CURRENT_LIMITS,
                 )
             )
-            self.connect(self.pwr_out_model.pwr, model_pwr)
+            self.connect(self.pwr_out_model.io, model_pwr)
             if self.get(self.pwr_out.is_connected()):
-                self.connect(self.pwr_out, self.pwr_out_model.pwr)
+                self.connect(self.pwr_out, self.pwr_out_model.io)
             self.export_tap(self.pwr_out.net, self.device.v3v3)
 
         if self.get(self.pwr_vin.is_connected()):

--- a/edg/parts/microcontroller/Rp2040.py
+++ b/edg/parts/microcontroller/Rp2040.py
@@ -500,7 +500,8 @@ class Xiao_Rp2040(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
+            # TODO debug this type failure
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
 
         self.connect(self.model.vreg_vout, self.model.dvdd)
         model_pwr = self.connect(self.model.iovdd, self.model.vreg_vin, self.model.adc_avdd, self.model.usb_vdd)

--- a/edg/parts/microcontroller/nRF52840.py
+++ b/edg/parts/microcontroller/nRF52840.py
@@ -710,8 +710,7 @@ class Feather_Nrf52840(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            # TODO debug this type failure
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/nRF52840.py
+++ b/edg/parts/microcontroller/nRF52840.py
@@ -719,9 +719,9 @@ class Feather_Nrf52840(
             self.pwr_out_model = self.Block(
                 DummyVoltageSource(voltage_out=self._AP2112_3V3_OUT, current_limits=UsbConnector.USB2_CURRENT_LIMITS)
             )
-            self.connect(self.pwr_out_model.pwr, self.model.pwr)
+            self.connect(self.pwr_out_model.io, self.model.pwr)
             if self.get(self.pwr_out.is_connected()):
-                self.connect(self.pwr_out, self.pwr_out_model.pwr)
+                self.connect(self.pwr_out, self.pwr_out_model.io)
             self.export_tap(self.pwr_out.net, self.device.pwr)
 
         if self.get(self.vusb_out.is_connected()):

--- a/edg/parts/microcontroller/nRF52840.py
+++ b/edg/parts/microcontroller/nRF52840.py
@@ -710,7 +710,8 @@ class Feather_Nrf52840(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
+            # TODO debug this type failure
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)  # type: ignore
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/nRF52840.py
+++ b/edg/parts/microcontroller/nRF52840.py
@@ -710,8 +710,7 @@ class Feather_Nrf52840(
             self.connect(self.gnd, self.model.gnd)
             self.export_tap(self.gnd, self.device.gnd)
         else:
-            self.gnd_model = self.Block(DummyGround())
-            self.connect(self.gnd_model.gnd, self.model.gnd)
+            self.gnd_model = self.Block(DummyGround()).connected(self.model.gnd)
 
         if self.get(self.pwr.is_connected()):  # power supplied externally
             self.connect(self.pwr, self.model.pwr)

--- a/edg/parts/microcontroller/test_mcu_wrapper.py
+++ b/edg/parts/microcontroller/test_mcu_wrapper.py
@@ -21,8 +21,7 @@ class OverallocateTest(DesignTop):
 
             self.ios = ElementDict[DummyDigitalSource]()
             for i in range(7):  # device only has 6 IOs
-                self.ios[i] = self.Block(DummyDigitalSource())
-                self.connect(self.ios[i].io, self.dut.gpio.request(str(i)))
+                self.ios[i] = self.Block(DummyDigitalSource()).connected(self.dut.gpio.request(str(i)))
 
 
 class FullMcuTest(DesignTop):
@@ -39,8 +38,7 @@ class FullMcuTest(DesignTop):
 
             self.ios = ElementDict[DummyDigitalSource]()
             for i in range(6):
-                self.ios[i] = self.Block(DummyDigitalSource())
-                self.connect(self.ios[i].io, self.dut.gpio.request(str(i)))
+                self.ios[i] = self.Block(DummyDigitalSource()).connected(self.dut.gpio.request(str(i)))
 
 
 class BaseMcuTest(DesignTop):
@@ -56,8 +54,7 @@ class BaseMcuTest(DesignTop):
 
             self.ios = ElementDict[DummyDigitalSource]()
             for i in range(2):
-                self.ios[i] = self.Block(DummyDigitalSource())
-                self.connect(self.ios[i].io, self.dut.gpio.request(str(i)))
+                self.ios[i] = self.Block(DummyDigitalSource()).connected(self.dut.gpio.request(str(i)))
 
 
 class AssignedPinsTest(BaseMcuTest):

--- a/edg/parts/microcontroller/test_mcu_wrapper.py
+++ b/edg/parts/microcontroller/test_mcu_wrapper.py
@@ -14,8 +14,8 @@ class OverallocateTest(DesignTop):
         self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
         self.gnd = self.Block(DummyGround())
         with self.implicit_connect(
-            ImplicitConnect(self.pwr.pwr, [Power]),
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.pwr.io, [Power]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.dut = imp.Block(Xiao_Esp32c3())
 
@@ -31,8 +31,8 @@ class FullMcuTest(DesignTop):
         self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
         self.gnd = self.Block(DummyGround())
         with self.implicit_connect(
-            ImplicitConnect(self.pwr.pwr, [Power]),
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.pwr.io, [Power]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.dut = imp.Block(Xiao_Esp32c3())
 
@@ -47,8 +47,8 @@ class BaseMcuTest(DesignTop):
         self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
         self.gnd = self.Block(DummyGround())
         with self.implicit_connect(
-            ImplicitConnect(self.pwr.pwr, [Power]),
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.pwr.io, [Power]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.dut = imp.Block(Xiao_Esp32c3())
 
@@ -81,8 +81,8 @@ class AssignedI2cTest(DesignTop):
         self.pwr = self.Block(DummyVoltageSource(voltage_out=3.3 * Volt(tol=0)))
         self.gnd = self.Block(DummyGround())
         with self.implicit_connect(
-            ImplicitConnect(self.pwr.pwr, [Power]),
-            ImplicitConnect(self.gnd.gnd, [Common]),
+            ImplicitConnect(self.pwr.io, [Power]),
+            ImplicitConnect(self.gnd.io, [Common]),
         ) as imp:
             self.dut = imp.Block(Xiao_Esp32c3())
 

--- a/edg/vendor_parts/generic/test_capacitor_generic.py
+++ b/edg/vendor_parts/generic/test_capacitor_generic.py
@@ -8,56 +8,56 @@ class CapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=0.1 * uFarad(tol=0.2), voltage=(0, 3.3) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class BigCapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=(50, 1000) * uFarad, voltage=(0, 5) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class HighVoltageCapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=0.2 * uFarad(tol=0.2), voltage=(0, 20) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class HighSingleCapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=22 * uFarad(tol=0.2), voltage=(0, 10) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class MediumSingleCapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=2 * uFarad(tol=0.2), voltage=(0, 20) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class DeratedCapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=1 * uFarad(tol=0.2), voltage=(0, 5) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class BigMultiCapacitorGenericTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericMlcc(capacitance=(50, 1000) * uFarad, voltage=(0, 5) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class CapacitorTestCase(unittest.TestCase):

--- a/edg/vendor_parts/generic/test_resistor_generic.py
+++ b/edg/vendor_parts/generic/test_resistor_generic.py
@@ -7,21 +7,17 @@ from .GenericResistor import GenericChipResistor
 class ResistorTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
-        self.dut = self.Block(
-            GenericChipResistor(
-                resistance=1 * kOhm(tol=0.1),
-            )
-        )
-        (self.dummya,), _ = self.chain(self.dut.a, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.b, self.Block(DummyPassive()))
+        self.dut = self.Block(GenericChipResistor(resistance=1 * kOhm(tol=0.1)))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.a)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.b)
 
 
 class PowerResistorTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(GenericChipResistor(resistance=1 * kOhm(tol=0.1), power=(0, 0.24) * Watt))
-        (self.dummya,), _ = self.chain(self.dut.a, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.b, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.a)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.b)
 
 
 class NonE12ResistorTestTop(Block):
@@ -32,8 +28,8 @@ class NonE12ResistorTestTop(Block):
                 resistance=8.06 * kOhm(tol=0.01),
             )
         )
-        (self.dummya,), _ = self.chain(self.dut.a, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.b, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.a)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.b)
 
 
 class ResistorTestCase(unittest.TestCase):

--- a/edg/vendor_parts/jlc/test_JlcCapacitor.py
+++ b/edg/vendor_parts/jlc/test_JlcCapacitor.py
@@ -6,16 +6,16 @@ class JlcCapacitorTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(JlcCapacitor(capacitance=10 * nFarad(tol=0.1), voltage=(0, 3.3) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class JlcBigCapacitorTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(JlcCapacitor(capacitance=(50, 1000) * uFarad, voltage=(0, 3.3) * Volt))
-        (self.dummya,), _ = self.chain(self.dut.pos, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.neg, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.pos)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.neg)
 
 
 class CapacitorTestCase(unittest.TestCase):

--- a/edg/vendor_parts/jlc/test_JlcResistor.py
+++ b/edg/vendor_parts/jlc/test_JlcResistor.py
@@ -6,8 +6,8 @@ class JlcResistorTestTop(Block):
     def __init__(self) -> None:
         super().__init__()
         self.dut = self.Block(JlcResistor(resistance=750 * Ohm(tol=0.10), power=(0, 0.25) * Watt))
-        (self.dummya,), _ = self.chain(self.dut.a, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.b, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.a)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.b)
 
 
 class JlcResistorTestCase(unittest.TestCase):

--- a/edg/vendor_parts/jlc/test_inductor.py
+++ b/edg/vendor_parts/jlc/test_inductor.py
@@ -13,8 +13,8 @@ class JlcInductorTestTop(Block):
                 # no frequency spec since JLC doesn't allow it
             )
         )
-        (self.dummya,), _ = self.chain(self.dut.a, self.Block(DummyPassive()))
-        (self.dummyb,), _ = self.chain(self.dut.b, self.Block(DummyPassive()))
+        self.dummya = self.Block(DummyPassive()).connected(self.dut.a)
+        self.dummyb = self.Block(DummyPassive()).connected(self.dut.b)
 
 
 class InductorTestCase(unittest.TestCase):

--- a/examples/TestLed/TestLed.net.ref
+++ b/examples/TestLed/TestLed.net.ref
@@ -25,10 +25,10 @@
   (sheetpath (names "/led/") (tstamps "/02750136/"))
   (tstamps "0296014b")))
 (nets
-(net (code 1) (name "gnd.gnd")
-  (node (ref R1) (pin 2)))
-(net (code 2) (name "src.io")
+(net (code 1) (name "led.signal")
   (node (ref D1) (pin 2)))
+(net (code 2) (name "led.gnd")
+  (node (ref R1) (pin 2)))
 (net (code 3) (name "led.package.k")
   (node (ref D1) (pin 1))
   (node (ref R1) (pin 1))))

--- a/examples/TestLed/TestLed.svgpcb.js
+++ b/examples/TestLed/TestLed.svgpcb.js
@@ -12,8 +12,8 @@ const R1 = board.add(R_0603_1608Metric, {
 })
 
 board.setNetlist([
-  {name: "gnd.gnd", pads: [["R1", "2"]]},
-  {name: "src.io", pads: [["D1", "2"]]},
+  {name: "led.signal", pads: [["D1", "2"]]},
+  {name: "led.gnd", pads: [["R1", "2"]]},
   {name: "led.package.k", pads: [["D1", "1"], ["R1", "1"]]}
 ])
 

--- a/examples/test_blinky.py
+++ b/examples/test_blinky.py
@@ -11,12 +11,9 @@ class TestLed(SimpleBoardTop):
 
     @override
     def contents(self) -> None:
-        self.gnd = self.Block(DummyGround())
-        self.src = self.Block(DummyDigitalSource())
         self.led = self.Block(IndicatorLed())
-
-        self.connect(self.led.signal, self.src.io)
-        self.connect(self.gnd.gnd, self.led.gnd)
+        self.gnd = self.Block(DummyGround()).connected(self.led.gnd)
+        self.src = self.Block(DummyDigitalSource()).connected(self.led.signal)
 
 
 class TestBlinkyBasic(SimpleBoardTop):

--- a/examples/test_iot_led_driver.py
+++ b/examples/test_iot_led_driver.py
@@ -96,10 +96,8 @@ class IotLedDriver(JlcBoardTop):
                 self.connect(self.mcu.gpio.request(f"led_pwm_{i}"), led_drv.pwm)
 
                 # no connectors to save space, just solder to one of the SMD pads
-                leda_sink = self.led_sink[i * 2] = imp.Block(DummyPassive())
-                self.connect(led_drv.leda, leda_sink.io)
-                ledk_sink = self.led_sink[i * 2 + 1] = imp.Block(DummyPassive())
-                self.connect(led_drv.ledk, ledk_sink.io)
+                self.led_sink[i * 2] = imp.Block(DummyPassive()).connected(led_drv.leda)
+                self.led_sink[i * 2 + 1] = imp.Block(DummyPassive()).connected(led_drv.ledk)
 
     @override
     def refinements(self) -> Refinements:

--- a/examples/test_multimeter.py
+++ b/examples/test_multimeter.py
@@ -37,8 +37,7 @@ class ResistorMux(Interface, KiCadImportableBlock, GeneratorBlock):
         self.res = ElementDict[Resistor]()
         for i, resistance in enumerate(self.get(self.resistances)):
             if resistance.upper == float("inf"):  # open circuit for this step
-                self.dummy = self.Block(DummyPassive())
-                self.connect(self.dummy.io, self.switch.inputs.request(str(i)))
+                self.dummy = self.Block(DummyPassive()).connected(self.switch.inputs.request(str(i)))
             else:
                 res = self.res[i] = self.Block(Resistor(resistance))
                 self.connect(res.a, self.input)

--- a/examples/test_usb_key.py
+++ b/examples/test_usb_key.py
@@ -18,8 +18,7 @@ class StTscSenseChannel(Block):
         super().contents()
         self.res = self.Block(Resistor(resistance=10 * kOhm(tol=0.05)))  # recommended by ST
         self.connect(self.io.net, self.res.a)  # ideal
-        self.load = self.Block(DummyPassive())  # avoid ERC
-        self.connect(self.res.b, self.load.io)
+        self.load = self.Block(DummyPassive()).connected(self.res.b)  # avoid ERC
 
 
 class StTscReference(Block):


### PR DESCRIPTION
Adds connected(...) to DummyBlocks with a base class. Unifies the port name to `io`, adding a deprecation pathway for the older port names.

Refactors the .connected(...) in TestPoints with a base class.

Refactors use sites.

Resolves #506, resolves #500