### PR TITLE
Require new contributions to be dual-licensed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Please make sure to read CONTRIBUTING.md. Ensure style, mypy, and the test suite passes. -->
+
+
+
+---
+
+### Contributor License Agreement
+
+<!-- You must check this box for PR approval. Why is this here? See CONTRIBUTING.md. -->
+
+By submitting this pull request, I agree to dual-license this contribution under both BSD 3-clause and Apache License, Version 2.0.
+
+- [ ] **I agree to dual-license this contribution under both BSD 3-clause and Apache License, Version 2.0.**

--- a/.github/workflows/pr-license.yml
+++ b/.github/workflows/pr-license.yml
@@ -1,0 +1,24 @@
+name: CLA Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  enforce-cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dual-License Agreement
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Use a regex match to look for the exact checked markdown box
+          if echo "$PR_BODY" | grep -qE '\-\s*\[x\]\s*\*?\*?I agree to dual\-license this contribution under both BSD 3\-clause and Apache License, Version 2\.0\.'; then
+            echo "CLA OK"
+          else
+            echo "You must check the dual-licensing agreement box in the PR description to pass this check."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,16 @@ We take pull requests!
 All pull requests are thoroughly reviewed for code quality.
 
 
+## Licensing
+
+The "outbound" license of this repository as a whole remains BSD 3-clause, as was set up at repository creation.
+New code ("inbound") is required to be dual-licensed under both BSD 3-clause and Apache License, Version 2.0.
+This requirement is so new contributions can be used with a more modern license without messy relicensing of older code.
+
+By contributing to this project, you agree to dual-license your contributions under both BSD 3-clause and Apache License, Version 2.0.
+The pull request template includes text to confirm this.
+
+
 ## Parts Contributions
 
 This repository maintains a curated parts library since:


### PR DESCRIPTION
 This requires new contributions to be dual-licensed under BSD 3-clause and Apache 2.0.

As of merge, I retroactively add an Apache 2.0 License to any personally owned commits. This does not change the license of commits not by or owned by me. I (probably) do not own commits before July 2024.


---

### Contributor License Agreement

<!-- You must check this box for PR approval. Why is this here? See CONTRIBUTING.md. -->

By submitting this pull request, I agree to dual-license this contribution under both BSD 3-clause and Apache License, Version 2.0.

- [x] **I agree to dual-license this contribution under both BSD 3-clause and Apache License, Version 2.0.**